### PR TITLE
return client_credentials grant type

### DIFF
--- a/src/cli/commands/application.ts
+++ b/src/cli/commands/application.ts
@@ -730,6 +730,7 @@ const appInit = Command.make(
           url: appData.url,
           proxy_url: appData.proxyUrl,
           authorization_scopes: appData.authorizationScopes,
+          oauth_grant_types: ["authorization_code", "client_credentials"],
           client_id: appData.clientId,
           files_written: {
             config: getConfigFilePath(environment),


### PR DESCRIPTION
This pull request makes a small update to the application initialization logic by explicitly specifying the OAuth grant types supported by the application.

* Added the `oauth_grant_types` property with values `["authorization_code", "client_credentials"]` to the application initialization object in `src/cli/commands/application.ts`