### PR TITLE
feat: default to prod, fix cross-platform config writes, support Windows installs

### DIFF
--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -193,4 +193,5 @@ jobs:
             dist/gddy-aarch64-apple-darwin.tar.gz \
             dist/gddy-x86_64-pc-windows-msvc.zip \
             dist/gddy-checksums-sha256.txt \
-            install.sh
+            install.sh \
+            install.ps1

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -177,8 +177,13 @@ jobs:
             printf '**Experimental alpha of the GoDaddy CLI Rust port.** Built from `%s` on %s.\n\n' "$SHORT_SHA" "$BUILT_ON"
             printf 'Installs as `gddy` so you can try it alongside the legacy `godaddy` CLI. It tracks the tip of the `rust-port` branch and is overwritten on every push — expect breakage.\n\n'
             printf 'Install / update (public repo — no auth needed):\n\n'
+            printf 'macOS / Linux (and Git Bash / MSYS2 / Cygwin on Windows):\n\n'
             printf '```\n'
             printf 'curl -fsSL https://github.com/%s/releases/download/alpha/install.sh | bash\n' "$REPO"
+            printf '```\n\n'
+            printf 'Windows (PowerShell):\n\n'
+            printf '```\n'
+            printf 'irm https://github.com/%s/releases/download/alpha/install.ps1 | iex\n' "$REPO"
             printf '```\n'
           } > alpha-notes.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ docs/
 .DS_Store
 .vscode/settings.json
 **/.claude/settings.local.json
+
+# Claude Code local runtime state (per-machine, not for commit)
+**/.claude/scheduled_tasks.lock
+**/.claude/scheduled_tasks.json

--- a/README.md
+++ b/README.md
@@ -14,14 +14,25 @@ gddy --help
 
 The CLI is being rewritten in Rust on the `rust-port` branch with expanded functionality. An experimental **`gddy`** binary is available that can be installed **alongside** the current `godaddy` CLI, so you can try it without disturbing your existing setup.
 
-To install it, run the following:
+To install it, run the following.
+
+**macOS / Linux (and Git Bash / MSYS2 / Cygwin on Windows):**
 
 ```bash
 curl -fsSL https://github.com/godaddy/cli/releases/download/alpha/install.sh | bash
 gddy --version
 ```
 
-The installer supports macOS and Linux. On Windows, download the `gddy-x86_64-pc-windows-msvc.zip` asset from the [`alpha` release](https://github.com/godaddy/cli/releases/tag/alpha) and put `gddy.exe` on your `PATH`.
+**Windows (PowerShell):**
+
+```powershell
+irm https://github.com/godaddy/cli/releases/download/alpha/install.ps1 | iex
+gddy --version
+```
+
+Both installers download, checksum-verify, and install the binary for your
+platform (`gddy.exe` on Windows). If you'd rather install by hand, download the
+`gddy-x86_64-pc-windows-msvc.zip` asset from the [`alpha` release](https://github.com/godaddy/cli/releases/tag/alpha) and put `gddy.exe` on your `PATH`.
 
 ## Output Contract
 

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$Prefix = (Join-Path $env:LOCALAPPDATA 'Programs\gddy')
+    [string]$Prefix
 )
 
 Set-StrictMode -Version Latest
@@ -36,6 +36,16 @@ function Write-Warn  { param([string]$Message) Write-Host "WARN: $Message" -Fore
 # Use `throw`, not `exit`: the documented invocation is `irm ... | iex`, which
 # runs this script in the caller's session — `exit` would close their terminal.
 function Die         { param([string]$Message) Write-Host "ERROR: $Message" -ForegroundColor Red; throw $Message }
+
+# Resolve the default install dir here (not in the param default) so a missing
+# LOCALAPPDATA can fall back / error cleanly instead of throwing in Join-Path
+# before Die is available.
+if (-not $Prefix) {
+    $base = if ($env:LOCALAPPDATA)   { $env:LOCALAPPDATA }
+            elseif ($env:USERPROFILE) { $env:USERPROFILE }
+            else { Die "Cannot determine a default install directory (LOCALAPPDATA and USERPROFILE are both unset). Re-run with -Prefix <dir>." }
+    $Prefix = Join-Path $base 'Programs\gddy'
+}
 
 # Force TLS 1.2 for older PowerShell / .NET defaults.
 try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocol]::Tls12 } catch { }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    gddy installer (Rust-port alpha) for Windows / PowerShell.
+
+.DESCRIPTION
+    Downloads, verifies, and installs the GoDaddy CLI Rust-port ALPHA binary
+    (gddy.exe) from the rolling `alpha` GitHub prerelease.
+
+    `gddy` installs alongside the legacy `godaddy` CLI so you can run both. It is
+    an experimental build that tracks the tip of `rust-port`; expect breakage.
+
+    macOS/Linux (and Git Bash/MSYS2/Cygwin) users should use install.sh instead.
+
+.PARAMETER Prefix
+    Install directory. Defaults to "$env:LOCALAPPDATA\Programs\gddy".
+
+.EXAMPLE
+    irm https://github.com/godaddy/cli/releases/download/alpha/install.ps1 | iex
+
+.EXAMPLE
+    .\install.ps1 -Prefix "C:\tools\gddy"
+#>
+[CmdletBinding()]
+param(
+    [string]$Prefix = (Join-Path $env:LOCALAPPDATA 'Programs\gddy')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'godaddy/cli'
+$Tag  = 'alpha'
+
+function Write-Info  { param([string]$Message) Write-Host "==> $Message" -ForegroundColor Blue }
+function Write-Warn  { param([string]$Message) Write-Host "WARN: $Message" -ForegroundColor Yellow }
+function Die         { param([string]$Message) Write-Host "ERROR: $Message" -ForegroundColor Red; exit 1 }
+
+# Force TLS 1.2 for older PowerShell / .NET defaults.
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocol]::Tls12 } catch { }
+
+# ── 1. Detect platform ───────────────────────────────────────────────────────
+
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+switch ($arch) {
+    'x64'   { $platform = 'x86_64-pc-windows-msvc' }
+    default {
+        Die ("Unsupported architecture '$arch'. Only x86_64-pc-windows-msvc is published today. " +
+             "Download the matching asset manually from https://github.com/$Repo/releases/tag/$Tag")
+    }
+}
+
+$bin       = 'gddy.exe'
+$archive   = "gddy-$platform.zip"
+$checksums = 'gddy-checksums-sha256.txt'
+$baseUrl   = "https://github.com/$Repo/releases/download/$Tag"
+
+Write-Info "Detected platform: $platform"
+Write-Info "Installing gddy alpha ($Tag)"
+
+# ── 2. Download + verify ─────────────────────────────────────────────────────
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("gddy-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+try {
+    $archivePath   = Join-Path $work $archive
+    $checksumsPath = Join-Path $work $checksums
+
+    Write-Info "Downloading $archive and checksums..."
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$archive"   -OutFile $archivePath   -UseBasicParsing
+    } catch {
+        Die "Failed to download $archive. Has the $Tag release been published yet?"
+    }
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$checksums" -OutFile $checksumsPath -UseBasicParsing
+    } catch {
+        Die "Failed to download $checksums."
+    }
+
+    Write-Info "Verifying checksum..."
+    # Each line is "<sha256>  <filename>"; match the filename exactly.
+    $expected = $null
+    foreach ($line in Get-Content $checksumsPath) {
+        $parts = $line -split '\s+', 2
+        if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $archive) {
+            $expected = $parts[0].Trim().ToLower()
+            break
+        }
+    }
+    if (-not $expected) { Die "Checksum for $archive not found in $checksums." }
+
+    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLower()
+    if ($expected -ne $actual) {
+        Die "Checksum mismatch!`n  Expected: $expected`n  Got:      $actual"
+    }
+    Write-Info "Checksum verified."
+
+    # ── 3. Extract + install ─────────────────────────────────────────────────
+
+    $extractDir = Join-Path $work 'extract'
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+
+    $extractedBin = Join-Path $extractDir $bin
+    if (-not (Test-Path -LiteralPath $extractedBin)) {
+        Die "Unexpected archive layout — expected a '$bin' binary at the archive root."
+    }
+
+    New-Item -ItemType Directory -Path $Prefix -Force | Out-Null
+    $destBin = Join-Path $Prefix $bin
+    Copy-Item -LiteralPath $extractedBin -Destination $destBin -Force
+    Write-Info "Binary installed to $destBin"
+
+    # ── 4. PATH ──────────────────────────────────────────────────────────────
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $onPath = ($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $Prefix.TrimEnd('\') }).Count -gt 0
+    if (-not $onPath) {
+        $newPath = if ([string]::IsNullOrEmpty($userPath)) { $Prefix } else { "$userPath;$Prefix" }
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        $env:Path = "$env:Path;$Prefix"  # current session
+        Write-Info "Added $Prefix to your user PATH (restart your shell for new shells to see it)."
+    }
+} finally {
+    Remove-Item -Recurse -Force -LiteralPath $work -ErrorAction SilentlyContinue
+}
+
+# ── 5. Success ────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Info "gddy alpha ($Tag) installed successfully!"
+Write-Host ""
+Write-Host "  Binary:    $(Join-Path $Prefix $bin)"
+Write-Host "  Verify:    gddy --version"
+Write-Host ""
+Write-Host "  Note: this is an experimental Rust-port alpha that installs alongside"
+Write-Host "  the current 'godaddy' CLI."
+Write-Host ""
+Write-Host "Share this one-liner with your team:"
+Write-Host ""
+Write-Host "  irm https://github.com/$Repo/releases/download/$Tag/install.ps1 | iex"
+Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -33,7 +33,9 @@ $Tag  = 'alpha'
 
 function Write-Info  { param([string]$Message) Write-Host "==> $Message" -ForegroundColor Blue }
 function Write-Warn  { param([string]$Message) Write-Host "WARN: $Message" -ForegroundColor Yellow }
-function Die         { param([string]$Message) Write-Host "ERROR: $Message" -ForegroundColor Red; exit 1 }
+# Use `throw`, not `exit`: the documented invocation is `irm ... | iex`, which
+# runs this script in the caller's session — `exit` would close their terminal.
+function Die         { param([string]$Message) Write-Host "ERROR: $Message" -ForegroundColor Red; throw $Message }
 
 # Force TLS 1.2 for older PowerShell / .NET defaults.
 try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocol]::Tls12 } catch { }

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 REPO="godaddy/cli"
 TAG="alpha"
 PREFIX="/usr/local/bin"
+PREFIX_EXPLICIT=0  # set when the user passes --prefix; gates the Windows default
 
 # ── 1. Arg parsing ──────────────────────────────────────────────────────────
 
@@ -45,8 +46,9 @@ Prerequisites:
 
 Windows:
   This script also runs under Git Bash / MSYS2 / Cygwin: it fetches the
-  x86_64-pc-windows-msvc .zip and installs gddy.exe. For a native PowerShell
-  install instead, use install.ps1.
+  x86_64-pc-windows-msvc .zip and installs gddy.exe. On Windows the default
+  prefix is %LOCALAPPDATA%\Programs\gddy (user-writable, no sudo) unless you
+  pass --prefix. For a native PowerShell install instead, use install.ps1.
 EOF
   exit 0
 }
@@ -55,7 +57,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --prefix)
       if [ $# -lt 2 ]; then echo "Error: --prefix requires a directory argument." >&2; exit 1; fi
-      PREFIX="$2"; shift 2 ;;
+      PREFIX="$2"; PREFIX_EXPLICIT=1; shift 2 ;;
     --help|-h)  usage ;;
     *)          echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -116,6 +118,17 @@ esac
 if [ "$OS" = "windows" ]; then
   BIN="gddy.exe"
   ARCHIVE_EXT="zip"
+  # /usr/local/bin is a poor default on Windows shells: there's usually no sudo
+  # and it often isn't user-writable (Git for Windows lives under Program Files).
+  # Default to a user-writable dir matching install.ps1 unless --prefix was given.
+  if [ "$PREFIX_EXPLICIT" = "0" ]; then
+    if [ -n "${LOCALAPPDATA:-}" ]; then
+      lad="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null || printf '%s' "$LOCALAPPDATA")"
+      PREFIX="${lad}/Programs/gddy"
+    else
+      PREFIX="${HOME}/bin"
+    fi
+  fi
 else
   BIN="gddy"
   ARCHIVE_EXT="tar.gz"

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,9 @@ Usage:
   bash install.sh [OPTIONS]
 
 Options:
-  --prefix  DIR       Binary install directory (default: /usr/local/bin)
+  --prefix  DIR       Binary install directory
+                      (default: /usr/local/bin on macOS/Linux;
+                       %LOCALAPPDATA%\Programs\gddy on Windows)
   --help              Show this help message
 
 Examples:

--- a/install.sh
+++ b/install.sh
@@ -169,8 +169,12 @@ if [ "$OS" = "windows" ]; then
   elif command -v powershell.exe >/dev/null 2>&1; then
     win_src="$(cygpath -w "${TMPDIR}/${ARCHIVE}" 2>/dev/null || printf '%s' "${TMPDIR}/${ARCHIVE}")"
     win_dst="$(cygpath -w "${EXTRACT_DIR}" 2>/dev/null || printf '%s' "${EXTRACT_DIR}")"
+    # Escape ' as '' so a path containing an apostrophe (legal in Windows
+    # usernames/paths) can't terminate the PowerShell single-quoted literal.
+    ps_src="${win_src//\'/\'\'}"
+    ps_dst="${win_dst//\'/\'\'}"
     powershell.exe -NoProfile -NonInteractive -Command \
-      "Expand-Archive -LiteralPath '${win_src}' -DestinationPath '${win_dst}' -Force" \
+      "Expand-Archive -LiteralPath '${ps_src}' -DestinationPath '${ps_dst}' -Force" \
       || error "Failed to extract ${ARCHIVE} with PowerShell Expand-Archive."
   else
     error "Need 'unzip' or 'powershell.exe' to extract ${ARCHIVE} on Windows, but neither was found."

--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,7 @@ if [ "$OS" = "windows" ]; then
     error "Need 'unzip' or 'powershell.exe' to extract ${ARCHIVE} on Windows, but neither was found."
   fi
 else
+  command -v tar >/dev/null 2>&1 || error "tar is required to extract ${ARCHIVE} but was not found."
   tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$EXTRACT_DIR"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,15 @@ Examples:
 
 Prerequisites:
   - curl
-  - tar
+  - tar                       (macOS/Linux archives)
+  - unzip or powershell.exe   (Windows .zip, e.g. under Git Bash/MSYS)
   - sha256sum (coreutils) or shasum
   - install (coreutils)
+
+Windows:
+  This script also runs under Git Bash / MSYS2 / Cygwin: it fetches the
+  x86_64-pc-windows-msvc .zip and installs gddy.exe. For a native PowerShell
+  install instead, use install.ps1.
 EOF
   exit 0
 }
@@ -62,8 +68,9 @@ warn()  { printf "\033[1;33mWARN:\033[0m %s\n" "$1"; }
 error() { printf "\033[1;31mERROR:\033[0m %s\n" "$1" >&2; exit 1; }
 
 command -v curl    >/dev/null 2>&1 || error "curl is required but not found."
-command -v tar     >/dev/null 2>&1 || error "tar is required but not found."
 command -v install >/dev/null 2>&1 || error "install (coreutils) is required but not found."
+# The extraction tool (tar vs unzip/powershell) is OS-specific and checked after
+# platform detection below.
 
 # Detect SHA-256 tool.
 if command -v sha256sum >/dev/null 2>&1; then
@@ -82,7 +89,10 @@ ARCH="$(uname -m)"
 case "$OS" in
   darwin) ;;
   linux)  ;;
-  *)      error "Unsupported OS: $OS. gddy supports darwin and linux." ;;
+  # Git Bash, MSYS2, and Cygwin report e.g. "mingw64_nt-10.0-26200"; normalize
+  # them all to "windows" and install the native gddy.exe from the .zip asset.
+  mingw*|msys*|cygwin*|windows*) OS="windows" ;;
+  *)      error "Unsupported OS: $OS. gddy supports darwin, linux, and windows (Git Bash/MSYS2/Cygwin)." ;;
 esac
 
 case "$ARCH" in
@@ -98,14 +108,25 @@ case "${OS}-${ARCH}" in
   darwin-aarch64) PLATFORM="aarch64-apple-darwin" ;;
   linux-x86_64)   PLATFORM="x86_64-unknown-linux-gnu" ;;
   linux-aarch64)  PLATFORM="aarch64-unknown-linux-gnu" ;;
+  windows-x86_64) PLATFORM="x86_64-pc-windows-msvc" ;;
   *)              error "Unsupported platform: ${OS}-${ARCH}" ;;
 esac
+
+# Windows ships a .zip with gddy.exe; the unix targets ship a .tar.gz with gddy.
+if [ "$OS" = "windows" ]; then
+  BIN="gddy.exe"
+  ARCHIVE_EXT="zip"
+else
+  BIN="gddy"
+  ARCHIVE_EXT="tar.gz"
+fi
+
 info "Detected platform: ${PLATFORM}"
 info "Installing gddy alpha (${TAG})"
 
 # ── 4. Download + verify ───────────────────────────────────────────────────
 
-ARCHIVE="gddy-${PLATFORM}.tar.gz"
+ARCHIVE="gddy-${PLATFORM}.${ARCHIVE_EXT}"
 CHECKSUMS="gddy-checksums-sha256.txt"
 BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 # GNU mktemp accepts a bare `-d`; BSD/macOS mktemp needs a template, so fall
@@ -139,10 +160,27 @@ info "Checksum verified."
 
 EXTRACT_DIR="${TMPDIR}/extract"
 mkdir -p "$EXTRACT_DIR"
-tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$EXTRACT_DIR"
+if [ "$OS" = "windows" ]; then
+  # Prefer unzip; fall back to PowerShell's Expand-Archive (always present on
+  # Windows). cygpath converts the MSYS/Cygwin paths to the Windows form that
+  # powershell.exe expects.
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q "${TMPDIR}/${ARCHIVE}" -d "$EXTRACT_DIR"
+  elif command -v powershell.exe >/dev/null 2>&1; then
+    win_src="$(cygpath -w "${TMPDIR}/${ARCHIVE}" 2>/dev/null || printf '%s' "${TMPDIR}/${ARCHIVE}")"
+    win_dst="$(cygpath -w "${EXTRACT_DIR}" 2>/dev/null || printf '%s' "${EXTRACT_DIR}")"
+    powershell.exe -NoProfile -NonInteractive -Command \
+      "Expand-Archive -LiteralPath '${win_src}' -DestinationPath '${win_dst}' -Force" \
+      || error "Failed to extract ${ARCHIVE} with PowerShell Expand-Archive."
+  else
+    error "Need 'unzip' or 'powershell.exe' to extract ${ARCHIVE} on Windows, but neither was found."
+  fi
+else
+  tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$EXTRACT_DIR"
+fi
 
-if [ ! -f "${EXTRACT_DIR}/gddy" ]; then
-  error "Unexpected archive layout — expected a 'gddy' binary at the archive root."
+if [ ! -f "${EXTRACT_DIR}/${BIN}" ]; then
+  error "Unexpected archive layout — expected a '${BIN}' binary at the archive root."
 fi
 
 # Determine if we need sudo for the prefix directory.
@@ -170,15 +208,15 @@ if [ -n "$SUDO" ]; then
   $SUDO mkdir -p "$PREFIX"
 fi
 
-$SUDO install -m 755 "${EXTRACT_DIR}/gddy" "${PREFIX}/gddy"
-info "Binary installed to ${PREFIX}/gddy"
+$SUDO install -m 755 "${EXTRACT_DIR}/${BIN}" "${PREFIX}/${BIN}"
+info "Binary installed to ${PREFIX}/${BIN}"
 
 # ── 6. Success ──────────────────────────────────────────────────────────────
 
 echo ""
 info "gddy alpha (${TAG}) installed successfully!"
 echo ""
-echo "  Binary:    ${PREFIX}/gddy"
+echo "  Binary:    ${PREFIX}/${BIN}"
 echo "  Verify:    gddy --version"
 echo ""
 echo "  Note: this is an experimental Rust-port alpha that installs alongside"

--- a/install.sh
+++ b/install.sh
@@ -125,8 +125,10 @@ if [ "$OS" = "windows" ]; then
     if [ -n "${LOCALAPPDATA:-}" ]; then
       lad="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null || printf '%s' "$LOCALAPPDATA")"
       PREFIX="${lad}/Programs/gddy"
-    else
+    elif [ -n "${HOME:-}" ]; then
       PREFIX="${HOME}/bin"
+    else
+      error "Cannot determine a default install directory (LOCALAPPDATA and HOME are unset). Re-run with --prefix <dir>."
     fi
   fi
 else

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -690,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,13 +709,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1021,6 +1042,7 @@ dependencies = [
  "chrono",
  "clap",
  "cli-engine",
+ "dirs",
  "fancy-regex",
  "httpmock",
  "regex",
@@ -1268,7 +1290,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1809,6 +1831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2020,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2029,7 +2057,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2132,6 +2160,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
 cli-engine = { features = ["pkce-auth"], version = "0.1.3" }
+dirs = "6"
 fancy-regex = "0.14"
 regex = { version = "1", features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -6,27 +6,40 @@ use serde_json::json;
 const OTE_API_URL: &str = "https://api.ote-godaddy.com";
 const PROD_API_URL: &str = "https://api.godaddy.com";
 const KNOWN_ENVS: &[&str] = &["ote", "prod"];
+pub const DEFAULT_ENV: &str = "prod";
 
-fn gdenv_path() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    std::path::PathBuf::from(home).join(".gdenv")
+/// Resolve the path to the `.gdenv` state file in the user's home directory.
+///
+/// Uses `dirs::home_dir()` for cross-platform resolution (`$HOME` on Unix,
+/// `%USERPROFILE%`/known folders on Windows) rather than reading `$HOME`
+/// directly, which is unset on Windows.
+fn gdenv_path() -> std::io::Result<std::path::PathBuf> {
+    dirs::home_dir()
+        .map(|home| home.join(".gdenv"))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "could not determine home directory",
+            )
+        })
 }
 
 pub fn get_env() -> Option<String> {
-    std::fs::read_to_string(gdenv_path())
+    gdenv_path()
         .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty())
 }
 
 pub fn set_env(env: &str) -> std::io::Result<()> {
-    std::fs::write(gdenv_path(), env)
+    std::fs::write(gdenv_path()?, env)
 }
 
 fn api_url_for(env: &str) -> &'static str {
     match env {
-        "prod" => PROD_API_URL,
-        _ => OTE_API_URL,
+        "ote" => OTE_API_URL,
+        _ => PROD_API_URL,
     }
 }
 
@@ -38,7 +51,7 @@ pub fn module() -> Module {
                     .with_system("env")
                     .with_tier(Tier::Read),
                 |_cred, _args| async move {
-                    let current = get_env().unwrap_or_else(|| "ote".to_owned());
+                    let current = get_env().unwrap_or_else(|| DEFAULT_ENV.to_owned());
                     let envs: Vec<_> = KNOWN_ENVS
                         .iter()
                         .map(|&e| {
@@ -57,7 +70,7 @@ pub fn module() -> Module {
                     .with_system("env")
                     .with_tier(Tier::Read),
                 |_cred, _args| async move {
-                    let env = get_env().unwrap_or_else(|| "ote".to_owned());
+                    let env = get_env().unwrap_or_else(|| DEFAULT_ENV.to_owned());
                     Ok(CommandResult::new(json!({
                         "env": env,
                         "apiUrl": api_url_for(&env),
@@ -69,7 +82,10 @@ pub fn module() -> Module {
                     .with_system("env")
                     .with_tier(Tier::Mutate)
                     .with_arg(
-                        clap::Arg::new("env")
+                        // Distinct id from the global `--env` flag (also id "env");
+                        // a shared id makes the positional collide with the flag's
+                        // default, so `env set <X>` would ignore <X>.
+                        clap::Arg::new("environment")
                             .value_name("ENV")
                             .required(true)
                             .help("Environment to activate (ote|prod)"),
@@ -77,7 +93,7 @@ pub fn module() -> Module {
                 |ctx| async move {
                     let env = ctx
                         .args
-                        .get("env")
+                        .get("environment")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_owned();
@@ -88,7 +104,9 @@ pub fn module() -> Module {
                         )));
                     }
                     set_env(&env).map_err(|e| {
-                        cli_engine::CliCoreError::message(format!("failed to write ~/.gdenv: {e}"))
+                        cli_engine::CliCoreError::message(format!(
+                            "failed to write .gdenv state file: {e}"
+                        ))
                     })?;
                     Ok(CommandResult::new(json!({
                         "env": env,
@@ -101,7 +119,7 @@ pub fn module() -> Module {
                     .with_system("env")
                     .with_tier(Tier::Read),
                 |_cred, _args| async move {
-                    let env = get_env().unwrap_or_else(|| "ote".to_owned());
+                    let env = get_env().unwrap_or_else(|| DEFAULT_ENV.to_owned());
                     Ok(CommandResult::new(json!({
                         "env": env,
                         "apiUrl": api_url_for(&env),

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -36,7 +36,12 @@ pub fn get_env() -> Option<String> {
 }
 
 pub fn set_env(env: &str) -> std::io::Result<()> {
-    std::fs::write(gdenv_path()?, env)
+    let path = gdenv_path()?;
+    std::fs::write(&path, env).map_err(|e| {
+        // Include the resolved (platform-dependent) path so callers can surface
+        // an actionable message — the raw write error omits it.
+        std::io::Error::new(e.kind(), format!("{}: {e}", path.display()))
+    })
 }
 
 fn api_url_for(env: &str) -> &'static str {

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -29,7 +29,10 @@ pub fn get_env() -> Option<String> {
         .ok()
         .and_then(|path| std::fs::read_to_string(path).ok())
         .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
+        // Ignore empty or unrecognized values (e.g. a hand-edited/corrupted
+        // .gdenv) so callers fall back to DEFAULT_ENV instead of propagating an
+        // unknown environment that helpers would silently treat as prod.
+        .filter(|s| KNOWN_ENVS.contains(&s.as_str()))
 }
 
 pub fn set_env(env: &str) -> std::io::Result<()> {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> ExitCode {
                         .long("env")
                         .global(true)
                         .value_name("ENV")
-                        .default_value(get_env().unwrap_or_else(|| "ote".to_owned()))
+                        .default_value(get_env().unwrap_or_else(|| env::DEFAULT_ENV.to_owned()))
                         .help("Target environment (ote|prod)"),
                 )
             }))


### PR DESCRIPTION
## Summary

Fixes issues surfaced while testing the `gddy` alpha on Windows (WSL build verified locally: Windows Credential Manager token storage works, prod default works).

- **Default environment `ote` → `prod`** everywhere. Adds a `DEFAULT_ENV` const (`rust/src/env/mod.rs`), updates the global `--env` flag default (`rust/src/main.rs`), and flips the `api_url_for` fallback so prod is the consistent default. Breaking change from the legacy CLI — intentional.
- **Cross-platform `.gdenv`**: resolved via `dirs::home_dir()` (`%USERPROFILE%` on Windows) instead of reading `$HOME` with a `/tmp` fallback. Fixes `gddy env set` failing on Windows with `failed to write ~/.gdenv: ... (os error 3)`.
- **`env set <ENV>` arg fix**: the positional shared arg id `"env"` with the global `--env` flag, so `env set ote` was ignoring its argument and writing the flag default. Renamed the positional to id `environment`.
- **Windows install support**: `install.sh` now detects Git Bash / MSYS2 / Cygwin and installs the `x86_64-pc-windows-msvc` `gddy.exe` from the `.zip` (via `unzip` or PowerShell `Expand-Archive`). Adds **`install.ps1`**, a native PowerShell installer, published as a release asset (`rust-port-alpha.yaml`) and documented in the README.
- Ignores Claude Code per-machine runtime state under `.claude/`.

## Verification

- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` (114 passing), `cargo build` — all green on Linux.
- Fresh `gddy env get` / `env info` report `prod`; `env set prod` / `env set ote` write `.gdenv` correctly.
- Cross-compiled `x86_64-pc-windows-msvc` locally (cargo-xwin); the resulting `gddy.exe` runs on Windows, defaults to prod, writes `%USERPROFILE%\.gdenv` without error, and stores credentials in Windows Credential Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)