### PR TITLE
Devx 73 http trace headers

### DIFF
--- a/.changeset/cli-http-trace-headers.md
+++ b/.changeset/cli-http-trace-headers.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/cli": minor
+---
+
+Outgoing HTTP requests now carry a consistent `User-Agent` (`godaddy-cli/<version>` from the package manifest) and a per-request `X-Request-ID` (UUID v7) on REST catalog calls, GraphQL requests, OAuth token exchange, and webhook event-type discovery. Presigned S3 artifact uploads are unchanged: only the headers returned with the presigned URL are sent, so uploads remain signature-compatible.

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -10,6 +10,7 @@ import {
 } from "../effect/errors";
 import { fileExists } from "../effect/fs-utils";
 import type { Keychain } from "../effect/services/keychain";
+import { CLI_USER_AGENT } from "../services/http-helpers";
 import { getTokenInfoEffect } from "./auth";
 import { type Environment, envGetEffect, getApiUrl } from "./environment";
 
@@ -76,7 +77,6 @@ const MAX_ERROR_SUMMARY_CHARS = 240;
 const MAX_ERROR_DEPTH = 6;
 const MAX_ERROR_ARRAY_ITEMS = 40;
 const MAX_ERROR_OBJECT_KEYS = 80;
-const DEFAULT_USER_AGENT = "godaddy-cli";
 
 function findHeaderKey(
   headers: Record<string, string>,
@@ -108,7 +108,7 @@ function ensureRequiredRequestHeaders(headers: Record<string, string>): void {
   }
 
   if (!hasNonEmptyHeader(headers, "user-agent")) {
-    headers["user-agent"] = DEFAULT_USER_AGENT;
+    headers["user-agent"] = CLI_USER_AGENT;
   }
 }
 

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -10,7 +10,7 @@ import {
 } from "../effect/errors";
 import { fileExists } from "../effect/fs-utils";
 import type { Keychain } from "../effect/services/keychain";
-import { CLI_USER_AGENT } from "../services/http-helpers";
+import { CLI_USER_AGENT } from "../shared/cli-trace";
 import { getTokenInfoEffect } from "./auth";
 import { type Environment, envGetEffect, getApiUrl } from "./environment";
 

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -7,12 +7,12 @@ import { AuthenticationError, ConfigurationError } from "../effect/errors";
 import { Browser } from "../effect/services/browser";
 
 import type { Keychain } from "../effect/services/keychain";
-import { cliTraceHeaders } from "../services/http-helpers";
 // loggedFetch calls globalThis.fetch directly — not through the Fetch service tag.
 // This is acceptable here because the OAuth callback runs inside a raw http.Server
 // handler (Promise context), outside the Effect runtime. The Fetch tag is for
 // code within Effect.gen contexts.
 import { loggedFetch } from "../services/logger";
+import { cliTraceHeaders } from "../shared/cli-trace";
 import {
   type Environment,
   envGetEffect,

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -7,6 +7,7 @@ import { AuthenticationError, ConfigurationError } from "../effect/errors";
 import { Browser } from "../effect/services/browser";
 
 import type { Keychain } from "../effect/services/keychain";
+import { cliTraceHeaders } from "../services/http-helpers";
 // loggedFetch calls globalThis.fetch directly — not through the Fetch service tag.
 // This is acceptable here because the OAuth callback runs inside a raw http.Server
 // handler (Promise context), outside the Effect runtime. The Fetch tag is for
@@ -183,6 +184,7 @@ export function authLoginEffect(options?: {
                     method: "POST",
                     headers: {
                       "Content-Type": "application/x-www-form-urlencoded",
+                      ...cliTraceHeaders(),
                     },
                     body: new URLSearchParams({
                       client_id: clientId,

--- a/src/services/extension/upload.ts
+++ b/src/services/extension/upload.ts
@@ -99,8 +99,11 @@ export function uploadArtifactEffect(
     let lastError: Error | undefined;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      // Use only the requiredHeaders from the presigned URL (already signed)
-      // Filter out x-amz-meta-upload-id as it's not signed
+      // Presigned S3 PUT: send only the headers returned with the URL (they are
+      // part of the AWS Signature v4 signing string). Do not add User-Agent or
+      // X-Request-ID here — unsigned headers can still affect behavior, and
+      // anything not in the signature can break the upload. Traceability for
+      // this hop is the presigned URL request (GraphQL), not the PUT itself.
       const { "x-amz-meta-upload-id": _, ...headers } = target.requiredHeaders;
 
       logger.debug(

--- a/src/services/extension/upload.ts
+++ b/src/services/extension/upload.ts
@@ -100,8 +100,8 @@ export function uploadArtifactEffect(
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       // Presigned S3 PUT: send only the headers returned with the URL (they are
-      // part of the AWS Signature v4 signing string). Do not add User-Agent or
-      // X-Request-ID here — unsigned headers can still affect behavior, and
+      // part of the AWS Signature v4 signing string). Do not add `user-agent` or
+      // `x-request-id` here — unsigned headers can still affect behavior, and
       // anything not in the signature can break the upload. Traceability for
       // this hop is the presigned URL request (GraphQL), not the PUT itself.
       const { "x-amz-meta-upload-id": _, ...headers } = target.requiredHeaders;

--- a/src/services/http-helpers.ts
+++ b/src/services/http-helpers.ts
@@ -6,24 +6,9 @@ import { Fetch } from "@effect/platform/FetchHttpClient";
 import type { FileSystem } from "@effect/platform/FileSystem";
 import * as Effect from "effect/Effect";
 import { GraphQLClient } from "graphql-request";
-import { v7 as uuid } from "uuid";
-import packageJson from "../../package.json";
 import { type Environment, envGetEffect, getApiUrl } from "../core/environment";
 import { ConfigurationError } from "../effect/errors";
-
-/** Shared User-Agent for outbound CLI HTTP requests (server-side tracing). */
-export const CLI_USER_AGENT = `godaddy-cli/${packageJson.version}`;
-
-/**
- * Headers attached to outbound requests so upstream logs can correlate calls.
- * Each invocation generates a fresh request ID.
- */
-export function cliTraceHeaders(): Record<string, string> {
-  return {
-    "User-Agent": CLI_USER_AGENT,
-    "X-Request-ID": uuid(),
-  };
-}
+import { cliTraceHeaders } from "../shared/cli-trace";
 
 /**
  * Resolve the API base URL from environment variables or the active environment.

--- a/src/services/http-helpers.ts
+++ b/src/services/http-helpers.ts
@@ -7,8 +7,23 @@ import type { FileSystem } from "@effect/platform/FileSystem";
 import * as Effect from "effect/Effect";
 import { GraphQLClient } from "graphql-request";
 import { v7 as uuid } from "uuid";
+import packageJson from "../../package.json";
 import { type Environment, envGetEffect, getApiUrl } from "../core/environment";
 import { ConfigurationError } from "../effect/errors";
+
+/** Shared User-Agent for outbound CLI HTTP requests (server-side tracing). */
+export const CLI_USER_AGENT = `godaddy-cli/${packageJson.version}`;
+
+/**
+ * Headers attached to outbound requests so upstream logs can correlate calls.
+ * Each invocation generates a fresh request ID.
+ */
+export function cliTraceHeaders(): Record<string, string> {
+  return {
+    "User-Agent": CLI_USER_AGENT,
+    "X-Request-ID": uuid(),
+  };
+}
 
 /**
  * Resolve the API base URL from environment variables or the active environment.
@@ -63,6 +78,6 @@ export function makeGraphQLClientEffect(): Effect.Effect<
 export function getRequestHeaders(accessToken: string): Record<string, string> {
   return {
     Authorization: `Bearer ${accessToken}`,
-    "X-Request-ID": uuid(),
+    ...cliTraceHeaders(),
   };
 }

--- a/src/services/webhook-events.ts
+++ b/src/services/webhook-events.ts
@@ -8,6 +8,7 @@ import {
   NetworkError,
   type ValidationError,
 } from "../effect/errors";
+import { cliTraceHeaders } from "./http-helpers";
 import { logHttpRequest, logHttpResponse } from "./logger";
 
 export type WebhookEventType = {
@@ -47,7 +48,7 @@ export function getWebhookEventsTypesEffect({
     const url = `${baseUrl}/v1/apis/webhook-event-types`;
     const headers = {
       Authorization: `Bearer ${accessToken}`,
-      UserAgent: "@godaddy/cli",
+      ...cliTraceHeaders(),
     };
 
     const startTime = Date.now();

--- a/src/services/webhook-events.ts
+++ b/src/services/webhook-events.ts
@@ -8,7 +8,7 @@ import {
   NetworkError,
   type ValidationError,
 } from "../effect/errors";
-import { cliTraceHeaders } from "./http-helpers";
+import { cliTraceHeaders } from "../shared/cli-trace";
 import { logHttpRequest, logHttpResponse } from "./logger";
 
 export type WebhookEventType = {

--- a/src/shared/cli-trace.ts
+++ b/src/shared/cli-trace.ts
@@ -1,0 +1,21 @@
+import { v7 as uuid } from "uuid";
+import packageJson from "../../package.json";
+
+/** Shared User-Agent for outbound CLI HTTP requests (server-side tracing). */
+export const CLI_USER_AGENT = `godaddy-cli/${packageJson.version}`;
+
+/**
+ * Headers attached to outbound requests so upstream logs can correlate calls.
+ * Each invocation generates a fresh request ID.
+ *
+ * Keys are lowercase (`user-agent`, `x-request-id`) so the same spelling is
+ * used as in `ensureRequiredRequestHeaders` (`src/core/api.ts`) and across
+ * REST, GraphQL, OAuth, and webhook calls. HTTP treats header names as
+ * case-insensitive; lowercase keeps log pipelines and tests consistent.
+ */
+export function cliTraceHeaders(): Record<string, string> {
+  return {
+    "user-agent": CLI_USER_AGENT,
+    "x-request-id": uuid(),
+  };
+}

--- a/tests/unit/core/api.test.ts
+++ b/tests/unit/core/api.test.ts
@@ -82,7 +82,7 @@ describe("API Core Functions", () => {
           headers: expect.objectContaining({
             Authorization: "Bearer test-token-123",
             "x-request-id": expect.any(String),
-            "user-agent": "godaddy-cli",
+            "user-agent": expect.stringMatching(/^godaddy-cli\/\d+\.\d+\.\d+$/),
           }),
         }),
       );

--- a/tests/unit/services/extension/presigned-url.test.ts
+++ b/tests/unit/services/extension/presigned-url.test.ts
@@ -26,8 +26,8 @@ vi.mock("@/services/http-helpers", () => {
   return {
     getRequestHeaders: (token: string) => ({
       Authorization: `Bearer ${token}`,
-      "User-Agent": "godaddy-cli/0.0.0-test",
-      "X-Request-ID": "test-uuid",
+      "user-agent": "godaddy-cli/0.0.0-test",
+      "x-request-id": "test-uuid",
     }),
     makeGraphQLClientEffect: () =>
       Effect.succeed({

--- a/tests/unit/services/extension/presigned-url.test.ts
+++ b/tests/unit/services/extension/presigned-url.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/services/http-helpers", () => {
   return {
     getRequestHeaders: (token: string) => ({
       Authorization: `Bearer ${token}`,
+      "User-Agent": "godaddy-cli/0.0.0-test",
       "X-Request-ID": "test-uuid",
     }),
     makeGraphQLClientEffect: () =>

--- a/tests/unit/services/http-helpers.test.ts
+++ b/tests/unit/services/http-helpers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import packageJson from "../../../package.json";
+import {
+  CLI_USER_AGENT,
+  cliTraceHeaders,
+  getRequestHeaders,
+} from "../../../src/services/http-helpers";
+
+describe("http-helpers trace headers", () => {
+  test("CLI_USER_AGENT includes package version", () => {
+    expect(CLI_USER_AGENT).toBe(`godaddy-cli/${packageJson.version}`);
+  });
+
+  test("cliTraceHeaders sets User-Agent and X-Request-ID", () => {
+    const h = cliTraceHeaders();
+    expect(h["User-Agent"]).toBe(CLI_USER_AGENT);
+    expect(h["X-Request-ID"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test("getRequestHeaders merges auth with trace headers", () => {
+    const h = getRequestHeaders("tok");
+    expect(h.Authorization).toBe("Bearer tok");
+    expect(h["User-Agent"]).toBe(CLI_USER_AGENT);
+    expect(h["X-Request-ID"]).toBeTruthy();
+  });
+});

--- a/tests/unit/shared/cli-trace.test.ts
+++ b/tests/unit/shared/cli-trace.test.ts
@@ -1,20 +1,17 @@
 import { describe, expect, test } from "vitest";
 import packageJson from "../../../package.json";
-import {
-  CLI_USER_AGENT,
-  cliTraceHeaders,
-  getRequestHeaders,
-} from "../../../src/services/http-helpers";
+import { getRequestHeaders } from "../../../src/services/http-helpers";
+import { CLI_USER_AGENT, cliTraceHeaders } from "../../../src/shared/cli-trace";
 
-describe("http-helpers trace headers", () => {
+describe("cli-trace", () => {
   test("CLI_USER_AGENT includes package version", () => {
     expect(CLI_USER_AGENT).toBe(`godaddy-cli/${packageJson.version}`);
   });
 
-  test("cliTraceHeaders sets User-Agent and X-Request-ID", () => {
+  test("cliTraceHeaders sets lowercase user-agent and x-request-id", () => {
     const h = cliTraceHeaders();
-    expect(h["User-Agent"]).toBe(CLI_USER_AGENT);
-    expect(h["X-Request-ID"]).toMatch(
+    expect(h["user-agent"]).toBe(CLI_USER_AGENT);
+    expect(h["x-request-id"]).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     );
   });
@@ -22,7 +19,7 @@ describe("http-helpers trace headers", () => {
   test("getRequestHeaders merges auth with trace headers", () => {
     const h = getRequestHeaders("tok");
     expect(h.Authorization).toBe("Bearer tok");
-    expect(h["User-Agent"]).toBe(CLI_USER_AGENT);
-    expect(h["X-Request-ID"]).toBeTruthy();
+    expect(h["user-agent"]).toBe(CLI_USER_AGENT);
+    expect(h["x-request-id"]).toBeTruthy();
   });
 });

--- a/tests/unit/shared/cli-trace.test.ts
+++ b/tests/unit/shared/cli-trace.test.ts
@@ -11,9 +11,14 @@ describe("cli-trace", () => {
   test("cliTraceHeaders sets lowercase user-agent and x-request-id", () => {
     const h = cliTraceHeaders();
     expect(h["user-agent"]).toBe(CLI_USER_AGENT);
-    expect(h["x-request-id"]).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-    );
+    const rid = h["x-request-id"];
+    expect(rid).toBeDefined();
+    // Standard UUID string forms are 32 hex digits (with optional hyphens);
+    // avoid a strict 8-4-4-4-12 regex so a future uuid package output shape
+    // does not flake the test as long as it remains 32 hex.
+    const hex = rid.replace(/-/g, "");
+    expect(hex).toHaveLength(32);
+    expect(hex).toMatch(/^[0-9a-f]+$/i);
   });
 
   test("getRequestHeaders merges auth with trace headers", () => {


### PR DESCRIPTION
What-
Adds a shared User-Agent (godaddy-cli/<version> from the package manifest) and a per-request x-request-id (UUID v7) on outbound calls: REST (apiRequestEffect), GraphQL (getRequestHeaders), OAuth token exchange, and webhook event-types. Centralized in src/shared/cli-trace.ts with lowercase header keys to match existing REST behavior. Presigned S3 PUTs are unchanged (signed headers only).

Why-
Improves server-side traceability in logs (e.g. Kibana) by consistently identifying the CLI and correlating individual requests.

How to verify-
pnpm exec tsc --noEmit
pnpm run build
pnpm vitest run

Changelog-
minor, see -.changeset/cli-http-trace-headers.md