### PR TITLE
fix: distinguish between 401 and 403 HTTP error codes

### DIFF
--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -197,8 +197,10 @@ function extractGraphQLError(err: unknown): string {
 function safeGraphQLUserMessage(err: unknown): string {
   if (err instanceof ClientError) {
     const status = err.response.status;
-    if (status === 401 || status === 403)
+    if (status === 401)
       return "Authentication failed. Run 'godaddy auth login'.";
+    if (status === 403)
+      return "Access denied. You may not have permission for this operation in the current environment.";
     if (status === 404) return "The requested resource was not found.";
     if (status && status >= 500)
       return "The server encountered an error. Please try again later.";


### PR DESCRIPTION
## Summary
- Separates handling of 401 (authentication) and 403 (authorization) errors
- 401: "Authentication failed. Run 'godaddy auth login'."
- 403: "Access denied. You may not have permission for this operation in the current environment."

This provides clearer guidance to users - authentication failures prompt re-login, while authorization failures indicate a permissions issue.

## Test plan
- [ ] Trigger a 401 error (expired/invalid token) and verify message
- [ ] Trigger a 403 error (valid token, insufficient permissions) and verify message

---
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>