### PR TITLE
[codex] Use filtered pnpm publish for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:coverage": "vitest --coverage",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && changeset publish"
+    "release": "pnpm build && pnpm publish -r --filter @godaddy/cli"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary

Switches the release script from `changeset publish` to pnpm's publish command filtered to the CLI package: `pnpm publish --filter @godaddy/cli`.

Updates the release-related GitHub Actions in both workflows to the latest release tags checked with `gh release view`:

- `actions/checkout@v6.0.2`
- `pnpm/action-setup@v6.0.5`
- `actions/setup-node@v6.4.0`
- `changesets/action@v1.7.0`

## Validation

- `pnpm publish --filter @godaddy/cli --dry-run --no-git-checks`

The dry run packaged only `@godaddy/cli@0.5.1`.
