### PR TITLE
DEVEX-695: Restore agent-first root discovery for bare `godaddy`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -536,9 +536,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2da24cf03ad0a4d53abf4c8d0fd5e477eede7ddccda47d1e6358f45c7655d07"
+checksum = "8f3ac303c124ed8284bbc3eb99f99e970509d3e1d4030896ab19663d09911fba"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1268,7 +1268,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1992,7 +1992,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2029,7 +2029,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.1.2" }
+cli-engine = { features = ["pkce-auth"], version = "0.1.3" }
 fancy-regex = "0.14"
 regex = { version = "1", features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -46,10 +46,10 @@ async fn main() -> ExitCode {
             }))
             .with_root_next_actions(Arc::new(|| {
                 vec![
-                    NextAction::new("godaddy auth status", "Check authentication status"),
-                    NextAction::new("godaddy env get", "Get the current active environment"),
-                    NextAction::new("godaddy application list", "List all applications"),
-                    NextAction::new("godaddy tree", "Display the full command tree"),
+                    NextAction::new("auth status", "Check authentication status"),
+                    NextAction::new("env get", "Get the current active environment"),
+                    NextAction::new("application list", "List all applications"),
+                    NextAction::new("tree", "Display the full command tree"),
                 ]
             }))
             .with_module(actions_catalog::module())

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -10,7 +10,7 @@ mod webhook;
 use std::{process::ExitCode, sync::Arc};
 
 use clap::Arg;
-use cli_engine::{BuildInfo, Cli, CliConfig};
+use cli_engine::{BuildInfo, Cli, CliConfig, NextAction};
 
 use crate::env::get_env;
 
@@ -43,6 +43,14 @@ async fn main() -> ExitCode {
                     mw.env = env.clone();
                 }
                 Ok(())
+            }))
+            .with_root_next_actions(Arc::new(|| {
+                vec![
+                    NextAction::new("godaddy auth status", "Check authentication status"),
+                    NextAction::new("godaddy env get", "Get the current active environment"),
+                    NextAction::new("godaddy application list", "List all applications"),
+                    NextAction::new("godaddy tree", "Display the full command tree"),
+                ]
             }))
             .with_module(actions_catalog::module())
             .with_module(api_explorer::module())


### PR DESCRIPTION
Addresses **parity gap #2** from the [PR #49 Rust-port review](https://github.com/godaddy/cli/pull/49#issuecomment-4605625023) (DEVEX-695): the TypeScript CLI returned JSON discovery on bare `godaddy`, but the Rust port rendered clap long-help text for the empty command path — an agent-first discovery regression.

## What this does
- Bumps `cli-engine` to the published **0.1.3** (drops the temporary local path patch used during development).
- Registers root next-actions via the new `with_root_next_actions` hook so bare `godaddy`:
  - **piped / CI / agent (non-TTY, or `--output json`)** → a JSON discovery envelope (`{ data: { description, version }, next_actions }`),
  - **interactive terminal** → long help + a "Suggested next actions" section.

`next_actions` are pointers to existing commands (`auth status`, `env get`, `application list`, `tree`) — the agent follows only what it needs, instead of one fat payload. The engine-side capability (and the curated-help / TTY-aware-output changes) shipped in [cli-engine#13](https://github.com/godaddy/cli-engine/pull/13) → released as cli-engine 0.1.3.

## Behavior
| Invocation | Result |
|---|---|
| `godaddy` (piped) | JSON discovery envelope |
| `godaddy` (TTY) | human help + suggested next actions |
| `godaddy --output json` / `--json` | JSON envelope |
| `GODADDY_OUTPUT=json godaddy` | JSON (env override) |

## Base branch
Targets **`rust-port`** (stacks on the open port PR #49), matching the convention from #50 (DEVEX-694). It will land on `main` with the rest of the port.

## Testing
`cargo build` / `cargo test` (114 pass) / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` all green against the published cli-engine 0.1.3. Manually verified the bare-`godaddy` JSON envelope (piped) and human help + suggested actions (`--human`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)