### PR TITLE
fix: default auth flow to production environment

### DIFF
--- a/.changeset/auth-prod-default.md
+++ b/.changeset/auth-prod-default.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/cli": patch
+---
+
+Default the unset CLI environment to production so `godaddy auth login` uses the production OAuth flow unless `--env ote` or `godaddy env set ote` is selected.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ godaddy --help
 All executable commands emit JSON envelopes:
 
 ```json
-{"ok":true,"command":"godaddy env get","result":{"environment":"ote"},"next_actions":[...]}
+{"ok":true,"command":"godaddy env get","result":{"environment":"prod"},"next_actions":[...]}
 ```
 
 ```json
@@ -49,6 +49,10 @@ Returns environment/auth snapshots and the full command tree.
 - `godaddy env get`
 - `godaddy env set <environment>`
 - `godaddy env info [environment]`
+
+When no environment has been selected, commands default to `prod`. Use
+`--env ote` for a single command or `godaddy env set ote` to persist OTE/test
+environment usage.
 
 ### Authentication
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -3,6 +3,7 @@ import * as Command from "@effect/cli/Command";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import {
+  DEFAULT_ENVIRONMENT,
   envGetEffect,
   envInfoEffect,
   envListEffect,
@@ -26,7 +27,7 @@ const envGroupActions: NextAction[] = [
       environment: {
         description: "Environment name",
         enum: ["ote", "prod"],
-        default: "ote",
+        default: DEFAULT_ENVIRONMENT,
         required: true,
       },
     },
@@ -42,7 +43,9 @@ const envGetActions: NextAction[] = [
   {
     command: "godaddy env info [environment]",
     description: "Show environment details",
-    params: { environment: { enum: ["ote", "prod"], default: "ote" } },
+    params: {
+      environment: { enum: ["ote", "prod"], default: DEFAULT_ENVIRONMENT },
+    },
   },
 ];
 
@@ -60,13 +63,19 @@ const envListActions: NextAction[] = [
     command: "godaddy env set <environment>",
     description: "Set active environment",
     params: {
-      environment: { enum: ["ote", "prod"], default: "ote", required: true },
+      environment: {
+        enum: ["ote", "prod"],
+        default: DEFAULT_ENVIRONMENT,
+        required: true,
+      },
     },
   },
   {
     command: "godaddy env info [environment]",
     description: "Show environment details",
-    params: { environment: { enum: ["ote", "prod"], default: "ote" } },
+    params: {
+      environment: { enum: ["ote", "prod"], default: DEFAULT_ENVIRONMENT },
+    },
   },
 ];
 
@@ -78,7 +87,7 @@ function envInfoActions(environment?: string): NextAction[] {
       params: {
         environment: {
           enum: ["ote", "prod"],
-          value: environment ?? "ote",
+          value: environment ?? DEFAULT_ENVIRONMENT,
           required: true,
         },
       },

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -14,7 +14,7 @@ import type { Keychain } from "../effect/services/keychain";
 import { loggedFetch } from "../services/logger";
 import { cliTraceHeaders } from "../shared/cli-trace";
 import {
-  type Environment,
+  DEFAULT_ENVIRONMENT,
   envGetEffect,
   getApiUrl,
   getClientId,
@@ -82,7 +82,7 @@ function getOauthAuthUrlEffect(): Effect.Effect<string, never, FileSystem> {
       return process.env.OAUTH_AUTH_URL;
     }
     const env = yield* envGetEffect().pipe(
-      Effect.orElseSucceed(() => "ote" as Environment),
+      Effect.orElseSucceed(() => DEFAULT_ENVIRONMENT),
     );
     return `${getApiUrl(env)}/v2/oauth2/authorize`;
   });
@@ -94,7 +94,7 @@ function getOauthTokenUrlEffect(): Effect.Effect<string, never, FileSystem> {
       return process.env.OAUTH_TOKEN_URL;
     }
     const env = yield* envGetEffect().pipe(
-      Effect.orElseSucceed(() => "ote" as Environment),
+      Effect.orElseSucceed(() => DEFAULT_ENVIRONMENT),
     );
     return `${getApiUrl(env)}/v2/oauth2/token`;
   });
@@ -106,7 +106,7 @@ function getOauthClientIdEffect(): Effect.Effect<string, never, FileSystem> {
       return process.env.GODADDY_OAUTH_CLIENT_ID;
     }
     const env = yield* envGetEffect().pipe(
-      Effect.orElseSucceed(() => "ote" as Environment),
+      Effect.orElseSucceed(() => DEFAULT_ENVIRONMENT),
     );
     return getClientId(env);
   });
@@ -345,7 +345,7 @@ export function authStatusEffect(): Effect.Effect<
 > {
   return Effect.gen(function* () {
     const environment = yield* envGetEffect().pipe(
-      Effect.orElseSucceed(() => "ote" as Environment),
+      Effect.orElseSucceed(() => DEFAULT_ENVIRONMENT),
     );
     const tokenInfo = yield* getTokenInfoEffect().pipe(
       Effect.catchAll(() => Effect.succeed(null)),

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -13,6 +13,7 @@ import {
 } from "../services/config";
 
 export type Environment = "ote" | "prod";
+export const DEFAULT_ENVIRONMENT: Environment = "prod";
 
 export interface EnvironmentDisplay {
   color: string;
@@ -68,11 +69,9 @@ function getEnvironmentOverride(): Effect.Effect<
  * Get the current active environment (internal helper).
  * Reads override from CliConfig service, then falls back to persisted file.
  */
-function getActiveEnvironmentInternalEffect(): Effect.Effect<
-  Environment,
-  never,
-  FileSystem
-> {
+function getActiveEnvironmentInternalEffect(
+  defaultEnvironment: Environment = DEFAULT_ENVIRONMENT,
+): Effect.Effect<Environment, never, FileSystem> {
   return Effect.gen(function* () {
     const override = yield* getEnvironmentOverride();
     if (override) {
@@ -87,11 +86,11 @@ function getActiveEnvironmentInternalEffect(): Effect.Effect<
         .pipe(Effect.orElseSucceed(() => ""));
       if (file.trim()) {
         return yield* Effect.try(() => validateEnvironment(file.trim())).pipe(
-          Effect.orElseSucceed(() => "ote" as Environment),
+          Effect.orElseSucceed(() => defaultEnvironment),
         );
       }
     }
-    return "ote" as Environment;
+    return defaultEnvironment;
   });
 }
 

--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import { ConfigurationError } from "../effect/errors";
 import { Keychain, type KeychainCredential } from "../effect/services/keychain";
 import {
+  DEFAULT_ENVIRONMENT,
   type Environment,
   envGetEffect,
   getApiUrl,
@@ -51,7 +52,7 @@ function getCurrentEnvironmentEffect(): Effect.Effect<
   never,
   FileSystem
 > {
-  return envGetEffect().pipe(Effect.orElseSucceed(() => "ote" as Environment));
+  return envGetEffect().pipe(Effect.orElseSucceed(() => DEFAULT_ENVIRONMENT));
 }
 
 function getTokenEndpoint(environment: Environment): string {

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,11 +1,48 @@
-import { describe, expect, test } from "vitest";
-import { getFromKeychainEffect } from "../../src/core/auth";
+import net from "node:net";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  authLoginEffect,
+  getFromKeychainEffect,
+  stopAuthServer,
+} from "../../src/core/auth";
+import { setRuntimeEnvironmentOverride } from "../../src/core/environment";
 import { runEffect } from "../setup/effect-test-utils";
+import {
+  mockKeytar,
+  mockOpen,
+  setupTestEnvironment,
+} from "../setup/system-mocks";
 import {
   withExpiredAuth,
   withNoAuth,
   withValidAuth,
 } from "../setup/test-utils";
+
+function rawHttpGet(url: URL): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(
+      { host: "127.0.0.1", port: Number(url.port) },
+      () => {
+        socket.write(
+          `GET ${url.pathname}${url.search} HTTP/1.1\r\nHost: ${url.host}\r\nConnection: close\r\n\r\n`,
+        );
+      },
+    );
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.on("end", () => resolve(response));
+    socket.on("error", reject);
+  });
+}
+
+afterEach(() => {
+  stopAuthServer();
+  setRuntimeEnvironmentOverride(null);
+  setupTestEnvironment();
+});
 
 describe("Auth Service", () => {
   test("returns valid token when present", async () => {
@@ -27,5 +64,38 @@ describe("Auth Service", () => {
 
     const token = await runEffect(getFromKeychainEffect("token"));
     expect(token).toBeNull();
+  });
+
+  test("opens production OAuth authorize URL by default", async () => {
+    withNoAuth();
+    process.env.OAUTH_AUTH_URL = "";
+    process.env.OAUTH_TOKEN_URL = "";
+    process.env.GODADDY_OAUTH_CLIENT_ID = "";
+
+    const login = runEffect(authLoginEffect());
+
+    await vi.waitFor(() => {
+      expect(mockOpen).toHaveBeenCalledWith(expect.any(String));
+    });
+
+    const openedUrl = new URL(String(mockOpen.mock.calls.at(-1)?.[0]));
+    expect(openedUrl.origin).toBe("https://api.godaddy.com");
+    expect(openedUrl.pathname).toBe("/v2/oauth2/authorize");
+    expect(openedUrl.searchParams.get("client_id")).toBe(
+      "39489dee-4103-4284-9aab-9f2452142bce",
+    );
+
+    const callbackUrl = new URL(openedUrl.searchParams.get("redirect_uri")!);
+    callbackUrl.searchParams.set("code", "test-auth-code");
+    callbackUrl.searchParams.set("state", openedUrl.searchParams.get("state")!);
+    await rawHttpGet(callbackUrl);
+
+    const result = await login;
+    expect(result.success).toBe(true);
+    expect(mockKeytar.setPassword).toHaveBeenCalledWith(
+      "godaddy-cli",
+      expect.stringMatching(/^token:v3:prod:/),
+      expect.stringContaining('"accessToken":"test-token-123"'),
+    );
   });
 });

--- a/tests/unit/core/api.test.ts
+++ b/tests/unit/core/api.test.ts
@@ -57,7 +57,7 @@ describe("API Core Functions", () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    test("makes authenticated request and returns parsed JSON", async () => {
+    test("makes authenticated request to production by default", async () => {
       vi.mocked(fetch).mockResolvedValueOnce(
         new Response(JSON.stringify({ shopperId: "12345" }), {
           status: 200,
@@ -76,7 +76,7 @@ describe("API Core Functions", () => {
       expect(result.data).toEqual({ shopperId: "12345" });
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith(
-        "https://api.ote-godaddy.com/v1/shoppers/me",
+        "https://api.godaddy.com/v1/shoppers/me",
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({


### PR DESCRIPTION
Closes #66

## Summary
- Default the unset CLI environment to `prod` instead of `ote`, so `godaddy auth login` opens the production OAuth flow for normal users.
- Keep explicit OTE usage available through `--env ote` or `godaddy env set ote`.
- Update env command metadata, README docs, token storage fallback, and API/auth regression tests for the new default.

## Verification
- `npx pnpm@10.14.0 test tests/unit/auth.test.ts tests/unit/core/api.test.ts tests/unit/core/environment.test.ts tests/unit/core/token-store.test.ts`
- `npx pnpm@10.14.0 run build`
- `npx pnpm@10.14.0 test tests/integration/cli-smoke.test.ts tests/unit/application-deploy-security.test.ts tests/unit/cli/deploy-stream.test.ts`
- `npx pnpm@10.14.0 exec biome check README.md src/cli/commands/env.ts src/core/auth.ts src/core/environment.ts src/core/token-store.ts tests/unit/auth.test.ts tests/unit/core/api.test.ts .changeset/auth-prod-default.md`