### PR TITLE
[codex] Use pnpm publish with latest release actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,16 +13,16 @@ jobs:
     concurrency: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.5
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev build-essential python3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.5
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev build-essential python3
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
@@ -35,14 +35,11 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --prefer-offline
 
-      - name: Build
-        run: pnpm run build
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.7.0
         with:
           version: pnpm run version
-          publish: pnpm run release
+          publish: pnpm publish --filter @godaddy/cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:coverage": "vitest --coverage",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && pnpm publish -r --filter @godaddy/cli"
+    "release": "pnpm build && pnpm publish --filter @godaddy/cli"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary

Aligns release publishing with the `godaddy/javascript` workflow shape:

- release workflow owns Changesets publishing; CICD only builds/checks/tests
- release workflow uses OIDC permissions and no `NPM_TOKEN` secret
- Changesets publish calls pnpm publish directly
- action versions are updated to current release tags

For this single-package repo, the publish command is non-recursive: `pnpm publish --filter @godaddy/cli`.

## Validation

- `pnpm publish --filter @godaddy/cli --dry-run --no-git-checks`

The dry run packaged only `@godaddy/cli@0.5.1`.
