### PR TITLE
Show oauth login browser link during `auth login`

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,14 +13,27 @@ use std::{process::ExitCode, sync::Arc};
 
 use clap::Arg;
 use cli_engine::{BuildInfo, Cli, CliConfig, NextAction};
+use tracing_subscriber::filter::LevelFilter;
 
 use crate::env::get_env;
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    let trace_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(LevelFilter::WARN.into())
+        .from_env_lossy()
+        .add_directive(
+            "cli_engine::auth::pkce=info"
+                .parse()
+                .expect("valid cli-engine PKCE tracing directive"),
+        );
+
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(trace_filter)
         .with_writer(std::io::stderr)
+        .without_time()
+        .with_target(false)
+        .with_level(false)
         .init();
 
     let auth_provider = Arc::new(auth::CompositeAuthProvider::new());


### PR DESCRIPTION
Small change to give a bit more output during the auth flow. Two goals:
1. Make it clear to the user (or driving agent) what is happening
2. Show the OAuth url in case the browser does not automatically open

Output during `gddy auth login` now looks like:
```
> gddy auth login --env prod
Opening browser for authentication…
If the browser does not open, visit:
  https://api.godaddy.com/v2/oauth2/authorize?response_type=code&client_id=bc87f347-af82-4892-833f-818f54a0e79e&redirect_uri=http%3A%2F%2Flocalhost%3A7443%2Fcallback&scope=apps.app-registry%3Aread+apps.app-registry%3Awrite&state=k6T6WR7ur8bjikaOCO2alw&code_challenge=GkYAMlefo88FiBIj7-xsCoW46JEYcNRaUOfHDVIho4M&code_challenge_method=S256
```

Found that the PKCE auth provider in cli-engine already provides this output as info tracing, so just exposed that - open to better ways to show this kind of detail.