### PR TITLE
docs(skill): route address discovery to api commands

### DIFF
--- a/.agents/skills/godaddy-cli/SKILL.md
+++ b/.agents/skills/godaddy-cli/SKILL.md
@@ -255,32 +255,38 @@ godaddy application deploy <name> --follow
 
 Release and deploy accept `--config <path>` and `--environment <env>`.
 
-### Raw API Requests
+### API Discovery and Requests
 
-Make authenticated requests to any GoDaddy API endpoint:
+Use `godaddy api` for endpoint discovery and authenticated API calls:
 
 ```bash
-# GET request
-godaddy api /v1/commerce/catalog/products
+# List domains and endpoints
+godaddy api list
+godaddy api list --domain commerce
 
-# POST with inline fields
-godaddy api /v1/some/endpoint -X POST -f "name=value" -f "count=5"
+# Describe one endpoint (operation ID or path)
+godaddy api describe commerce.location.verify-address
+godaddy api describe /location/addresses
 
-# POST with body from file
-godaddy api /v1/some/endpoint -X POST -F body.json
+# Search endpoints by keyword
+godaddy api search address
+godaddy api search catalog
 
-# Custom headers
-godaddy api /v1/some/endpoint -H "X-Custom: value"
-
-# Extract a field from the response
-godaddy api /v1/some/endpoint -q ".data[0].id"
-
-# Include response headers in output
-godaddy api /v1/some/endpoint -i
-
-# Auto re-auth on 403 with specific scope
-godaddy api /v1/commerce/orders -s commerce.orders:read
+# Call endpoint (explicit form)
+godaddy api call /v1/commerce/catalog/products
+godaddy api call /v1/some/endpoint -X POST -f "name=value" -f "count=5"
+godaddy api call /v1/some/endpoint -X POST -F body.json
+godaddy api call /v1/some/endpoint -H "X-Custom: value"
+godaddy api call /v1/some/endpoint -q ".data[0].id"
+godaddy api call /v1/some/endpoint -i
+godaddy api call /v1/commerce/orders -s commerce.orders:read
 ```
+
+Compatibility behavior:
+- `godaddy api <endpoint>` still works. If the token after `api` is not one of `list`, `describe`, `search`, or `call`, the CLI treats it as an endpoint and executes `api call`.
+- This means legacy usage like `godaddy api /v1/commerce/location/addresses` remains supported.
+
+As with other large result sets, `api list` may be truncated in the inline JSON response. When `truncated: true`, read the `full_output` file path for complete results.
 
 ### Actions
 

--- a/.agents/skills/godaddy-cli/SKILL.md
+++ b/.agents/skills/godaddy-cli/SKILL.md
@@ -288,18 +288,27 @@ Compatibility behavior:
 
 As with other large result sets, `api list` may be truncated in the inline JSON response. When `truncated: true`, read the `full_output` file path for complete results.
 
+Address task rule:
+- For requests like "find/search/verify an address", start with:
+  `godaddy api search address`
+  `godaddy api list --domain location`
+  `godaddy api describe /location/addresses`
+- Do not use `godaddy actions describe` for generic API endpoint discovery.
+
 ### Actions
+
+`godaddy actions` is only for developers discovering action hook contracts they can integrate with as providers (or consume as a contract in app configuration). It is not for API endpoint discovery or API calls.
 
 ```bash
 # List all available actions
 godaddy actions list
 
 # Describe an action's request/response contract
-godaddy actions describe location.address.verify
 godaddy actions describe commerce.taxes.calculate
+godaddy actions describe commerce.payment.process
 ```
 
-Available actions: `location.address.verify`, `commerce.taxes.calculate`, `commerce.shipping-rates.calculate`, `commerce.price-adjustment.apply`, `commerce.price-adjustment.list`, `notifications.email.send`, `commerce.payment.get`, `commerce.payment.cancel`, `commerce.payment.refund`, `commerce.payment.process`, `commerce.payment.auth`.
+Use `godaddy actions list` to discover current action names and then `godaddy actions describe <action>` to inspect request/response schemas for that hook contract.
 
 ### Webhooks
 


### PR DESCRIPTION
## Summary
- update godaddy-cli skill API guidance to document api list, api describe, api search, and api call usage
- explicitly document legacy compatibility for godaddy api <endpoint>
- clarify that godaddy actions describe is for action hook contracts only, not API endpoint discovery
- add explicit address-task rule to start with godaddy api search/list/describe

## Why
Agents were using godaddy actions describe location.address.verify when asked to find/search addresses, which is the wrong command family for API endpoint discovery and calling.

## Testing
- docs-only changes