### PR TITLE
[codex] Fix config update path persistence

### DIFF
--- a/.changeset/config-update-path-persistence.md
+++ b/.changeset/config-update-path-persistence.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/cli": patch
+---
+
+Fix application config updates so action, subscription, and extension additions write back to the resolved config file instead of re-resolving the environment path.

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,5 +1,5 @@
 import * as nodeFs from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { FileSystem } from "@effect/platform/FileSystem";
 import * as TOML from "@iarna/toml";
 import { type ArkErrors, type } from "arktype";
@@ -207,7 +207,9 @@ export function getConfigFilePath(
   configPath?: string,
 ): string {
   if (configPath) {
-    return join(process.cwd(), configPath);
+    return isAbsolute(configPath)
+      ? configPath
+      : join(process.cwd(), configPath);
   }
 
   const resolvedEnv = resolveConfigEnvironment(env);
@@ -235,7 +237,7 @@ export function getConfigFileEffect({
 
     // If a specific config path is provided, use that
     if (configPath) {
-      const absolutePath = join(process.cwd(), configPath);
+      const absolutePath = getConfigFilePath(undefined, configPath);
       const exists = yield* fileExists(absolutePath);
       if (exists) {
         const content = yield* fs.readFileString(absolutePath);
@@ -298,7 +300,7 @@ export function getConfigFile({
   const resolvedEnv = resolveConfigEnvironment(env);
 
   if (configPath) {
-    const absolutePath = join(process.cwd(), configPath);
+    const absolutePath = getConfigFilePath(undefined, configPath);
     if (nodeFs.existsSync(absolutePath)) {
       const content = nodeFs.readFileSync(absolutePath, "utf-8");
       return Config(TOML.parse(content));
@@ -429,7 +431,7 @@ function getConfigFilePathForUpdateEffect(
     const resolvedEnv = resolveConfigEnvironment(env);
 
     if (configPath) {
-      const absolutePath = join(process.cwd(), configPath);
+      const absolutePath = getConfigFilePath(undefined, configPath);
       const exists = yield* fileExists(absolutePath);
       if (exists) {
         return { path: absolutePath };
@@ -467,13 +469,12 @@ function getConfigFilePathForUpdateEffect(
 /**
  * Write a full Config object to the TOML file.
  */
-function writeConfigToFileEffect(
+function writeConfigToResolvedPathEffect(
   data: Config,
-  env?: ConfigEnvironment,
+  filePath: string,
 ): Effect.Effect<void, ConfigurationError, FileSystem> {
   return Effect.gen(function* () {
     const fs = yield* FileSystem;
-    const filePath = getConfigFilePath(env);
 
     // Try to read the existing file to preserve structure
     let existingConfig = {};
@@ -558,6 +559,13 @@ function writeConfigToFileEffect(
   );
 }
 
+function writeConfigToFileEffect(
+  data: Config,
+  env?: ConfigEnvironment,
+): Effect.Effect<void, ConfigurationError, FileSystem> {
+  return writeConfigToResolvedPathEffect(data, getConfigFilePath(env));
+}
+
 /**
  * Write the config data to the appropriate TOML file.
  */
@@ -614,11 +622,11 @@ export function addActionToConfigEffect(
       actions: [...(configResult.actions || []), action],
     };
 
-    const { env } = yield* getConfigFilePathForUpdateEffect(
+    const { path } = yield* getConfigFilePathForUpdateEffect(
       options.configPath,
       options.env,
     );
-    yield* writeConfigToFileEffect(updatedConfig, env);
+    yield* writeConfigToResolvedPathEffect(updatedConfig, path);
   }).pipe(
     Effect.catchAll((error) =>
       Effect.fail(toConfigError(error, "Unable to update actions in config")),
@@ -651,11 +659,11 @@ export function addSubscriptionToConfigEffect(
       },
     };
 
-    const { env } = yield* getConfigFilePathForUpdateEffect(
+    const { path } = yield* getConfigFilePathForUpdateEffect(
       options.configPath,
       options.env,
     );
-    yield* writeConfigToFileEffect(updatedConfig, env);
+    yield* writeConfigToResolvedPathEffect(updatedConfig, path);
   }).pipe(
     Effect.catchAll((error) =>
       Effect.fail(
@@ -783,11 +791,11 @@ export function addExtensionToConfigEffect(
       extensions: updatedExtensions,
     } satisfies Config;
 
-    const { env } = yield* getConfigFilePathForUpdateEffect(
+    const { path } = yield* getConfigFilePathForUpdateEffect(
       options.configPath,
       options.env,
     );
-    yield* writeConfigToFileEffect(updatedConfig, env);
+    yield* writeConfigToResolvedPathEffect(updatedConfig, path);
   }).pipe(
     Effect.catchAll((error) =>
       Effect.fail(

--- a/tests/unit/services/config-routing.test.ts
+++ b/tests/unit/services/config-routing.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   type Config,
+  addActionToConfigEffect,
   createConfigFileEffect,
   createEnvFileEffect,
   getConfigFilePath,
@@ -65,6 +66,42 @@ describe("Config Environment Routing", () => {
 
     expect(fs.existsSync(path.join(tempDir, "godaddy.dev.toml"))).toBe(true);
     expect(fs.existsSync(path.join(tempDir, "godaddy.ote.toml"))).toBe(false);
+  });
+
+  test("adds actions to the explicit config path", async () => {
+    const configPath = path.join(tempDir, "godaddy.ote.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        'name = "test-app"',
+        'client_id = "a502484b-d7b1-4509-aa88-08b391a54c28"',
+        'description = "Test app"',
+        'version = "1.0.0"',
+        'url = "https://example.com"',
+        'proxy_url = "https://example.com/api"',
+        'authorization_scopes = [ "shopper.readonly" ]',
+        "actions = [ ]",
+        "",
+        "[subscriptions]",
+        "webhook = [ ]",
+        "",
+      ].join("\n"),
+    );
+
+    await runEffect(
+      addActionToConfigEffect(
+        {
+          name: "commerce.communications.broadcast",
+          url: "/actions/broadcast",
+        },
+        { configPath },
+      ),
+    );
+
+    const content = fs.readFileSync(configPath, "utf-8");
+    expect(content).toContain('name = "commerce.communications.broadcast"');
+    expect(content).toContain('url = "/actions/broadcast"');
+    expect(fs.existsSync(path.join(tempDir, "godaddy.toml"))).toBe(false);
   });
 
   test("writes env file to mapped environment file", async () => {


### PR DESCRIPTION
## Summary

Fixes config update operations so they write back to the exact config file path that was resolved for the update. This prevents `godaddy application add action` from returning success while leaving the intended OTE TOML unchanged when a specific config path or environment-specific fallback is involved.

## Root Cause

`addActionToConfigEffect`, `addSubscriptionToConfigEffect`, and `addExtensionToConfigEffect` resolved a target path, but then discarded that path and wrote through environment-based lookup again. Absolute config paths were also being joined onto `process.cwd()`, producing invalid duplicated paths in internal callers/tests.

## Changes

- Preserve absolute config paths in `getConfigFilePath`.
- Reuse config path resolution for both Effect and sync config reads.
- Add a path-based config writer for update flows.
- Update action, subscription, and extension config mutations to write to the resolved path.
- Add a regression test proving action updates persist to an explicit OTE config file without creating/updating the wrong default file.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `pnpm test tests/unit/services/config-routing.test.ts`
- `pnpm test tests/integration/cli-smoke.test.ts tests/unit/application-deploy-security.test.ts tests/unit/cli/deploy-stream.test.ts`
- `rg "export async function" src`
- `rg "toEffect|effect-interop" src`
- `git diff --check`