### PR TITLE
chore: bump cli-engine to 0.3.4 (non-interactive OAuth scope step-up)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -523,6 +523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,14 +551,16 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d52e2b73598b7c6dbbaf3946a476a888d0cda6a36d2d98c1f477f8d7a8034c1"
+checksum = "4500a5c23d3171897dc68633fa37c541114759c93aaa600dad95dea196d6987c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "clap",
+ "clap_complete",
  "jmespath",
  "keyring",
  "open",
@@ -1363,7 +1374,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2170,7 +2181,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2207,7 +2218,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.3.0" }
+cli-engine = { features = ["pkce-auth"], version = "0.3.4" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"


### PR DESCRIPTION
## What

Bumps `cli-engine` from `0.3.0` → `0.3.4` (`rust/Cargo.toml`, `rust/Cargo.lock`).

## Why

cli-engine 0.3.4 ([godaddy/cli-engine#34](https://github.com/godaddy/cli-engine/pull/34)) fixes an asymmetry in OAuth scope step-up. Previously, `PkceAuthProvider::get_credential_for` gated step-up on a TTY check **only** when a token already existed: a command run without a TTY (agent harness, piped stdio) that held a token missing a required scope hard-errored with `missing required scope(s): …; run auth login --env … --scope …`, while the no-token path always launched the browser flow. The result — surfaced in a bug bash — was that `gddy domain suggest` failed on first run but auto-authenticated once the token was cleared, and the error's suggested fix (`auth login --scope …`) was the wrong path.

With the bump, any scoped command (`domain suggest`, `domain purchase`, …) now steps up to acquire the missing scope regardless of interactivity. The requested set stays `defaults ∪ granted ∪ required`, so step-up never narrows an existing grant.

## Notes

- Transitively adds `clap_complete v4.6.5` (cli-engine's shell-completion feature, added in 0.3.3).
- No source changes needed here — `src/auth.rs` delegates straight to `PkceAuthProvider`, and domain commands already declare their scopes via `with_scopes`.

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (182 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)