### PR TITLE
[codex] Fix trusted publishing runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version-file: ".nvmrc"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/godaddy/cli.git"
+  },
   "scripts": {
     "format": "pnpm biome format --write .",
     "lint": "pnpm biome lint  --write",


### PR DESCRIPTION
## Summary

Fixes the trusted-publishing runtime used by the Release workflow after #40.

The failed Release run showed `changesets/action` detected OIDC, but `pnpm publish --filter @godaddy/cli` still failed with `ENEEDAUTH` because the runner was on Node 22/npm 10. npm trusted publishing requires npm 11.5.1+, and `godaddy/javascript` succeeds with Node 24/npm 11.

Changes:

- use Node 24 in the Release workflow so pnpm publish shells through npm 11
- add `repository` metadata matching `godaddy/cli`, which npm trusted publishing docs call out for GitHub matching

## Validation

- `pnpm publish --filter @godaddy/cli --dry-run --no-git-checks`
