### PR TITLE
Add verbose output with tiered logging levels (-v and -vv)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -86,6 +86,8 @@ esbuild
 			"keytar",
 			// TypeScript is a peer dependency and should not be bundled
 			"typescript",
+			// pino-pretty uses worker threads and must be external
+			"pino-pretty",
 		],
 	})
 	.catch((e) => {

--- a/require-shim.js
+++ b/require-shim.js
@@ -8,4 +8,9 @@
  * CommonJS module loader.
  */
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
 globalThis.require = createRequire(import.meta.url);
+globalThis.__filename = fileURLToPath(import.meta.url);
+globalThis.__dirname = dirname(globalThis.__filename);

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -29,7 +29,7 @@ import { createActionsCommand } from "./cli/commands/actions";
 import { createApplicationCommand } from "./cli/commands/application";
 import { createWebhookCommand } from "./cli/commands/webhook";
 import { envGet, validateEnvironment } from "./core/environment";
-import { setDebugMode } from "./services/logger";
+import { setVerbosityLevel } from "./services/logger";
 
 type Descriptor = CommandDescriptor.Command<unknown>;
 
@@ -287,8 +287,21 @@ function applyGlobalOptions(
 ): void {
 	const options = extractCommandOptions(rootCommand, parsedRootValue);
 
-	if (options.debug === true || options.verbose === true) {
-		setDebugMode(true);
+	let verbosity = 0;
+	if (options.verbose === true || options.info === true) {
+		verbosity = 1;
+	}
+	if (options.debug === true) {
+		verbosity = 2;
+	}
+
+	if (verbosity > 0) {
+		setVerbosityLevel(verbosity);
+		if (verbosity === 1) {
+			process.stderr.write("(verbose output enabled)\n");
+		} else {
+			process.stderr.write("(verbose output enabled: full details)\n");
+		}
 	}
 
 	const environment = typeof options.env === "string" ? options.env : undefined;
@@ -334,9 +347,10 @@ export function createCliProgram(): Command {
 		)
 		.option(
 			"-v, --verbose",
-			"Enable verbose output for HTTP requests and responses",
+			"Enable basic verbose output for HTTP requests and responses",
 		)
-		.option("--debug", "Enable debug logging for HTTP requests and responses")
+		.option("--info", "Enable basic verbose output (same as -v)")
+		.option("--debug", "Enable full verbose output (same as -vv)")
 		.action(async () => {
 			const envResult = await envGet();
 			const commandTree = getRootCommandTree();

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -287,7 +287,7 @@ function applyGlobalOptions(
 ): void {
 	const options = extractCommandOptions(rootCommand, parsedRootValue);
 
-	if (options.debug === true) {
+	if (options.debug === true || options.verbose === true) {
 		setDebugMode(true);
 	}
 
@@ -332,12 +332,15 @@ export function createCliProgram(): Command {
 			"-e, --env <environment>",
 			"Set the target environment for commands (ote, prod)",
 		)
+		.option(
+			"-v, --verbose",
+			"Enable verbose output for HTTP requests and responses",
+		)
 		.option("--debug", "Enable debug logging for HTTP requests and responses")
 		.action(async () => {
 			const envResult = await envGet();
 			const commandTree = getRootCommandTree();
 			let authSnapshot: { error: string } | Record<string, unknown> | undefined;
-
 			try {
 				const authModule = await import("./core/auth");
 				const authResult = await authModule.authStatus();

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -45,6 +45,52 @@ const EFFECT_CLI_CONFIG = CliConfig.make({
 	showBuiltIns: true,
 });
 
+function isShortVerboseCluster(token: string): boolean {
+	return /^-v{2,}$/.test(token);
+}
+
+function normalizeVerbosityArgs(argv: ReadonlyArray<string>): string[] {
+	const retained: string[] = [];
+	let verbosity = 0;
+
+	for (const token of argv) {
+		if (token === "--debug") {
+			verbosity = Math.max(verbosity, 2);
+			continue;
+		}
+
+		if (token === "--info" || token === "--verbose") {
+			verbosity += 1;
+			continue;
+		}
+
+		if (token === "-v") {
+			verbosity += 1;
+			continue;
+		}
+
+		if (isShortVerboseCluster(token)) {
+			const level = token.length - 1;
+			verbosity += level;
+			continue;
+		}
+
+		retained.push(token);
+	}
+
+	const normalizedVerbosity = Math.min(verbosity, 2);
+
+	if (normalizedVerbosity >= 2) {
+		return ["--debug", ...retained];
+	}
+
+	if (normalizedVerbosity === 1) {
+		return ["--verbose", ...retained];
+	}
+
+	return retained;
+}
+
 function buildOptionsParser(
 	options: ReadonlyArray<Command["options"][number]>,
 ): Options.Options<unknown> {
@@ -397,10 +443,11 @@ export function createCliProgram(): Command {
 export async function runCli(argv: ReadonlyArray<string>): Promise<void> {
 	const rootCommand = createCliProgram();
 	const descriptor = buildDescriptor(rootCommand);
+	const normalizedArgv = normalizeVerbosityArgs(argv);
 
 	const parseEffect = CommandDescriptor.parse(
 		descriptor,
-		[rootCommand.name, ...argv],
+		[rootCommand.name, ...normalizedArgv],
 		EFFECT_CLI_CONFIG,
 	).pipe(Effect.provide(NodeContext.layer));
 

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import http from "node:http";
 import { URL } from "node:url";
 import openBrowser from "open";
+import { loggedFetch } from "../services/logger";
 import {
 	AuthenticationError,
 	type CmdResult,
@@ -14,7 +15,6 @@ import {
 	getApiUrl,
 	getClientId,
 } from "./environment";
-import { loggedFetch } from "../services/logger";
 
 const KEYCHAIN_SERVICE = "godaddy-cli";
 const PORT = 7443;
@@ -98,19 +98,26 @@ export async function authLogin(): Promise<CmdResult<AuthResult>> {
 							);
 						}
 
-						const tokenResponse = await loggedFetch(oauthTokenUrl, {
-							method: "POST",
-							headers: {
-								"Content-Type": "application/x-www-form-urlencoded",
+						const tokenResponse = await loggedFetch(
+							oauthTokenUrl,
+							{
+								method: "POST",
+								headers: {
+									"Content-Type": "application/x-www-form-urlencoded",
+								},
+								body: new URLSearchParams({
+									client_id: clientId,
+									code,
+									grant_type: "authorization_code",
+									redirect_uri: `http://localhost:${actualPort}/callback`,
+									code_verifier: codeVerifier,
+								}),
 							},
-							body: new URLSearchParams({
-								client_id: clientId,
-								code,
-								grant_type: "authorization_code",
-								redirect_uri: `http://localhost:${actualPort}/callback`,
-								code_verifier: codeVerifier,
-							}),
-						});
+							{
+								includeRequestBody: false,
+								includeResponseBody: false,
+							},
+						);
 
 						if (!tokenResponse.ok) {
 							throw new Error(`Token request failed: ${tokenResponse.status}`);

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -14,6 +14,7 @@ import {
 	getApiUrl,
 	getClientId,
 } from "./environment";
+import { loggedFetch } from "../services/logger";
 
 const KEYCHAIN_SERVICE = "godaddy-cli";
 const PORT = 7443;
@@ -97,7 +98,7 @@ export async function authLogin(): Promise<CmdResult<AuthResult>> {
 							);
 						}
 
-						const tokenResponse = await fetch(oauthTokenUrl, {
+						const tokenResponse = await loggedFetch(oauthTokenUrl, {
 							method: "POST",
 							headers: {
 								"Content-Type": "application/x-www-form-urlencoded",

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -3,6 +3,21 @@ import pinoPretty from "pino-pretty";
 
 // Global verbosity level: 0 = none, 1 = basic, 2 = full
 let verbosityLevel = 0;
+const SENSITIVE_LOG_VALUE = "[REDACTED]";
+const SENSITIVE_KEY_PARTS = [
+	"token",
+	"secret",
+	"password",
+	"authorization",
+	"api_key",
+	"apikey",
+	"code_verifier",
+] as const;
+
+interface LoggedFetchOptions {
+	includeRequestBody?: boolean;
+	includeResponseBody?: boolean;
+}
 
 // Configure logger based on environment and verbosity level
 const createLogger = () => {
@@ -122,8 +137,11 @@ const redactSensitiveFields = (obj: unknown): unknown => {
 
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(obj)) {
-		if (key === "access_token" || key === "accessToken") {
-			result[key] = "[REDACTED]";
+		const lowerKey = key.toLowerCase();
+		if (
+			SENSITIVE_KEY_PARTS.some((part) => lowerKey.includes(part.toLowerCase()))
+		) {
+			result[key] = SENSITIVE_LOG_VALUE;
 		} else if (typeof value === "object" && value !== null) {
 			result[key] = redactSensitiveFields(value);
 		} else {
@@ -133,22 +151,47 @@ const redactSensitiveFields = (obj: unknown): unknown => {
 	return result;
 };
 
+function isSensitiveEndpoint(url: string): boolean {
+	try {
+		const path = new URL(url).pathname.toLowerCase();
+		return path.includes("/oauth/token") || path.includes("/oauth2/token");
+	} catch {
+		const normalized = url.toLowerCase();
+		return (
+			normalized.includes("/oauth/token") ||
+			normalized.includes("/oauth2/token")
+		);
+	}
+}
+
+function normalizeRequestBodyForLogs(body: RequestInit["body"]): unknown {
+	if (body instanceof URLSearchParams) {
+		return Object.fromEntries(body.entries());
+	}
+	return body;
+}
+
 export const loggedFetch = async (
 	url: string,
 	init?: RequestInit,
+	options?: LoggedFetchOptions,
 ): Promise<Response> => {
 	const method = init?.method ?? "(unknown)";
 	const headers = init?.headers;
 	const body = init?.body;
+	const endpointSensitive = isSensitiveEndpoint(url);
+	const includeRequestBody =
+		(options?.includeRequestBody ?? true) && !endpointSensitive;
+	const includeResponseBody =
+		(options?.includeResponseBody ?? true) && !endpointSensitive;
 
 	logHttpRequest({
 		method,
 		url,
 		headers: headers as Record<string, string>,
-		body:
-			body instanceof URLSearchParams
-				? Object.fromEntries(body.entries())
-				: body,
+		body: includeRequestBody
+			? redactSensitiveFields(normalizeRequestBodyForLogs(body))
+			: SENSITIVE_LOG_VALUE,
 	});
 
 	const startTime = Date.now();
@@ -156,7 +199,7 @@ export const loggedFetch = async (
 	const duration = Date.now() - startTime;
 
 	let responseBody: unknown;
-	if (verbosityLevel >= 2 && response.ok) {
+	if (verbosityLevel >= 2 && response.ok && includeResponseBody) {
 		const contentType = response.headers.get("content-type");
 		if (contentType?.includes("application/json")) {
 			const clonedResponse = response.clone();
@@ -167,6 +210,8 @@ export const loggedFetch = async (
 				responseBody = undefined;
 			}
 		}
+	} else if (!includeResponseBody) {
+		responseBody = SENSITIVE_LOG_VALUE;
 	}
 
 	logHttpResponse({

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,11 +1,13 @@
 import pino from "pino";
+import pinoPretty from "pino-pretty";
 
-// Global debug state
-let isDebugEnabled = false;
+// Global verbosity level: 0 = none, 1 = basic, 2 = full
+let verbosityLevel = 0;
 
-// Configure logger based on environment and debug flag
+// Configure logger based on environment and verbosity level
 const createLogger = () => {
-	const level = isDebugEnabled ? "debug" : "info";
+	const isDev = process.env.NODE_ENV === "development";
+	const level = verbosityLevel > 0 ? "debug" : "info";
 
 	const redact = {
 		paths: [
@@ -16,6 +18,22 @@ const createLogger = () => {
 		],
 		censor: "[REDACTED]",
 	};
+
+	if (isDev || verbosityLevel > 0) {
+		const prettyStream = pinoPretty({
+			colorize: true,
+			translateTime: "HH:MM:ss",
+			ignore: "pid,hostname",
+			destination: 2,
+		});
+		return pino(
+			{
+				level,
+				redact,
+			},
+			prettyStream,
+		);
+	}
 
 	// Always log to stderr to keep stdout reserved for JSON command envelopes.
 	return pino(
@@ -29,8 +47,8 @@ const createLogger = () => {
 
 let logger = createLogger();
 
-export const setDebugMode = (enabled: boolean) => {
-	isDebugEnabled = enabled;
+export const setVerbosityLevel = (level: number) => {
+	verbosityLevel = level;
 	logger = createLogger();
 };
 
@@ -43,7 +61,7 @@ export const logHttpRequest = (options: {
 	headers?: Record<string, string>;
 	body?: unknown;
 }) => {
-	if (isDebugEnabled) {
+	if (verbosityLevel >= 2) {
 		logger.debug(
 			{
 				type: "http_request",
@@ -54,6 +72,8 @@ export const logHttpRequest = (options: {
 			},
 			`→ ${options.method} ${options.url}`,
 		);
+	} else if (verbosityLevel === 1) {
+		logger.debug(`→ ${options.method} ${options.url}`);
 	}
 };
 
@@ -66,7 +86,7 @@ export const logHttpResponse = (options: {
 	body?: unknown;
 	duration?: number;
 }) => {
-	if (isDebugEnabled) {
+	if (verbosityLevel >= 2) {
 		logger.debug(
 			{
 				type: "http_response",
@@ -82,5 +102,81 @@ export const logHttpResponse = (options: {
 				options.duration ? `(${options.duration}ms)` : ""
 			}`,
 		);
+	} else if (verbosityLevel === 1) {
+		logger.debug(
+			`← ${options.status} ${options.method} ${options.url} ${
+				options.duration ? `(${options.duration}ms)` : ""
+			}`,
+		);
 	}
+};
+
+const redactSensitiveFields = (obj: unknown): unknown => {
+	if (typeof obj !== "object" || obj === null) {
+		return obj;
+	}
+
+	if (Array.isArray(obj)) {
+		return obj.map(redactSensitiveFields);
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (key === "access_token" || key === "accessToken") {
+			result[key] = "[REDACTED]";
+		} else if (typeof value === "object" && value !== null) {
+			result[key] = redactSensitiveFields(value);
+		} else {
+			result[key] = value;
+		}
+	}
+	return result;
+};
+
+export const loggedFetch = async (
+	url: string,
+	init?: RequestInit,
+): Promise<Response> => {
+	const method = init?.method ?? "(unknown)";
+	const headers = init?.headers;
+	const body = init?.body;
+
+	logHttpRequest({
+		method,
+		url,
+		headers: headers as Record<string, string>,
+		body:
+			body instanceof URLSearchParams
+				? Object.fromEntries(body.entries())
+				: body,
+	});
+
+	const startTime = Date.now();
+	const response = await fetch(url, init);
+	const duration = Date.now() - startTime;
+
+	let responseBody: unknown;
+	if (verbosityLevel >= 2 && response.ok) {
+		const contentType = response.headers.get("content-type");
+		if (contentType?.includes("application/json")) {
+			const clonedResponse = response.clone();
+			try {
+				const jsonBody = await clonedResponse.json();
+				responseBody = redactSensitiveFields(jsonBody);
+			} catch {
+				responseBody = undefined;
+			}
+		}
+	}
+
+	logHttpResponse({
+		method,
+		url,
+		status: response.status,
+		statusText: response.statusText,
+		body: responseBody,
+		duration,
+	});
+
+	return response;
 };

--- a/tests/integration/cli-smoke.test.ts
+++ b/tests/integration/cli-smoke.test.ts
@@ -89,4 +89,56 @@ describe("CLI Smoke Tests", () => {
 		expect(result.stdout).toContain("COMMANDS");
 		expect(result.stdout).toContain("application");
 	});
+
+	it("-v enables basic verbose mode", () => {
+		const result = runCli(["-v"]);
+		expect(result.status).toBe(0);
+
+		const payload = JSON.parse(result.stdout);
+		expect(payload.ok).toBe(true);
+		expect(payload.command).toBe("godaddy -v");
+		expect(result.stderr).toContain("(verbose output enabled)");
+		expect(result.stderr).not.toContain("full details");
+	});
+
+	it("-vv enables full verbose mode", () => {
+		const result = runCli(["-vv"]);
+		expect(result.status).toBe(0);
+
+		const payload = JSON.parse(result.stdout);
+		expect(payload.ok).toBe(true);
+		expect(payload.command).toBe("godaddy -vv");
+		expect(result.stderr).toContain("(verbose output enabled: full details)");
+	});
+
+	it("repeated -v flags enable full verbose mode", () => {
+		const result = runCli(["-v", "-v"]);
+		expect(result.status).toBe(0);
+
+		const payload = JSON.parse(result.stdout);
+		expect(payload.ok).toBe(true);
+		expect(payload.command).toBe("godaddy -v -v");
+		expect(result.stderr).toContain("(verbose output enabled: full details)");
+	});
+
+	it("--info aliases to basic verbose mode", () => {
+		const result = runCli(["--info"]);
+		expect(result.status).toBe(0);
+
+		const payload = JSON.parse(result.stdout);
+		expect(payload.ok).toBe(true);
+		expect(payload.command).toBe("godaddy --info");
+		expect(result.stderr).toContain("(verbose output enabled)");
+		expect(result.stderr).not.toContain("full details");
+	});
+
+	it("--debug aliases to full verbose mode", () => {
+		const result = runCli(["--debug"]);
+		expect(result.status).toBe(0);
+
+		const payload = JSON.parse(result.stdout);
+		expect(payload.ok).toBe(true);
+		expect(payload.command).toBe("godaddy --debug");
+		expect(result.stderr).toContain("(verbose output enabled: full details)");
+	});
 });


### PR DESCRIPTION
## Summary

This PR adds comprehensive verbose output support with two levels of verbosity, along with fixes for ES module compatibility issues that were preventing verbose mode from working.

## Features Added

### Tiered Verbosity Levels
- **Level 1 (`-v`, `--info`)**: Basic output showing HTTP method, URL, status code, and duration
  ```bash
  → POST https://api.godaddy.com/v2/oauth2/token
  ← 200 POST https://api.godaddy.com/v2/oauth2/token (234ms)
  ```
- **Level 2 (`-vv`, `--debug`)**: Full output including headers, request/response bodies with automatic sensitive field redaction
  ```bash
  [Full JSON output with headers, request body, response body]
  ```

### Automatic HTTP Logging
- Introduced `loggedFetch()` wrapper that automatically logs HTTP requests
- Extracts logging details from actual requests/responses, eliminating hardcoded duplication
- Automatic timing and status code capture
- Smart JSON response parsing for level 2 verbosity
- No need to manually specify method/status in logging calls - prevents drift between code and logs

### Security Enhancements
- Automatic redaction of `access_token` and `accessToken` fields in response logs
- Recursive redaction for nested objects
- Follows existing redaction patterns for Authorization headers
- Keeps logs clean and secure while still being useful for debugging

## Bug Fixes

### ES Module Compatibility Issues
- **Fixed `__dirname is not defined` error**: Added `__dirname` and `__filename` shims in `require-shim.js` for dependencies expecting CommonJS globals
- **Fixed worker thread error**: Marked `pino-pretty` as external dependency to avoid bundling worker thread code that breaks at runtime
- **Fixed pino transport issue**: Changed from pino transport API to direct stream usage to eliminate worker thread dependency

These fixes ensure that verbose mode actually works when the CLI is installed globally.

## CLI Options

- `-v, --verbose`: Incrementing flag (can be used multiple times: `-vv`)
- `--info`: Alias for level 1 verbosity (`-v`)
- `--debug`: Alias for level 2 verbosity (`-vv`)

## Examples

```bash
# Basic logging - just URL, status, and time
godaddy -v auth login
godaddy --info auth login

# Full logging - headers, bodies, everything
godaddy -vv auth login
godaddy --debug auth login

# Multiple v flags also work
godaddy -vv auth login
```

## Implementation Highlights

- **DRY principle**: Single `loggedFetch()` wrapper handles all HTTP logging
- **No hardcoded values**: Method/status extracted from actual requests/responses
- **Level-aware**: Only parses JSON bodies when verbosity level requires it
- **Visual feedback**: Shows `(verbose output enabled)` or `(verbose output enabled: full details)` when enabled

## Testing

Tested with:
- `godaddy -v auth login` - Basic logging works
- `godaddy -vv auth login` - Full logging works with redacted tokens
- `godaddy --info env get` - Alias works
- `godaddy --debug env get` - Alias works
- No worker thread errors when installed globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)