### PR TITLE
fix(DEVX-68): reject localhost/private URLs in application init

### DIFF
--- a/.changeset/devx-68-reject-private-urls.md
+++ b/.changeset/devx-68-reject-private-urls.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/cli": patch
+---
+
+DEVX-68: Reject non-public URLs when initializing an application. URLs pointing at localhost, loopback addresses (127.0.0.1, ::1), private IP ranges (10/8, 172.16/12, 192.168/16), link-local addresses, or .local/.localhost hostnames are now rejected up front with a ValidationError that explains a publicly reachable HTTPS URL is required, instead of being accepted and later failing at delivery time with an opaque NetworkError. Public HTTPS URLs and valid hostnames continue to be accepted (behavior unchanged)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Returns environment/auth snapshots and the full command tree.
 - `godaddy application disable <name> --store-id <storeId>`
 - `godaddy application archive <name>`
 - `godaddy application init [--name <name>] [--description <description>] [--url <url>] [--proxy-url <proxyUrl>] [--scopes <scopes>] [--config <path>] [--environment <env>]`
+  - `--url` and `--proxy-url` must be publicly-resolvable `http(s)` URLs. `localhost`, loopback (`127.0.0.1`, `::1`), link-local, and RFC1918 private IPs are rejected. For local development, expose a tunnel (e.g. [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), [ngrok](https://ngrok.com/)) and register the tunnel hostname.
 - `godaddy application release <name> --release-version <version> [--description <description>] [--config <path>] [--environment <env>]`
 - `godaddy application deploy <name> [--config <path>] [--environment <env>] [--follow]`
 

--- a/src/core/applications.ts
+++ b/src/core/applications.ts
@@ -32,6 +32,7 @@ import {
   getExtensionsFromConfigEffect,
 } from "../services/config";
 import { bundleExtensionEffect as bundleExtServiceEffect } from "../services/extension/bundler";
+import { publicHttpUrl } from "../services/public-url";
 import { getUploadTargetEffect } from "../services/extension/presigned-url";
 import {
   scanBundleEffect,
@@ -183,8 +184,8 @@ const updateApplicationInputValidator = type({
 const createApplicationInputValidator = type({
   name: "string",
   description: "string",
-  url: type.keywords.string.url.root,
-  proxyUrl: type.keywords.string.url.root,
+  url: publicHttpUrl,
+  proxyUrl: publicHttpUrl,
   authorizationScopes: type.string.array().moreThanLength(0),
 });
 
@@ -477,7 +478,7 @@ export function applicationInitEffect(
       return yield* Effect.fail(
         new ValidationError({
           message: validationResult.summary,
-          userMessage: "Invalid application configuration",
+          userMessage: `Invalid application configuration: ${validationResult.summary}`,
         }),
       );
     }

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -4,6 +4,7 @@ import { graphql } from "gql.tada";
 import { ClientError } from "graphql-request";
 import { AuthenticationError, NetworkError } from "../effect/errors";
 import { getRequestHeaders, makeGraphQLClientEffect } from "./http-helpers";
+import { publicHttpUrl } from "./public-url";
 
 const ApplicationQuery = graphql(`
   query Application($name: String!) {
@@ -144,8 +145,8 @@ export const applicationInput = type({
   label: "string",
   name: "string",
   description: "string",
-  url: type.keywords.string.url.root,
-  proxyUrl: type.keywords.string.url.root,
+  url: publicHttpUrl,
+  proxyUrl: publicHttpUrl,
   authorizationScopes: type.string.array().moreThanLength(0),
 });
 

--- a/src/services/public-url.ts
+++ b/src/services/public-url.ts
@@ -1,0 +1,131 @@
+import { type } from "arktype";
+
+/**
+ * Returns true when `value` is a syntactically valid `http(s)` URL whose host
+ * is expected to be resolvable on the public internet.
+ *
+ * The following host classes are rejected:
+ *  - `localhost` and any `*.localhost` / `*.local` hostnames
+ *  - IPv4 loopback `127.0.0.0/8` and the unspecified address `0.0.0.0`
+ *  - IPv6 loopback `::1` and unspecified `::`
+ *  - IPv4 link-local `169.254.0.0/16`
+ *  - IPv6 link-local `fe80::/10`
+ *  - RFC1918 private IPv4 ranges: `10.0.0.0/8`, `172.16.0.0/12`,
+ *    `192.168.0.0/16`
+ *
+ * This is enforced client-side so users get an actionable error immediately
+ * rather than an opaque 403 from the upstream WAF.
+ */
+export function isPublicRoutableUrl(value: string): boolean {
+	if (typeof value !== "string" || value.trim() === "") {
+		return false;
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return false;
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return false;
+	}
+
+	const rawHost = parsed.hostname.toLowerCase();
+
+	if (rawHost === "") {
+		return false;
+	}
+
+	// WHATWG URL returns IPv6 hostnames wrapped in square brackets.
+	const host =
+		rawHost.startsWith("[") && rawHost.endsWith("]")
+			? rawHost.slice(1, -1)
+			: rawHost;
+
+	if (host === "localhost") {
+		return false;
+	}
+
+	if (host.endsWith(".localhost") || host.endsWith(".local")) {
+		return false;
+	}
+
+	if (isIPv4(host)) {
+		return isPublicIPv4(host);
+	}
+
+	if (isIPv6(host)) {
+		return isPublicIPv6(host);
+	}
+
+	return true;
+}
+
+function isIPv4(host: string): boolean {
+	return /^(\d{1,3}\.){3}\d{1,3}$/.test(host);
+}
+
+function parseIPv4Octets(host: string): number[] | null {
+	const parts = host.split(".").map((p) => Number(p));
+	if (parts.length !== 4) return null;
+	for (const p of parts) {
+		if (!Number.isInteger(p) || p < 0 || p > 255) return null;
+	}
+	return parts;
+}
+
+function isPublicIPv4(host: string): boolean {
+	const octets = parseIPv4Octets(host);
+	if (!octets) return false;
+	const [a, b] = octets as [number, number, number, number];
+
+	// Unspecified 0.0.0.0/8
+	if (a === 0) return false;
+	// Loopback 127.0.0.0/8
+	if (a === 127) return false;
+	// RFC1918: 10.0.0.0/8
+	if (a === 10) return false;
+	// RFC1918: 172.16.0.0/12
+	if (a === 172 && b >= 16 && b <= 31) return false;
+	// RFC1918: 192.168.0.0/16
+	if (a === 192 && b === 168) return false;
+	// Link-local 169.254.0.0/16
+	if (a === 169 && b === 254) return false;
+
+	return true;
+}
+
+function isIPv6(host: string): boolean {
+	// WHATWG URL parses IPv6 hostnames wrapped in [] and returns them
+	// unwrapped in .hostname, so detect by the presence of a ":".
+	return host.includes(":");
+}
+
+function isPublicIPv6(host: string): boolean {
+	const normalized = host.toLowerCase();
+
+	if (normalized === "::" || normalized === "::1") return false;
+	if (normalized.startsWith("fe80:") || normalized.startsWith("fe80::")) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Arktype narrowing that accepts only publicly-routable `http(s)` URLs.
+ *
+ * Use in schemas in place of `type.keywords.string.url.root` when the URL
+ * will be stored server-side and needs to be reachable from the public
+ * internet (for example: app homepage URLs and OAuth redirect URIs).
+ */
+export const publicHttpUrl = type("string").narrow((value, ctx) => {
+	if (isPublicRoutableUrl(value)) {
+		return true;
+	}
+	return ctx.mustBe(
+		"a publicly-resolvable http(s) URL (localhost, loopback, and private IPs are not allowed)",
+	);
+});

--- a/tests/unit/services/public-url.test.ts
+++ b/tests/unit/services/public-url.test.ts
@@ -1,0 +1,121 @@
+import { type } from "arktype";
+import { describe, expect, test } from "vitest";
+import {
+	isPublicRoutableUrl,
+	publicHttpUrl,
+} from "../../../src/services/public-url";
+
+describe("isPublicRoutableUrl", () => {
+	describe("accepts publicly-resolvable http(s) URLs", () => {
+		test.each([
+			"https://example.com",
+			"https://app.example.com",
+			"http://example.com",
+			"https://api.example.com:8443",
+			"https://example.com/path?query=1",
+			"https://sub.domain.example.co.uk",
+			"https://xn--bcher-kva.example.com",
+			"https://[2606:4700:4700::1111]",
+		])("accepts %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(true);
+		});
+	});
+
+	describe("rejects localhost variants", () => {
+		test.each([
+			"http://localhost",
+			"http://localhost:3000",
+			"http://localhost:3000/callback",
+			"https://localhost:5678",
+			"http://LOCALHOST",
+			"http://foo.localhost",
+			"http://foo.local",
+			"http://foo.bar.local",
+		])("rejects %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(false);
+		});
+	});
+
+	describe("rejects loopback and unspecified addresses", () => {
+		test.each([
+			"http://127.0.0.1",
+			"http://127.0.0.1:8080",
+			"http://127.1.2.3",
+			"http://0.0.0.0",
+			"http://0.0.0.0:8080",
+			"http://[::1]",
+			"http://[::1]:8080",
+			"http://[::]",
+		])("rejects %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(false);
+		});
+	});
+
+	describe("rejects RFC1918 private IPv4 ranges", () => {
+		test.each([
+			"http://10.0.0.1",
+			"http://10.255.255.255",
+			"http://172.16.0.1",
+			"http://172.20.1.2",
+			"http://172.31.255.255",
+			"http://192.168.0.1",
+			"http://192.168.1.100",
+		])("rejects %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(false);
+		});
+	});
+
+	describe("rejects link-local ranges", () => {
+		test.each([
+			"http://169.254.0.1",
+			"http://169.254.169.254",
+			"http://[fe80::1]",
+			"http://[FE80::abcd]",
+		])("rejects %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(false);
+		});
+	});
+
+	describe("rejects non-http(s) schemes and malformed input", () => {
+		test.each([
+			"ftp://example.com",
+			"file:///etc/passwd",
+			"javascript:alert(1)",
+			"not-a-url",
+			"",
+			"   ",
+		])("rejects %s", (url) => {
+			expect(isPublicRoutableUrl(url)).toBe(false);
+		});
+	});
+
+	test("does not treat non-RFC1918 /8 ranges like 172.15 or 172.32 as private", () => {
+		expect(isPublicRoutableUrl("http://172.15.0.1")).toBe(true);
+		expect(isPublicRoutableUrl("http://172.32.0.1")).toBe(true);
+	});
+});
+
+describe("publicHttpUrl (arktype narrowing)", () => {
+	test("parses a valid public URL", () => {
+		const result = publicHttpUrl("https://app.example.com");
+		expect(result).toBe("https://app.example.com");
+	});
+
+	test("produces an ArkError for localhost", () => {
+		const result = publicHttpUrl("http://localhost:3000/callback");
+		expect(result).toBeInstanceOf(type.errors);
+		if (result instanceof type.errors) {
+			expect(result.summary).toMatch(/publicly-resolvable/i);
+		}
+	});
+
+	test("produces an ArkError for loopback IP", () => {
+		const result = publicHttpUrl("http://127.0.0.1:8080");
+		expect(result).toBeInstanceOf(type.errors);
+	});
+
+	test("produces an ArkError for non-http(s) scheme", () => {
+		const result = publicHttpUrl("ftp://example.com");
+		expect(result).toBeInstanceOf(type.errors);
+	});
+});


### PR DESCRIPTION
Ticket: https://godaddy-corp.atlassian.net/browse/DEVX-68

Added `publicHttpUrl` — an arktype narrow backed by a pure `isPublicRoutableUrl` predicate. Strict subset of the old URL keyword: still requires a syntactically-valid URL, and additionally requires `http` / `https` scheme and a host outside the IETF/IANA non-routable classes:
- `localhost`, `*.localhost`, `*.local` (RFC 6761 / 6762)
- IPv4 loopback `127.0.0.0/8` and unspecified `0.0.0.0` (RFC 1122)
- IPv4 link-local `169.254.0.0/16` (RFC 3927)
- RFC 1918 private ranges `10/8`, `172.16/12`, `192.168/16`
- IPv6 loopback `::1`, unspecified `::`, link-local `fe80::/10` (RFC 4291)

Swapped arktype's built-in URL keyword for `publicHttpUrl` at both `application init` input schemas. Validation already ran first in the init effect, so bad URLs now short-circuit before any auth or HTTP call. Auth, HTTP, environment routing, and WAF rules are untouched.

The error message now includes the arktype summary — the failing field, the rejected value, and the reason — in place of the previous generic "Invalid application configuration".

Updated the documentation with a note on the updated URL constraints for `application init`