### PR TITLE
fix: payments add always returns URL, treats browser failure as non-fatal

### DIFF
--- a/rust/src/payments/mod.rs
+++ b/rust/src/payments/mod.rs
@@ -1,7 +1,5 @@
 //! `gddy payments` — payment method management.
 
-use std::io::Write as _;
-
 use cli_engine::{
     CliCoreError, CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec,
     RuntimeGroupSpec, Tier,
@@ -37,19 +35,15 @@ fn add_command() -> RuntimeCommandSpec {
         |ctx| async move {
             let env = environments::resolve(&ctx.middleware.env).map_err(map_env_err)?;
             let url = format!("{}/payment-methods/add-payment?plid=1", env.account_url);
-            if let Err(e) = open::that(&url) {
-                let mut stderr = std::io::stderr().lock();
-                drop(writeln!(
-                    stderr,
-                    "Failed to open browser. Visit manually:\n  {url}"
-                ));
-                return Err(CliCoreError::message(format!(
-                    "failed to open browser: {e}"
-                )));
-            }
+            let opened = open::that(&url).is_ok();
             Ok(CommandResult::new(json!({
-                "info": "Browser opened to the payment methods management page. \
-                         Only credit card or Good-as-Gold can be used for domain purchases."
+                "url": url,
+                "info": if opened {
+                    "Browser opened. Only credit card or Good-as-Gold can be used for domain purchases."
+                } else {
+                    "Could not open browser. Visit the URL above to add a payment method. \
+                     Only credit card or Good-as-Gold can be used for domain purchases."
+                }
             })))
         },
     )


### PR DESCRIPTION
## Summary

- `payments add` now always includes the payment URL in the JSON result, so it's visible (and clickable in modern terminals) regardless of whether the browser opened
- Browser launch failure is no longer treated as a fatal error — the command returns `Ok` in both cases
- Removes unused `std::io::Write` import

## Background

On WSL2 (and other headless Linux environments), `xdg-open` exits with code 3 because no desktop environment is configured. The previous code returned an `Err` on browser launch failure, surfacing a confusing error message even though the URL had already been printed to stderr. This made the command unusable on WSL2 without a workaround.

## Test plan

- [ ] Run `gddy payments add` on WSL2 — should return the URL in the result instead of an error
- [ ] Run `gddy payments add` on macOS/Windows — browser should open and URL should still appear in the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)