### PR TITLE
Fix incorrect file references in CLAUDE.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ This is a command-line application that does not run on a network port.
 - **Format**: `pnpm run format`
 - **Lint**: `pnpm run lint`
 - **Type Check**: `pnpm run check`
-- **Run CLI**: `node ./dist/index.mjs` or `./dist/index.mjs` (after building)
-- **Development Mode**: `pnpm tsx --watch index.ts`
-- **Quick CLI Command**: `pnpm tsx src/index.tsx application <command>`
+- **Run CLI**: `node ./dist/cli.js` or `./dist/cli.js` (after building)
+- **Development Mode**: `pnpm tsx --watch src/index.ts`
+- **Quick CLI Command**: `pnpm tsx src/index.ts application <command>`
 
 ## Architecture
 
@@ -30,7 +30,7 @@ GoDaddy CLI is a terminal-based application built using:
 
 ### Core Architecture Components:
 
-1. **Entry Point** (`src/index.tsx`): Defines the CLI command structure using Commander.js and renders commands with Ink
+1. **Entry Point** (`src/index.ts`): Defines the CLI command structure using Commander.js and renders commands with Ink
 
 2. **Command Structure**:
    - Root commands (application, webhook, auth, env)


### PR DESCRIPTION
This PR fixes some incorrect file references in the `CLAUDE.md` file.

I ran `pnpm run build`, followed by this as per original instructions:

```
$ node ./dist/index.mjs api describe /stores/{storeId}/fulfillments
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '/home/agibson/Projects/cli/dist/index.mjs'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

Corrected to `./dist/cli.js` : 

```
$ node ./dist/cli.js api describe /stores/{storeId}/fulfillments
{"ok":true,"command":"godaddy api describe" [...truncated]
```

Additional errors, also fixed:

```
$ pnpm tsx --watch index.ts

node:internal/modules/run_main:122
    triggerUncaughtException(
    ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/agibson/Projects/cli/index.ts' imported from /home/agibson/Projects/cli/
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at nextResolve (node:internal/modules/esm/hooks:748:28)
    at resolveBase (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:6726)
    at async resolveDirectory (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:7807)
    at async resolve2 (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:10165)
    at async nextResolve (node:internal/modules/esm/hooks:748:22)
    at async Hooks.resolve (node:internal/modules/esm/hooks:240:24)
    at async handleMessage (node:internal/modules/esm/worker:199:18) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///home/agibson/Projects/cli/index.ts'
}
```

Fixed: 

```
$ pnpm tsx --watch src/index.ts
{"ok":true,"command":"godaddy","result" [...truncated]
Completed running 'src/index.ts'
```

---

```
$ pnpm tsx src/index.tsx application

node:internal/modules/run_main:122
    triggerUncaughtException(
    ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/agibson/Projects/cli/src/index.tsx' imported from /home/agibson/Projects/cli/
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at nextResolve (node:internal/modules/esm/hooks:748:28)
    at resolveBase (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:6726)
    at async resolveDirectory (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:7807)
    at async resolve2 (file:///home/agibson/Projects/cli/node_modules/tsx/dist/register-lJYvHe5s.mjs:2:10165)
    at async nextResolve (node:internal/modules/esm/hooks:748:22)
    at async Hooks.resolve (node:internal/modules/esm/hooks:240:24)
    at async handleMessage (node:internal/modules/esm/worker:199:18) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///home/agibson/Projects/cli/src/index.tsx'
}
```

Fixed:

```
$ pnpm tsx src/index.ts application
{"ok":true,"command":"godaddy application" [...truncated]
```