### PR TITLE
feat(cli): add --log-level flag for structured log verbosity control

### DIFF
--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -219,6 +219,12 @@ function normalizeVerbosityArgs(argv: readonly string[]): string[] {
 }
 
 const API_SUBCOMMANDS = new Set(["list", "describe", "search", "call"]);
+const LOG_LEVEL_MAP: Record<string, number> = {
+  error: 0,
+  info: 1,
+  debug: 2,
+};
+
 const ROOT_FLAG_WITH_VALUE = new Set([
   "--env",
   "-e",
@@ -310,6 +316,12 @@ const rootCommand = Command.make(
       ),
       Options.optional,
     ),
+    logLevel: Options.text("log-level").pipe(
+      Options.withDescription(
+        "Set log verbosity level (error, info, debug)",
+      ),
+      Options.optional,
+    ),
   },
   (_config) =>
     Effect.gen(function* () {
@@ -385,6 +397,8 @@ export function runCli(rawArgv: ReadonlyArray<string>): Promise<void> {
   let prettyPrint = false;
   let verbosity = 0;
   let envOverride: Environment | null = null;
+  let logLevelSet = false;
+  let hasVerbosityFlag = false;
 
   const stripIndices = new Set<number>();
   for (let i = 0; i < normalized.length; i++) {
@@ -393,16 +407,44 @@ export function runCli(rawArgv: ReadonlyArray<string>): Promise<void> {
       prettyPrint = true;
       stripIndices.add(i);
     }
-    if (token === "--verbose" || token === "-v")
+    if (token === "--verbose" || token === "-v") {
       verbosity = Math.max(verbosity, 1);
-    if (token === "--debug") verbosity = 2;
-    if (token === "--info") verbosity = Math.max(verbosity, 1);
+      hasVerbosityFlag = true;
+    }
+    if (token === "--debug") {
+      verbosity = 2;
+      hasVerbosityFlag = true;
+    }
+    if (token === "--info") {
+      verbosity = Math.max(verbosity, 1);
+      hasVerbosityFlag = true;
+    }
+    if (token === "--log-level" && i + 1 < normalized.length) {
+      const level = normalized[i + 1].toLowerCase();
+      if (level in LOG_LEVEL_MAP) {
+        verbosity = LOG_LEVEL_MAP[level];
+        logLevelSet = true;
+      } else {
+        process.stderr.write(
+          `Warning: unknown --log-level "${normalized[i + 1]}", expected: error, info, debug\n`,
+        );
+      }
+      stripIndices.add(i);
+      stripIndices.add(i + 1);
+      i++; // skip value
+    }
     if ((token === "--env" || token === "-e") && i + 1 < normalized.length) {
       envOverride = validateEnvironment(normalized[i + 1]);
       stripIndices.add(i);
       stripIndices.add(i + 1);
       i++; // skip value
     }
+  }
+
+  if (logLevelSet && hasVerbosityFlag) {
+    process.stderr.write(
+      "Warning: --log-level overrides --verbose/--debug/--info flags\n",
+    );
   }
 
   const frameworkArgs = normalized.filter((_, i) => !stripIndices.has(i));

--- a/tests/integration/cli-smoke.test.ts
+++ b/tests/integration/cli-smoke.test.ts
@@ -351,4 +351,78 @@ describe("CLI Smoke Tests", () => {
     expect(payload.command).toBe("godaddy --debug");
     expect(result.stderr).toContain("(verbose output enabled: full details)");
   });
+
+  it("--log-level error produces no verbose output", () => {
+    const result = runCli(["--log-level", "error", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload.ok).toBe(true);
+    expect(result.stderr).not.toContain("verbose output enabled");
+  });
+
+  it("--log-level info enables basic verbose mode", () => {
+    const result = runCli(["--log-level", "info", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload.ok).toBe(true);
+    expect(result.stderr).toContain("(verbose output enabled)");
+    expect(result.stderr).not.toContain("full details");
+  });
+
+  it("--log-level debug enables full verbose mode", () => {
+    const result = runCli(["--log-level", "debug", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload.ok).toBe(true);
+    expect(result.stderr).toContain("(verbose output enabled: full details)");
+  });
+
+  it("--log-level is case-insensitive", () => {
+    const result = runCli(["--log-level", "DEBUG", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    expect(result.stderr).toContain("(verbose output enabled: full details)");
+  });
+
+  it("unknown --log-level emits a warning", () => {
+    const result = runCli(["--log-level", "bogus", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    expect(result.stderr).toContain('unknown --log-level "bogus"');
+    expect(result.stderr).toContain("error, info, debug");
+  });
+
+  it("--log-level combined with --verbose emits conflict warning", () => {
+    const result = runCli(["--log-level", "debug", "--verbose", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    expect(result.stderr).toContain(
+      "--log-level overrides --verbose/--debug/--info flags",
+    );
+    expect(result.stderr).toContain("(verbose output enabled: full details)");
+  });
+
+  it("--log-level combined with --debug emits conflict warning", () => {
+    const result = runCli(["--log-level", "info", "--debug", "env", "get"]);
+    expect(result.status).toBe(0);
+
+    expect(result.stderr).toContain(
+      "--log-level overrides --verbose/--debug/--info flags",
+    );
+    // --log-level info wins over --debug
+    expect(result.stderr).toContain("(verbose output enabled)");
+    expect(result.stderr).not.toContain("full details)");
+  });
+
+  it("--log-level is stripped from argv and does not break subcommands", () => {
+    const result = runCli(["--log-level", "error", "application"]);
+    expect(result.status).toBe(0);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload.ok).toBe(true);
+    expect(payload.result.command).toBe("godaddy application");
+  });
 });


### PR DESCRIPTION
Adds a --log-level option (error, info, debug) as an alternative to --verbose/--debug/--info flags, with conflict detection and warnings.

Q: Whether we should add trace and warning via log_level command line option?

Alternative is to eliminate log_level from command line and the docs. 

