### PR TITLE
feat: publish gddy alpha binary on rust-port pushes; rename binary to gddy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,20 +17,20 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: godaddy
+            artifact: gddy
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: godaddy
+            artifact: gddy
             cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact: godaddy
+            artifact: gddy
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: godaddy
+            artifact: gddy
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact: godaddy.exe
+            artifact: gddy.exe
     defaults:
       run:
         working-directory: rust
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          ARCHIVE="godaddy-${TAG}-${{ matrix.target }}"
+          ARCHIVE="gddy-${TAG}-${{ matrix.target }}"
           mkdir dist
           cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/
           cd dist

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -17,11 +17,13 @@ permissions:
   contents: write
 
 # The publish job deletes and recreates the single rolling `alpha` release/tag.
-# Serialize runs and cancel superseded ones so two quick pushes can't race and
-# leave the prerelease half-updated; the latest push wins.
+# Serialize runs so two quick pushes can't race the single rolling `alpha`
+# release. cancel-in-progress is false on purpose: the publish job deletes and
+# recreates the release/tag, so a cancellation mid-window could leave `alpha`
+# missing. Queuing instead lets each publish finish atomically; the last one wins.
 concurrency:
   group: rust-port-alpha
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -1,0 +1,181 @@
+name: rust-port alpha
+
+# Publishes a `gddy` alpha binary on every push to the rust-port feature branch
+# so people can try the Rust port alongside the legacy `godaddy` CLI. The Rust
+# binary is named `gddy` (see rust/Cargo.toml). Output is a single rolling
+# prerelease on the fixed `alpha` tag, overwritten on each push.
+#
+# This repo is PUBLIC, so the install flow uses plain `curl` against the public
+# release assets — no `gh` or auth required (see install.sh).
+
+on:
+  push:
+    branches: [rust-port]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Install cross
+        if: matrix.cross == true
+        run: cargo install cross --locked
+
+      - name: Build
+        shell: bash
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package gddy
+        shell: bash
+        run: |
+          TARGET="${{ matrix.target }}"
+          ARCHIVE="gddy-${TARGET}"
+          mkdir -p staging
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            cp "target/${TARGET}/release/gddy.exe" "staging/gddy.exe"
+            7z a "${ARCHIVE}.zip" "./staging/gddy.exe"
+            echo "ASSET=rust/${ARCHIVE}.zip" >> "$GITHUB_ENV"
+          else
+            cp "target/${TARGET}/release/gddy" "staging/gddy"
+            chmod 755 "staging/gddy"
+            tar -czf "${ARCHIVE}.tar.gz" -C staging gddy
+            echo "ASSET=rust/${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  publish:
+    name: Publish alpha
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum gddy-*.tar.gz gddy-*.zip > gddy-checksums-sha256.txt
+
+      - name: Publish rolling alpha prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          BUILT_ON="$(date -u +%Y-%m-%d)"
+          REPO="${{ github.repository }}"
+
+          # Roll the single alpha release: drop the old tag + release so assets
+          # and notes reflect the latest commit, then recreate.
+          gh release delete alpha --yes --cleanup-tag || true
+
+          {
+            printf '**Experimental alpha of the GoDaddy CLI Rust port.** Built from `%s` on %s.\n\n' "$SHORT_SHA" "$BUILT_ON"
+            printf 'Installs as `gddy` so you can try it alongside the legacy `godaddy` CLI. It tracks the tip of the `rust-port` branch and is overwritten on every push — expect breakage.\n\n'
+            printf 'Install / update (public repo — no auth needed):\n\n'
+            printf '```\n'
+            printf 'curl -fsSL https://github.com/%s/releases/download/alpha/install.sh | bash\n' "$REPO"
+            printf '```\n'
+          } > alpha-notes.md
+
+          gh release create alpha \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "rust-port alpha (${SHORT_SHA})" \
+            --notes-file alpha-notes.md \
+            dist/gddy-x86_64-unknown-linux-gnu.tar.gz \
+            dist/gddy-aarch64-unknown-linux-gnu.tar.gz \
+            dist/gddy-x86_64-apple-darwin.tar.gz \
+            dist/gddy-aarch64-apple-darwin.tar.gz \
+            dist/gddy-x86_64-pc-windows-msvc.zip \
+            dist/gddy-checksums-sha256.txt \
+            install.sh

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -16,6 +16,13 @@ on:
 permissions:
   contents: write
 
+# The publish job deletes and recreates the single rolling `alpha` release/tag.
+# Serialize runs and cancel superseded ones so two quick pushes can't race and
+# leave the prerelease half-updated; the latest push wins.
+concurrency:
+  group: rust-port-alpha
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -119,7 +119,9 @@ jobs:
           mkdir -p staging
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             cp "target/${TARGET}/release/gddy.exe" "staging/gddy.exe"
-            7z a "${ARCHIVE}.zip" "./staging/gddy.exe"
+            # Zip from inside staging/ so gddy.exe sits at the archive root
+            # (matching the tarballs and release.yaml), not under staging/.
+            (cd staging && 7z a "../${ARCHIVE}.zip" gddy.exe)
             echo "ASSET=rust/${ARCHIVE}.zip" >> "$GITHUB_ENV"
           else
             cp "target/${TARGET}/release/gddy" "staging/gddy"

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -13,8 +13,10 @@ on:
     branches: [rust-port]
   workflow_dispatch:
 
+# Least privilege by default; only the publish job needs `contents: write` to
+# roll the `alpha` release/tag.
 permissions:
-  contents: write
+  contents: read
 
 # The publish job deletes and recreates the single rolling `alpha` release/tag.
 # Serialize runs so two quick pushes can't race the single rolling `alpha`
@@ -140,6 +142,8 @@ jobs:
     name: Publish alpha
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ curl -fsSL https://github.com/godaddy/cli/releases/download/alpha/install.sh | b
 gddy --version
 ```
 
+The installer supports macOS and Linux. On Windows, download the `gddy-x86_64-pc-windows-msvc.zip` asset from the [`alpha` release](https://github.com/godaddy/cli/releases/tag/alpha) and put `gddy.exe` on your `PATH`.
+
 ## Output Contract
 
 All executable commands emit JSON envelopes:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,18 @@ Agent-first CLI for interacting with GoDaddy Developer Platform.
 Download the latest release binary from the [releases page](https://github.com/godaddy/cli/releases) and place it on your `PATH`.
 
 ```bash
-godaddy --help
+gddy --help
+```
+
+### Alpha (Rust port preview)
+
+The CLI is being rewritten in Rust on the `rust-port` branch with expanded functionality. An experimental **`gddy`** binary is available that can be installed **alongside** the current `godaddy` CLI, so you can try it without disturbing your existing setup. 
+
+To install it, run the following:
+
+```bash
+curl -fsSL https://github.com/godaddy/cli/releases/download/alpha/install.sh | bash
+gddy --version
 ```
 
 ## Output Contract
@@ -15,11 +26,11 @@ godaddy --help
 All executable commands emit JSON envelopes:
 
 ```json
-{"ok":true,"command":"godaddy env get","result":{"environment":"ote"},"next_actions":[...]}
+{"ok":true,"command":"gddy env get","result":{"environment":"ote"},"next_actions":[...]}
 ```
 
 ```json
-{"ok":false,"command":"godaddy application info demo","error":{"message":"Application 'demo' not found","code":"NOT_FOUND"},"fix":"Use discovery commands such as: godaddy application list or godaddy actions list.","next_actions":[...]}
+{"ok":false,"command":"gddy application info demo","error":{"message":"Application 'demo' not found","code":"NOT_FOUND"},"fix":"Use discovery commands such as: gddy application list or gddy actions list.","next_actions":[...]}
 ```
 
 `--help` remains standard CLI help text.
@@ -30,7 +41,7 @@ Long-running operations can stream typed NDJSON events with `--follow`, ending w
 ## Root Discovery
 
 ```bash
-godaddy
+gddy
 ```
 
 Returns environment/auth snapshots and the full command tree.
@@ -45,54 +56,54 @@ Returns environment/auth snapshots and the full command tree.
 
 ### Environment
 
-- `godaddy env`
-- `godaddy env list`
-- `godaddy env get`
-- `godaddy env set <environment>`
-- `godaddy env info [environment]`
+- `gddy env`
+- `gddy env list`
+- `gddy env get`
+- `gddy env set <environment>`
+- `gddy env info [environment]`
 
 ### Authentication
 
-- `godaddy auth`
-- `godaddy auth login`
-- `godaddy auth logout`
-- `godaddy auth status`
+- `gddy auth`
+- `gddy auth login`
+- `gddy auth logout`
+- `gddy auth status`
 
 ### Application
 
-- `godaddy application` (alias: `godaddy app`)
-- `godaddy application list` (alias: `godaddy app ls`)
-- `godaddy application info <name>`
-- `godaddy application validate <name>`
-- `godaddy application update <name> [--label <label>] [--description <description>] [--status <status>]`
-- `godaddy application enable <name> --store-id <storeId>`
-- `godaddy application disable <name> --store-id <storeId>`
-- `godaddy application archive <name>`
-- `godaddy application init [--name <name>] [--description <description>] [--url <url>] [--proxy-url <proxyUrl>] [--scopes <scopes>] [--config <path>] [--environment <env>]`
+- `gddy application` (alias: `gddy app`)
+- `gddy application list` (alias: `gddy app ls`)
+- `gddy application info <name>`
+- `gddy application validate <name>`
+- `gddy application update <name> [--label <label>] [--description <description>] [--status <status>]`
+- `gddy application enable <name> --store-id <storeId>`
+- `gddy application disable <name> --store-id <storeId>`
+- `gddy application archive <name>`
+- `gddy application init [--name <name>] [--description <description>] [--url <url>] [--proxy-url <proxyUrl>] [--scopes <scopes>] [--config <path>] [--environment <env>]`
   - `--url` and `--proxy-url` must be publicly-resolvable `http(s)` URLs. `localhost`, loopback (`127.0.0.1`, `::1`), link-local, and RFC1918 private IPs are rejected. For local development, expose a tunnel (e.g. [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), [ngrok](https://ngrok.com/)) and register the tunnel hostname.
-- `godaddy application release <name> --release-version <version> [--description <description>] [--config <path>] [--environment <env>]`
-- `godaddy application deploy <name> [--config <path>] [--environment <env>] [--follow]`
+- `gddy application release <name> --release-version <version> [--description <description>] [--config <path>] [--environment <env>]`
+- `gddy application deploy <name> [--config <path>] [--environment <env>] [--follow]`
 
 #### Application Add
 
-- `godaddy application add`
-- `godaddy application add action --name <name> --url <url>`
-- `godaddy application add subscription --name <name> --events <events> --url <url>`
-- `godaddy application add extension`
-- `godaddy application add extension embed --name <name> --handle <handle> --source <source> --target <targets>`
-- `godaddy application add extension checkout --name <name> --handle <handle> --source <source> --target <targets>`
-- `godaddy application add extension blocks --source <source>`
+- `gddy application add`
+- `gddy application add action --name <name> --url <url>`
+- `gddy application add subscription --name <name> --events <events> --url <url>`
+- `gddy application add extension`
+- `gddy application add extension embed --name <name> --handle <handle> --source <source> --target <targets>`
+- `gddy application add extension checkout --name <name> --handle <handle> --source <source> --target <targets>`
+- `gddy application add extension blocks --source <source>`
 
 ### Webhooks
 
-- `godaddy webhook`
-- `godaddy webhook events`
+- `gddy webhook`
+- `gddy webhook events`
 
 ### Actions
 
-- `godaddy actions`
-- `godaddy actions list`
-- `godaddy actions describe <action>`
+- `gddy actions`
+- `gddy actions list`
+- `gddy actions describe <action>`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gddy --help
 
 ### Alpha (Rust port preview)
 
-The CLI is being rewritten in Rust on the `rust-port` branch with expanded functionality. An experimental **`gddy`** binary is available that can be installed **alongside** the current `godaddy` CLI, so you can try it without disturbing your existing setup. 
+The CLI is being rewritten in Rust on the `rust-port` branch with expanded functionality. An experimental **`gddy`** binary is available that can be installed **alongside** the current `godaddy` CLI, so you can try it without disturbing your existing setup.
 
 To install it, run the following:
 

--- a/install.sh
+++ b/install.sh
@@ -61,8 +61,9 @@ info()  { printf "\033[1;34m==>\033[0m %s\n" "$1"; }
 warn()  { printf "\033[1;33mWARN:\033[0m %s\n" "$1"; }
 error() { printf "\033[1;31mERROR:\033[0m %s\n" "$1" >&2; exit 1; }
 
-command -v curl >/dev/null 2>&1 || error "curl is required but not found."
-command -v tar  >/dev/null 2>&1 || error "tar is required but not found."
+command -v curl    >/dev/null 2>&1 || error "curl is required but not found."
+command -v tar     >/dev/null 2>&1 || error "tar is required but not found."
+command -v install >/dev/null 2>&1 || error "install (coreutils) is required but not found."
 
 # Detect SHA-256 tool.
 if command -v sha256sum >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,9 @@ EOF
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --prefix)   PREFIX="$2"; shift 2 ;;
+    --prefix)
+      if [ $# -lt 2 ]; then echo "Error: --prefix requires a directory argument." >&2; exit 1; fi
+      PREFIX="$2"; shift 2 ;;
     --help|-h)  usage ;;
     *)          echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -113,7 +115,9 @@ curl -fsSL "${BASE_URL}/${CHECKSUMS}" -o "${TMPDIR}/${CHECKSUMS}" \
   || error "Failed to download ${CHECKSUMS}."
 
 info "Verifying checksum..."
-EXPECTED="$(grep "${ARCHIVE}" "${TMPDIR}/${CHECKSUMS}" | awk '{print $1}')"
+# Exact filename match ($2 is the path field from sha256sum/shasum output) so a
+# regex-special character or a substring of another asset name can't mislead us.
+EXPECTED="$(awk -v f="$ARCHIVE" '$2 == f {print $1}' "${TMPDIR}/${CHECKSUMS}")"
 if [ -z "$EXPECTED" ]; then
   error "Checksum for ${ARCHIVE} not found in ${CHECKSUMS}."
 fi
@@ -147,6 +151,12 @@ if [ ! -w "$PREFIX" ]; then
       SUDO="sudo"
     fi
   fi
+fi
+
+# If elevation is required, make sure sudo actually exists before relying on it,
+# so locked-down/minimal hosts get an actionable message instead of "command not found".
+if [ -n "$SUDO" ] && ! command -v sudo >/dev/null 2>&1; then
+  error "Installing to ${PREFIX} requires elevated permissions, but 'sudo' was not found. Re-run with --prefix pointing to a writable directory, e.g. --prefix \"\$HOME/.local/bin\"."
 fi
 
 if [ -n "$SUDO" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# gddy installer — downloads, verifies, and installs the GoDaddy CLI Rust-port
+# ALPHA binary (`gddy`) from the rolling `alpha` GitHub prerelease.
+#
+# `gddy` installs alongside the legacy `godaddy` CLI so you can run both. It is
+# an experimental build that tracks the tip of `rust-port`; expect compatibility
+# breakage.
+#
+# Usage:
+#   curl -fsSL https://github.com/godaddy/cli/releases/download/alpha/install.sh | bash
+#
+# Options (when run as a file, e.g. `bash install.sh --prefix ~/.local/bin`):
+#   --prefix  DIR       Install directory (default: /usr/local/bin)
+#   --help              Show this help message
+
+set -euo pipefail
+
+REPO="godaddy/cli"
+TAG="alpha"
+PREFIX="/usr/local/bin"
+
+# ── 1. Arg parsing ──────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'EOF'
+gddy installer (Rust-port alpha)
+
+Usage:
+  bash install.sh [OPTIONS]
+
+Options:
+  --prefix  DIR       Binary install directory (default: /usr/local/bin)
+  --help              Show this help message
+
+Examples:
+  bash install.sh                       # latest alpha to /usr/local/bin
+  bash install.sh --prefix ~/.local/bin # custom prefix (no sudo for binaries)
+
+Prerequisites:
+  - curl
+  - tar
+EOF
+  exit 0
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix)   PREFIX="$2"; shift 2 ;;
+    --help|-h)  usage ;;
+    *)          echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── 2. Preflight ────────────────────────────────────────────────────────────
+
+info()  { printf "\033[1;34m==>\033[0m %s\n" "$1"; }
+warn()  { printf "\033[1;33mWARN:\033[0m %s\n" "$1"; }
+error() { printf "\033[1;31mERROR:\033[0m %s\n" "$1" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || error "curl is required but not found."
+command -v tar  >/dev/null 2>&1 || error "tar is required but not found."
+
+# Detect SHA-256 tool.
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256_CMD="shasum -a 256"
+else
+  error "Neither sha256sum nor shasum found — cannot verify checksums."
+fi
+
+# ── 3. Detect platform ─────────────────────────────────────────────────────
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  darwin) ;;
+  linux)  ;;
+  *)      error "Unsupported OS: $OS. gddy supports darwin and linux." ;;
+esac
+
+case "$ARCH" in
+  x86_64)  ARCH="x86_64" ;;
+  aarch64) ARCH="aarch64" ;;
+  arm64)   ARCH="aarch64" ;;  # macOS Apple Silicon
+  *)       error "Unsupported architecture: $ARCH" ;;
+esac
+
+# Map OS+arch to the Rust target triple used in release archive names.
+case "${OS}-${ARCH}" in
+  darwin-x86_64)  PLATFORM="x86_64-apple-darwin" ;;
+  darwin-aarch64) PLATFORM="aarch64-apple-darwin" ;;
+  linux-x86_64)   PLATFORM="x86_64-unknown-linux-gnu" ;;
+  linux-aarch64)  PLATFORM="aarch64-unknown-linux-gnu" ;;
+  *)              error "Unsupported platform: ${OS}-${ARCH}" ;;
+esac
+info "Detected platform: ${PLATFORM}"
+info "Installing gddy alpha (${TAG})"
+
+# ── 4. Download + verify ───────────────────────────────────────────────────
+
+ARCHIVE="gddy-${PLATFORM}.tar.gz"
+CHECKSUMS="gddy-checksums-sha256.txt"
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "Downloading ${ARCHIVE} and checksums..."
+curl -fsSL "${BASE_URL}/${ARCHIVE}"   -o "${TMPDIR}/${ARCHIVE}" \
+  || error "Failed to download ${ARCHIVE}. Has the ${TAG} release been published yet?"
+curl -fsSL "${BASE_URL}/${CHECKSUMS}" -o "${TMPDIR}/${CHECKSUMS}" \
+  || error "Failed to download ${CHECKSUMS}."
+
+info "Verifying checksum..."
+EXPECTED="$(grep "${ARCHIVE}" "${TMPDIR}/${CHECKSUMS}" | awk '{print $1}')"
+if [ -z "$EXPECTED" ]; then
+  error "Checksum for ${ARCHIVE} not found in ${CHECKSUMS}."
+fi
+
+ACTUAL="$($SHA256_CMD "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  error "Checksum mismatch!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"
+fi
+info "Checksum verified."
+
+# ── 5. Extract + install ───────────────────────────────────────────────────
+
+EXTRACT_DIR="${TMPDIR}/extract"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$EXTRACT_DIR"
+
+if [ ! -f "${EXTRACT_DIR}/gddy" ]; then
+  error "Unexpected archive layout — expected a 'gddy' binary at the archive root."
+fi
+
+# Determine if we need sudo for the prefix directory.
+SUDO=""
+if [ ! -w "$PREFIX" ]; then
+  if [ -d "$PREFIX" ]; then
+    info "Write permission required for ${PREFIX} — will use sudo."
+    SUDO="sudo"
+  else
+    # Try to create the directory; if that fails, use sudo.
+    if ! mkdir -p "$PREFIX" 2>/dev/null; then
+      info "Cannot create ${PREFIX} — will use sudo."
+      SUDO="sudo"
+    fi
+  fi
+fi
+
+if [ -n "$SUDO" ]; then
+  $SUDO mkdir -p "$PREFIX"
+fi
+
+$SUDO install -m 755 "${EXTRACT_DIR}/gddy" "${PREFIX}/gddy"
+info "Binary installed to ${PREFIX}/gddy"
+
+# ── 6. Success ──────────────────────────────────────────────────────────────
+
+echo ""
+info "gddy alpha (${TAG}) installed successfully!"
+echo ""
+echo "  Binary:    ${PREFIX}/gddy"
+echo "  Verify:    gddy --version"
+echo ""
+echo "  Note: this is an experimental Rust-port alpha that installs alongside"
+echo "  the current 'godaddy' CLI."
+echo ""
+if ! printf '%s' ":$PATH:" | grep -q ":${PREFIX}:"; then
+  warn "${PREFIX} is not on your PATH — add it to use 'gddy' directly."
+fi
+echo "Share this one-liner with your team:"
+echo ""
+echo "  curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/install.sh | bash"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,8 @@ Examples:
 Prerequisites:
   - curl
   - tar
+  - sha256sum (coreutils) or shasum
+  - install (coreutils)
 EOF
   exit 0
 }
@@ -124,7 +126,9 @@ fi
 
 ACTUAL="$($SHA256_CMD "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
 if [ "$EXPECTED" != "$ACTUAL" ]; then
-  error "Checksum mismatch!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"
+  error "Checksum mismatch!
+  Expected: ${EXPECTED}
+  Got:      ${ACTUAL}"
 fi
 info "Checksum verified."
 
@@ -177,7 +181,7 @@ echo ""
 echo "  Note: this is an experimental Rust-port alpha that installs alongside"
 echo "  the current 'godaddy' CLI."
 echo ""
-if ! printf '%s' ":$PATH:" | grep -q ":${PREFIX}:"; then
+if ! printf '%s' ":$PATH:" | grep -qF ":${PREFIX}:"; then
   warn "${PREFIX} is not on your PATH — add it to use 'gddy' directly."
 fi
 echo "Share this one-liner with your team:"

--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,9 @@ info "Installing gddy alpha (${TAG})"
 ARCHIVE="gddy-${PLATFORM}.tar.gz"
 CHECKSUMS="gddy-checksums-sha256.txt"
 BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-TMPDIR="$(mktemp -d)"
+# GNU mktemp accepts a bare `-d`; BSD/macOS mktemp needs a template, so fall
+# back to `-t` for portability across both.
+TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t gddy)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 info "Downloading ${ARCHIVE} and checksums..."

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ license = "Proprietary"
 members = [".", "tools/generate-api-catalog"]
 
 [[bin]]
-name = "godaddy"
+name = "gddy"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -94,7 +94,7 @@ pub fn module() -> Module {
                     .to_owned();
                 let schema = load_action_schema(&name).ok_or_else(|| {
                     cli_engine::CliCoreError::message(format!(
-                        "action {name:?} not found; run `godaddy actions list` to see available actions"
+                        "action {name:?} not found; run `gddy actions list` to see available actions"
                     ))
                 })?;
                 Ok(CommandResult::new(schema))

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -540,7 +540,7 @@ fn call_command() -> RuntimeCommandSpec {
 
             if status == 403 && !scopes.is_empty() {
                 return Err(cli_engine::CliCoreError::message(format!(
-                    "403 Forbidden — your token may be missing scope(s): {}\nRun `godaddy auth login` to re-authenticate.",
+                    "403 Forbidden — your token may be missing scope(s): {}\nRun `gddy auth login` to re-authenticate.",
                     scopes.join(", ")
                 )));
             }

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -627,7 +627,7 @@ fn deploy_command() -> RuntimeCommandSpec {
                 .map(str::to_owned);
             let Some(release_id) = release_id else {
                 return Err(cli_engine::CliCoreError::message(format!(
-                    "application '{name}' has no releases — create one first with: godaddy application release --application-id {application_id} --version 0.0.1"
+                    "application '{name}' has no releases — create one first with: gddy application release --application-id {application_id} --version 0.0.1"
                 )));
             };
             sender

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -32,7 +32,7 @@ impl GoDaddyAuthProvider {
             OTE_CLIENT_ID,
             SCOPES,
         )
-        .with_app_id("godaddy")
+        .with_app_id("gddy")
         .with_redirect_uri("http://localhost:7443/callback");
 
         let prod = PkceAuthProvider::new(
@@ -42,7 +42,7 @@ impl GoDaddyAuthProvider {
             PROD_CLIENT_ID,
             SCOPES,
         )
-        .with_app_id("godaddy")
+        .with_app_id("gddy")
         .with_redirect_uri("http://localhost:7443/callback");
 
         Self { ote, prod }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> ExitCode {
     let auth_provider = Arc::new(auth::GoDaddyAuthProvider::new());
 
     let cli = Cli::new(
-        CliConfig::new("godaddy", "GoDaddy developer CLI", "godaddy")
+        CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
             .with_build(BuildInfo::new(env!("CARGO_PKG_VERSION")))
             .with_default_auth_provider("godaddy")
             .with_auth_provider(auth_provider)


### PR DESCRIPTION
## What

Stands up an **alpha distribution pipeline** for the Rust port and renames the binary from `godaddy` to **`gddy`** so it installs alongside the legacy `godaddy` CLI.

Targets `rust-port` (not `main`) so it ships with the port rather than sweeping it into the stable release.

## Changes

- **`.github/workflows/rust-port-alpha.yaml`** (new) — on every push to `rust-port`: test → build 5 targets (GitHub-hosted runners; `cross` for aarch64-linux) → publish a single rolling **`alpha`** prerelease (delete+recreate) with archives, `gddy-checksums-sha256.txt`, and `install.sh`.
- **`install.sh`** (new) — curl-based installer (public repo, so no `gh`/auth), verifies the SHA-256 checksum and installs `gddy`. One-liner: `curl -fsSL https://github.com/godaddy/cli/releases/download/alpha/install.sh | bash`.
- **Binary rename → `gddy`**: `rust/Cargo.toml` `[[bin]]`, `CliConfig` name + `app_id`, and the PKCE credential namespace (`auth.rs` `with_app_id`). User-facing "run `godaddy …`" hint strings and README command examples updated to `gddy`.
- **`release.yaml`** — artifact/archive names `godaddy` → `gddy` (the renamed binary).

## Deliberately unchanged

- The `godaddy.toml` **application manifest** filename (renaming it would break existing app dirs).
- The internal auth-provider identity (`with_default_auth_provider` ↔ provider `name()`).
- `GoDaddy` / `godaddy.com` branding and `godaddy/cli` URLs.

## Verification

- `cargo build` / `cargo clippy -- -D warnings` / `cargo test` (114 passing) on the rebased base (cli-engine 0.1.3).
- `gddy --version` → `gddy version 0.1.0`; `Usage: gddy [OPTIONS] [COMMAND]`.
- `actionlint` clean on both workflows; `bash -n install.sh` clean.

> Note: the `alpha` release one-liner 404s until the first post-merge run of the new workflow publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)