### PR TITLE
[codex] Use npm trusted publishing for releases

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -38,12 +38,3 @@ jobs:
 
       - name: Run tests
         run: pnpm test
-
-      - name: Create Release Pull Request or Publish
-        if: github.ref == 'refs/heads/main'
-        uses: changesets/action@v1
-        with:
-          publish: pnpm run release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -41,4 +46,3 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_SECRET }}


### PR DESCRIPTION
## Summary
- switch the Release workflow from `NPM_SECRET` token publishing to npm trusted publishing via GitHub OIDC
- grant the Release workflow the `id-token`, `contents`, and `pull-requests` permissions needed by Changesets and npm trusted publishing
- remove the duplicate Changesets publish step from CICD so publishing is centralized in the Release workflow

## Why
The Release workflow failed while publishing `@godaddy/cli@0.5.1` with npm `E404` on `PUT https://registry.npmjs.org/@godaddy%2fcli`. The package exists on npm, so this points to the CI npm token lacking publish rights for the package/scope.

`godaddy/javascript` avoids this by using npm trusted publishing: it does not set `NPM_TOKEN`, grants `id-token: write`, and lets npm authenticate the GitHub Actions workflow through OIDC.

## Follow-up required before merge/release
An npm package owner/admin needs to configure `@godaddy/cli` on npmjs.com with a trusted publisher for this repository and workflow:

- GitHub organization/user: `godaddy`
- Repository: `cli`
- Workflow filename: `release.yaml`
- Branch: `main`

## Validation
- Parsed `.github/workflows/release.yaml` and `.github/workflows/cicd.yml` with Ruby YAML parser.
- Confirmed no workflow references remain to `NPM_SECRET` or `NPM_TOKEN`.
