### PR TITLE
fix: domain-purchase data formatting + comprehensive CLI help

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -328,6 +328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +589,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +656,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -793,6 +817,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "ena"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,7 +915,7 @@ checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1118,6 +1154,7 @@ dependencies = [
  "fancy-regex",
  "httpmock",
  "open",
+ "phonenumber",
  "regex",
  "reqwest",
  "serde",
@@ -1139,6 +1176,15 @@ checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
 dependencies = [
  "combine",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1166,6 +1212,20 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1644,7 +1704,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1704,6 +1764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1780,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1888,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1902,6 +1993,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oncemutex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
 name = "open"
@@ -2002,6 +2099,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "phonenumber"
+version = "0.3.9+9.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
+dependencies = [
+ "either",
+ "fnv",
+ "nom",
+ "once_cell",
+ "postcard",
+ "quick-xml",
+ "regex",
+ "regex-cache",
+ "serde",
+ "serde_derive",
+ "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2165,19 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -2166,6 +2296,15 @@ dependencies = [
  "serde_tokenstream",
  "serde_yaml",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2363,7 +2502,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2374,8 +2513,26 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-cache"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7b62d69743b8b94f353b6b7c3deb4c5582828328bcb8d5fedf214373808793"
+dependencies = [
+ "lru-cache",
+ "oncemutex",
+ "regex",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2455,6 +2612,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2870,6 +3036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,6 +3073,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"
 open = "5"
+phonenumber = "0.3"
 regex = { version = "1", features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 sha2 = "0.10"

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -59,12 +59,24 @@ fn load_action_schema(name: &str) -> Option<serde_json::Value> {
 
 pub fn module() -> Module {
     Module::new("Contracts", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new(
-            "actions",
-            "Discover available GoDaddy action contracts",
-        ))
+        RuntimeGroupSpec::new(
+            GroupSpec::new("actions", "Discover available GoDaddy action contracts")
+                .with_long(
+                    "Browse the catalog of GoDaddy actions your application can declare.\n\
+                     An action contract defines the name, and the input/output schema, \
+                     of a capability your app exposes to the GoDaddy platform.\n\
+                     Use `gddy actions list` to see all available actions, and \
+                     `gddy actions describe` to inspect a specific action's schema.",
+                ),
+        )
         .with_command(RuntimeCommandSpec::new(
             CommandSpec::new("list", "List all available action contracts")
+                .with_long(
+                    "Prints the name and short description of every action your \
+                     application can declare.\n\
+                     Run `gddy actions describe <ACTION>` to see the full \
+                     input/output schema for a specific action.",
+                )
                 .with_system("actions")
                 .with_tier(Tier::Read)
                 .no_auth(true),
@@ -77,7 +89,12 @@ pub fn module() -> Module {
             },
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
-            CommandSpec::new("describe", "Show detailed schema for an action contract")
+            CommandSpec::new("describe", "Show the input/output schema for an action")
+                .with_long(
+                    "Prints the full JSON schema for the named action contract, \
+                     including its expected input fields and the shape of its output.\n\
+                     Run `gddy actions list` for the list of valid action names.",
+                )
                 .with_system("actions")
                 .with_tier(Tier::Read)
                 .no_auth(true)
@@ -85,7 +102,10 @@ pub fn module() -> Module {
                     clap::Arg::new("action")
                         .value_name("ACTION")
                         .required(true)
-                        .help("Action name (e.g. location.address.verify)"),
+                        .help(
+                            "Name of the action to describe \
+                             (e.g. location.address.verify)",
+                        ),
                 ),
             |ctx| async move {
                 let name = ctx

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -237,17 +237,33 @@ fn search_endpoints<'a>(catalog: &'a [Domain], query: &str) -> Vec<(&'a Domain, 
 
 pub fn module() -> Module {
     Module::new("Contracts", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new(
-            "api",
-            "Explore and call GoDaddy API endpoints",
-        ))
-        .with_group(
-            RuntimeGroupSpec::new(GroupSpec::new("domain", "Browse API domains"))
-                .with_command(domain_list_command()),
+        RuntimeGroupSpec::new(
+            GroupSpec::new("api", "Explore and call GoDaddy API endpoints").with_long(
+                "Browse the GoDaddy API catalog and make authenticated requests \
+                     against any endpoint. Use `api domain list` / `api endpoint list` to \
+                     discover available operations, `api describe` to inspect parameters, \
+                     and `api call` to execute a request with automatic OAuth scope handling.",
+            ),
         )
         .with_group(
-            RuntimeGroupSpec::new(GroupSpec::new("endpoint", "Browse API endpoints"))
-                .with_command(endpoint_list_command()),
+            RuntimeGroupSpec::new(GroupSpec::new("domain", "Browse API domains").with_long(
+                "Browse the top-level API domains available in the embedded catalog. \
+                     Each domain groups a related set of endpoints under a shared base URL. \
+                     Use `api endpoint list --domain <domain>` to see the endpoints \
+                     within a specific domain.",
+            ))
+            .with_command(domain_list_command()),
+        )
+        .with_group(
+            RuntimeGroupSpec::new(
+                GroupSpec::new("endpoint", "Browse API endpoints").with_long(
+                    "Browse the endpoints within a single API domain. \
+                     Use `api domain list` first to find available domain names, \
+                     then `api describe <operationId>` to inspect full parameter \
+                     and schema details for an individual endpoint.",
+                ),
+            )
+            .with_command(endpoint_list_command()),
         )
         .with_command(describe_command())
         .with_command(search_command())
@@ -258,6 +274,12 @@ pub fn module() -> Module {
 fn domain_list_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("list", "List all API domains")
+            .with_long(
+                "Lists every API domain in the embedded catalog, together with the number \
+                 of endpoints and base URL for each. No authentication is required. \
+                 Use `api endpoint list --domain <domain>` to drill into a specific domain, \
+                 or `api search <query>` to find endpoints across all domains at once.",
+            )
             .with_system("api")
             .with_tier(Tier::Read)
             .no_auth(true)
@@ -292,6 +314,12 @@ fn domain_list_command() -> RuntimeCommandSpec {
 fn endpoint_list_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("list", "List endpoints within an API domain")
+            .with_long(
+                "Lists every endpoint in one API domain, showing the operation ID, HTTP \
+                 method, path, and summary. Use `api domain list` to find available domain \
+                 names, `api describe <operationId>` to view full parameter details, and \
+                 `api call <path>` to execute a request.",
+            )
             .with_system("api")
             .with_tier(Tier::Read)
             .no_auth(true)
@@ -346,6 +374,12 @@ fn describe_command() -> RuntimeCommandSpec {
             "describe",
             "Show schema and parameters for an endpoint",
         )
+        .with_long(
+            "Shows the full details of one API endpoint: HTTP method, path, required and \
+             optional parameters, request body schema, response shapes, and declared OAuth \
+             scopes. Accepts an operation ID (e.g. createOrder) or a path fragment \
+             (e.g. /v1/commerce/orders). No authentication is required.",
+        )
         .with_system("api")
         .with_tier(Tier::Read)
         .no_auth(true)
@@ -393,6 +427,12 @@ fn describe_command() -> RuntimeCommandSpec {
 fn search_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("search", "Search API endpoints by keyword")
+            .with_long(
+                "Full-text searches across all API domains, matching against operation IDs, \
+                 paths, summaries, and descriptions. Returns matching endpoints with domain, \
+                 method, path, and summary. No authentication is required. Use \
+                 `api describe <operationId>` to inspect a result in full detail.",
+            )
             .with_system("api")
             .with_tier(Tier::Read)
             .no_auth(true)
@@ -463,6 +503,19 @@ fn extract_json_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
 fn call_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("call", "Make an authenticated API request")
+            .with_long(
+                "Executes an authenticated HTTP request against any GoDaddy API endpoint. \
+                 Required OAuth scopes are resolved automatically: the catalog is searched \
+                 for the endpoint path and its declared scopes are merged with any explicit \
+                 `--scope` flags, then a credential with exactly those scopes is obtained \
+                 before the request is sent. Supply the request body as raw JSON (`--body \
+                 '{...}'`), as individual fields (`--field key=value`, repeatable), or \
+                 from a JSON file (`--file body.json`); `--file` takes precedence over \
+                 `--body`, and `--field` values are merged on top of either. Use `--query \
+                 .path[0].field` to extract a value from the response JSON, and `--include` \
+                 to see response headers alongside the body. Use `api describe <endpoint>` \
+                 first to inspect required parameters and scopes.",
+            )
             .with_system("api")
             .with_tier(Tier::Mutate)
             .with_arg(

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -109,7 +109,14 @@ fn arg_str<'a>(ctx: &'a cli_engine::CommandContext, key: &str) -> &'a str {
 
 pub fn application_group() -> RuntimeGroupSpec {
     RuntimeGroupSpec::new(
-        GroupSpec::new("application", "Manage GoDaddy applications").with_alias("app"),
+        GroupSpec::new("application", "Manage GoDaddy applications")
+            .with_long(
+                "Manage GoDaddy developer-platform applications. A GoDaddy application is a \
+                developer-platform app described by a godaddy.toml manifest in your working \
+                directory. Use `application init` to create one, `application validate` to \
+                check it, and `application deploy` to publish it.",
+            )
+            .with_alias("app"),
     )
     .with_command(list_command())
     .with_command(info_command())
@@ -127,6 +134,11 @@ pub fn application_group() -> RuntimeGroupSpec {
 fn list_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("list", "List all applications")
+            .with_long(
+                "List all GoDaddy developer-platform applications visible to the current \
+                account. Use `application info --name <name>` to fetch full details for a \
+                single application.",
+            )
             .with_system("applications")
             .with_tier(Tier::Read)
             .with_default_fields("name,label,status")
@@ -152,6 +164,11 @@ fn list_command() -> RuntimeCommandSpec {
 fn info_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("info", "Get application details")
+            .with_long(
+                "Fetch full details for a single GoDaddy developer-platform application by \
+                name, including status, URLs, and authorization scopes. Use `application list` \
+                to find available names.",
+            )
             .with_system("applications")
             .with_tier(Tier::Read)
             .with_output_schema::<ApplicationSummary>()
@@ -198,6 +215,13 @@ fn info_command() -> RuntimeCommandSpec {
 fn init_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("init", "Create and initialize a new application")
+            .with_long(
+                "Register a new GoDaddy developer-platform application and write a \
+                godaddy.toml manifest to the current directory. The manifest captures the \
+                application name, URL, authorization scopes, and any actions or extensions \
+                added later. Run `application validate` to confirm the manifest is valid, \
+                then `application release` to create a versioned release.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ApplicationCredentials>()
@@ -319,6 +343,11 @@ fn init_command() -> RuntimeCommandSpec {
 fn validate_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("validate", "Validate godaddy.toml config")
+            .with_long(
+                "Parse and validate the godaddy.toml manifest in the current directory \
+                (or the path given by --config). Exits non-zero and prints a diagnostic if \
+                the file is missing or malformed. Does not require authentication.",
+            )
             .with_system("applications")
             .with_tier(Tier::Read)
             .with_output_schema::<ValidationResult>()
@@ -352,6 +381,11 @@ fn validate_command() -> RuntimeCommandSpec {
 fn update_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("update", "Update an application")
+            .with_long(
+                "Update the label or description of a GoDaddy developer-platform application \
+                by its ID. At least one of --label or --description must be provided. \
+                Use `application info --name <name>` to retrieve the application ID.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ApplicationUpdate>()
@@ -427,6 +461,11 @@ fn update_command() -> RuntimeCommandSpec {
 fn enable_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("enable", "Enable an application on a store")
+            .with_long(
+                "Make a GoDaddy developer-platform application available on a specific \
+                store. Use `application disable` to reverse this. Both the application name \
+                and a store ID are required.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ApplicationRef>()
@@ -494,6 +533,11 @@ fn enable_command() -> RuntimeCommandSpec {
 fn disable_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("disable", "Disable an application on a store")
+            .with_long(
+                "Remove a GoDaddy developer-platform application from a specific store, \
+                making it unavailable there. Use `application enable` to re-enable it. \
+                Both the application name and a store ID are required.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ApplicationRef>()
@@ -563,6 +607,11 @@ fn disable_command() -> RuntimeCommandSpec {
 fn archive_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("archive", "Archive an application")
+            .with_long(
+                "Archive a GoDaddy developer-platform application by name. Archiving is \
+                irreversible via this CLI; the application will no longer be active. \
+                Use `application list` to confirm the application name before archiving.",
+            )
             .with_system("applications")
             .with_tier(Tier::Destructive)
             .with_output_schema::<ApplicationArchive>()
@@ -598,6 +647,12 @@ fn archive_command() -> RuntimeCommandSpec {
 fn release_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("release", "Create a new application release")
+            .with_long(
+                "Tag a new versioned release for a GoDaddy developer-platform application. \
+                The version must follow semver (e.g. 1.2.3). A release is required before \
+                running `application deploy`. Use `application info --name <name>` to \
+                retrieve the application ID.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ApplicationRelease>()
@@ -648,6 +703,13 @@ fn release_command() -> RuntimeCommandSpec {
 fn deploy_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_streaming(
         CommandSpec::new("deploy", "Deploy an application, streaming progress events")
+            .with_long(
+                "Read godaddy.toml from the current directory, bundle all declared extensions \
+                with esbuild, run the security scanner (rules SEC101–SEC115) on each bundle, \
+                then upload the artifacts to the latest release of the named application. \
+                Progress is streamed as JSON events. A release must exist before deploying; \
+                create one with `application release`.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_arg(
@@ -915,107 +977,141 @@ async fn deploy_extension(
 }
 
 pub fn add_group() -> RuntimeGroupSpec {
-    RuntimeGroupSpec::new(GroupSpec::new("add", "Add components to an application"))
-        .with_command(RuntimeCommandSpec::new_with_context(
-            CommandSpec::new("action", "Add an action to godaddy.toml")
-                .with_system("applications")
-                .with_tier(Tier::Mutate)
-                .with_output_schema::<ConfigAction>()
-                .no_auth(true)
-                .with_arg(
-                    clap::Arg::new("name")
-                        .long("name")
-                        .required(true)
-                        .help("Action name"),
-                )
-                .with_arg(
-                    clap::Arg::new("url")
-                        .long("url")
-                        .required(true)
-                        .help("Action URL"),
-                ),
-            |ctx| async move {
-                let name = arg_str(&ctx, "name").to_owned();
-                let url = arg_str(&ctx, "url").to_owned();
-                let path = crate::config::config_path(Some(&ctx.middleware.env));
-                let mut config = crate::config::read_config(&path)
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                config.actions.push(crate::config::ActionConfig {
-                    name: name.clone(),
-                    url: url.clone(),
-                });
-                crate::config::write_config(&path, &config)
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                Ok(CommandResult::new(json!({ "name": name, "url": url })))
-            },
-        ))
-        .with_command(RuntimeCommandSpec::new_with_context(
-            CommandSpec::new("subscription", "Add a webhook subscription to godaddy.toml")
-                .with_system("applications")
-                .with_tier(Tier::Mutate)
-                .with_output_schema::<ConfigSubscription>()
-                .no_auth(true)
-                .with_arg(
-                    clap::Arg::new("name")
-                        .long("name")
-                        .required(true)
-                        .help("Subscription name"),
-                )
-                .with_arg(
-                    clap::Arg::new("url")
-                        .long("url")
-                        .required(true)
-                        .help("Webhook URL"),
-                )
-                .with_arg(
-                    clap::Arg::new("events")
-                        .long("events")
-                        .num_args(1..)
-                        .value_name("EVENT")
-                        .required(true)
-                        .help("Webhook event types"),
-                ),
-            |ctx| async move {
-                let name = arg_str(&ctx, "name").to_owned();
-                let url = arg_str(&ctx, "url").to_owned();
-                let events: Vec<String> = ctx
-                    .args
-                    .get("events")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(str::to_owned))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let path = crate::config::config_path(Some(&ctx.middleware.env));
-                let mut config = crate::config::read_config(&path)
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                let subs = config
-                    .subscriptions
-                    .get_or_insert_with(|| crate::config::SubscriptionsConfig { webhook: vec![] });
-                subs.webhook.push(crate::config::SubscriptionConfig {
-                    name: name.clone(),
-                    events: events.clone(),
-                    url: url.clone(),
-                });
-                crate::config::write_config(&path, &config)
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                Ok(CommandResult::new(
-                    json!({ "name": name, "url": url, "events": events }),
-                ))
-            },
-        ))
-        .with_group(add_extension_group())
+    RuntimeGroupSpec::new(
+        GroupSpec::new("add", "Add components to an application").with_long(
+            "Append actions, webhook subscriptions, or UI extensions to the \
+                godaddy.toml manifest in the current directory. These commands do not \
+                require authentication and do not contact the API; run \
+                `application deploy` to publish the updated manifest.",
+        ),
+    )
+    .with_command(RuntimeCommandSpec::new_with_context(
+        CommandSpec::new("action", "Add an action to godaddy.toml")
+            .with_long(
+                "Append an action entry to the godaddy.toml manifest in the current \
+                    directory. An action is an HTTP endpoint that the platform calls on \
+                    behalf of the application; it is identified by a name and a public \
+                    HTTPS URL. The manifest is updated in place; run `application validate` \
+                    to confirm the result.",
+            )
+            .with_system("applications")
+            .with_tier(Tier::Mutate)
+            .with_output_schema::<ConfigAction>()
+            .no_auth(true)
+            .with_arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .required(true)
+                    .help("Unique action name written into godaddy.toml"),
+            )
+            .with_arg(
+                clap::Arg::new("url")
+                    .long("url")
+                    .required(true)
+                    .help("Public HTTPS URL the platform will invoke for this action"),
+            ),
+        |ctx| async move {
+            let name = arg_str(&ctx, "name").to_owned();
+            let url = arg_str(&ctx, "url").to_owned();
+            let path = crate::config::config_path(Some(&ctx.middleware.env));
+            let mut config = crate::config::read_config(&path)
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            config.actions.push(crate::config::ActionConfig {
+                name: name.clone(),
+                url: url.clone(),
+            });
+            crate::config::write_config(&path, &config)
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            Ok(CommandResult::new(json!({ "name": name, "url": url })))
+        },
+    ))
+    .with_command(RuntimeCommandSpec::new_with_context(
+        CommandSpec::new("subscription", "Add a webhook subscription to godaddy.toml")
+            .with_long(
+                "Append a webhook subscription entry to the godaddy.toml manifest in \
+                    the current directory. A subscription routes platform events to an HTTPS \
+                    endpoint. Provide one or more event types with --events; run \
+                    `gddy webhook events` to discover the full list of valid event types.",
+            )
+            .with_system("applications")
+            .with_tier(Tier::Mutate)
+            .with_output_schema::<ConfigSubscription>()
+            .no_auth(true)
+            .with_arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .required(true)
+                    .help("Unique subscription name written into godaddy.toml"),
+            )
+            .with_arg(
+                clap::Arg::new("url")
+                    .long("url")
+                    .required(true)
+                    .help("Public HTTPS URL that will receive webhook POST requests"),
+            )
+            .with_arg(
+                clap::Arg::new("events")
+                    .long("events")
+                    .num_args(1..)
+                    .value_name("EVENT")
+                    .required(true)
+                    .help(
+                        "One or more event types to subscribe to \
+                            (run `gddy webhook events` to list valid values)",
+                    ),
+            ),
+        |ctx| async move {
+            let name = arg_str(&ctx, "name").to_owned();
+            let url = arg_str(&ctx, "url").to_owned();
+            let events: Vec<String> = ctx
+                .args
+                .get("events")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let path = crate::config::config_path(Some(&ctx.middleware.env));
+            let mut config = crate::config::read_config(&path)
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            let subs = config
+                .subscriptions
+                .get_or_insert_with(|| crate::config::SubscriptionsConfig { webhook: vec![] });
+            subs.webhook.push(crate::config::SubscriptionConfig {
+                name: name.clone(),
+                events: events.clone(),
+                url: url.clone(),
+            });
+            crate::config::write_config(&path, &config)
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            Ok(CommandResult::new(
+                json!({ "name": name, "url": url, "events": events }),
+            ))
+        },
+    ))
+    .with_group(add_extension_group())
 }
 
 pub fn add_extension_group() -> RuntimeGroupSpec {
-    RuntimeGroupSpec::new(GroupSpec::new(
-        "extension",
-        "Add an extension to godaddy.toml",
-    ))
+    RuntimeGroupSpec::new(
+        GroupSpec::new("extension", "Add an extension to godaddy.toml").with_long(
+            "Append a UI extension entry to the godaddy.toml manifest in the current \
+                directory. Extensions are JavaScript bundles that the platform renders \
+                inside store surfaces. Three types are supported: embed (inline widget), \
+                checkout (checkout-flow widget), and blocks (content blocks). Run \
+                `application deploy` to bundle and upload the registered extensions.",
+        ),
+    )
     .with_command(RuntimeCommandSpec::new_with_context(
         CommandSpec::new("embed", "Add an embed extension")
+            .with_long(
+                "Register an embed UI extension in godaddy.toml. An embed extension is a \
+                JavaScript bundle rendered as an inline widget inside a store surface. \
+                Provide a unique name, a platform handle, and the path to the source \
+                entry-point file. Run `application deploy` to bundle and upload.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ExtensionHandle>()
@@ -1024,19 +1120,19 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 clap::Arg::new("name")
                     .long("name")
                     .required(true)
-                    .help("Extension name"),
+                    .help("Unique extension name written into godaddy.toml"),
             )
             .with_arg(
                 clap::Arg::new("handle")
                     .long("handle")
                     .required(true)
-                    .help("Unique handle"),
+                    .help("Platform handle used to identify this extension surface"),
             )
             .with_arg(
                 clap::Arg::new("source")
                     .long("source")
                     .required(true)
-                    .help("Source file path"),
+                    .help("Path to the JavaScript entry-point file for this extension"),
             ),
         |ctx| async move {
             let name = arg_str(&ctx, "name").to_owned();
@@ -1067,6 +1163,12 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
     ))
     .with_command(RuntimeCommandSpec::new_with_context(
         CommandSpec::new("checkout", "Add a checkout extension")
+            .with_long(
+                "Register a checkout UI extension in godaddy.toml. A checkout extension is \
+                a JavaScript bundle rendered during the store checkout flow. Provide a \
+                unique name, a platform handle, and the path to the source entry-point \
+                file. Run `application deploy` to bundle and upload.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ExtensionHandle>()
@@ -1075,19 +1177,19 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 clap::Arg::new("name")
                     .long("name")
                     .required(true)
-                    .help("Extension name"),
+                    .help("Unique extension name written into godaddy.toml"),
             )
             .with_arg(
                 clap::Arg::new("handle")
                     .long("handle")
                     .required(true)
-                    .help("Unique handle"),
+                    .help("Platform handle used to identify this extension surface"),
             )
             .with_arg(
                 clap::Arg::new("source")
                     .long("source")
                     .required(true)
-                    .help("Source file path"),
+                    .help("Path to the JavaScript entry-point file for this extension"),
             ),
         |ctx| async move {
             let name = arg_str(&ctx, "name").to_owned();
@@ -1118,6 +1220,13 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
     ))
     .with_command(RuntimeCommandSpec::new_with_context(
         CommandSpec::new("blocks", "Add a blocks extension")
+            .with_long(
+                "Register a blocks UI extension in godaddy.toml. A blocks extension is a \
+                JavaScript bundle that provides content blocks within a store. Only one \
+                blocks extension is supported per application; running this command again \
+                will overwrite the existing entry. Run `application deploy` to bundle and \
+                upload.",
+            )
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_output_schema::<ExtensionBlocks>()
@@ -1126,7 +1235,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 clap::Arg::new("source")
                     .long("source")
                     .required(true)
-                    .help("Source file path"),
+                    .help("Path to the JavaScript entry-point file for the blocks extension"),
             ),
         |ctx| async move {
             let source = arg_str(&ctx, "source").to_owned();

--- a/rust/src/contacts/mod.rs
+++ b/rust/src/contacts/mod.rs
@@ -102,24 +102,32 @@ impl Contact {
     /// code. `encoding` is reported honestly: `ASCII` when every field is ASCII,
     /// else `UTF-8`, so accented names/addresses aren't mislabeled.
     pub fn to_api(&self, role: Role) -> Result<api::ContactDomainCreate, String> {
-        let country = api::AddressCountry::try_from(self.country.to_ascii_uppercase().as_str())
-            .map_err(|_| {
-                format!(
-                    "{} contact in contacts.toml has invalid country {:?} \
-                     (expected a two-letter ISO code, e.g. US)",
-                    role.label(),
-                    self.country,
-                )
-            })?;
+        let country_upper = self.country.to_ascii_uppercase();
+        let country = api::AddressCountry::try_from(country_upper.as_str()).map_err(|_| {
+            format!(
+                "{} contact in contacts.toml has invalid country {:?} \
+                 (expected a two-letter ISO code, e.g. US)",
+                role.label(),
+                self.country,
+            )
+        })?;
         let encoding = if self.is_all_ascii() {
             api::ContactDomainCreateEncoding::Ascii
         } else {
             api::ContactDomainCreateEncoding::Utf8
         };
+        // Normalize phone (required) and fax (optional, only when present) to the
+        // API's `+<code>.<number>` format so common inputs aren't rejected with a
+        // cryptic 422.
+        let phone = normalize_phone(&self.phone, &country_upper, "phone", role)?;
+        let fax = match empty_to_none(&self.fax) {
+            Some(f) => Some(normalize_phone(&f, &country_upper, "fax", role)?),
+            None => None,
+        };
         Ok(api::ContactDomainCreate {
             address_mailing: api::Address {
                 address1: self.address1.clone(),
-                address2: self.address2.clone(),
+                address2: empty_to_none(&self.address2),
                 city: self.city.clone(),
                 country,
                 postal_code: self.postal_code.clone(),
@@ -127,14 +135,14 @@ impl Contact {
             },
             email: self.email.clone(),
             encoding,
-            fax: self.fax.clone(),
-            job_title: self.job_title.clone(),
+            fax,
+            job_title: empty_to_none(&self.job_title),
             metadata: Default::default(),
             name_first: self.name_first.clone(),
             name_last: self.name_last.clone(),
-            name_middle: self.name_middle.clone(),
-            organization: self.organization.clone(),
-            phone: self.phone.clone(),
+            name_middle: empty_to_none(&self.name_middle),
+            organization: empty_to_none(&self.organization),
+            phone,
         })
     }
 
@@ -163,6 +171,46 @@ impl Contact {
                 .iter()
                 .all(|o| o.as_deref().is_none_or(str::is_ascii))
     }
+}
+
+/// Trim an optional string and treat an empty value as absent. A blank optional
+/// field in `contacts.toml` (e.g. `address2 = ""`) would otherwise deserialize to
+/// `Some("")` and be sent as `"address2": ""`; the Domains API enforces a minimum
+/// length of 1 on these optional fields when present, so an empty string is
+/// rejected with a `LENGTH_UNDER` 422. Returning `None` lets serde omit the field
+/// entirely (the generated types `skip_serializing_if = Option::is_none`).
+fn empty_to_none(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+/// Normalize a user-entered phone or fax number to the Domains API format
+/// `+<country-calling-code>.<national-number>` (e.g. `+1.4805551212`), matching the
+/// API's required pattern `^\+([0-9]){1,3}\.([0-9] ?){5,14}$`.
+///
+/// `region` is the contact's two-letter ISO country, used as the default region so
+/// a number typed without a `+` country prefix (e.g. a local `07793 601890`) still
+/// parses. Returns a human-readable error (surfaced by `domain purchase`, like the
+/// invalid-country error) when the value can't be parsed as a phone number, rather
+/// than forwarding it and letting the API reject it opaquely.
+fn normalize_phone(raw: &str, region: &str, field: &str, role: Role) -> Result<String, String> {
+    let region_id = region.parse::<phonenumber::country::Id>().ok();
+    let number = phonenumber::parse(region_id, raw).map_err(|_| {
+        format!(
+            "{} contact in contacts.toml has an unrecognized {} {:?} \
+             (expected a phone number like +1.4805551212)",
+            role.label(),
+            field,
+            raw,
+        )
+    })?;
+    // `NationalNumber`'s Display preserves significant leading zeros (e.g. Italy),
+    // so this is correct for every region, not just those whose national number is
+    // a plain integer.
+    Ok(format!("+{}.{}", number.code().value(), number.national()))
 }
 
 impl ContactsFile {
@@ -350,6 +398,107 @@ country = "ZZ"
             .expect_err("ZZ is not a valid ISO country");
         assert!(err.contains("invalid country"));
         assert!(err.contains("registrant"));
+    }
+
+    /// Build a single-registrant `ContactsFile` from a `[registrant]` TOML body.
+    fn registrant(body: &str) -> api::ContactDomainCreate {
+        let toml = format!("[registrant]\n{body}");
+        let file: ContactsFile = toml::from_str(&toml).expect("parses");
+        file.to_api(Role::Registrant)
+            .expect("valid")
+            .expect("present")
+    }
+
+    const GB_BASE: &str = r#"name_first = "Jane"
+name_last = "Doe"
+email = "jane@example.com"
+address1 = "10 Downing St"
+city = "London"
+state = "London"
+postal_code = "SW1A 2AA"
+country = "GB"
+"#;
+
+    #[test]
+    fn gb_phone_common_formats_normalize_to_dotted() {
+        // International (no separator), international (spaced), and bare local —
+        // all the same UK number — normalize to the API's `+44.7793601890`.
+        for input in ["+447793601890", "+44 7793 601890", "07793 601890"] {
+            let c = registrant(&format!("{GB_BASE}phone = \"{input}\"\n"));
+            assert_eq!(c.phone, "+44.7793601890", "input {input:?}");
+        }
+    }
+
+    #[test]
+    fn us_phone_normalizes_to_dotted() {
+        let body = r#"name_first = "Ada"
+name_last = "Lovelace"
+email = "ada@example.com"
+phone = "(480) 555-1212"
+address1 = "1 Main"
+city = "Tempe"
+state = "AZ"
+postal_code = "85281"
+country = "US"
+"#;
+        assert_eq!(registrant(body).phone, "+1.4805551212");
+    }
+
+    #[test]
+    fn already_dotted_phone_is_preserved() {
+        let c = registrant(&format!("{GB_BASE}phone = \"+1.4805551212\"\n"));
+        assert_eq!(c.phone, "+1.4805551212");
+    }
+
+    #[test]
+    fn unparseable_phone_errors_with_role_and_example() {
+        let toml = format!("[registrant]\n{GB_BASE}phone = \"not-a-phone\"\n");
+        let file: ContactsFile = toml::from_str(&toml).expect("parses");
+        let err = file
+            .to_api(Role::Registrant)
+            .expect_err("garbage phone is rejected");
+        assert!(err.contains("registrant"), "got: {err}");
+        assert!(err.contains("phone"), "got: {err}");
+        assert!(err.contains("+1.4805551212"), "got: {err}");
+    }
+
+    #[test]
+    fn blank_address2_is_omitted() {
+        // The #33 regression: `address2 = ""` must not be sent (would 422 with
+        // LENGTH_UNDER). A whitespace-only value is likewise omitted.
+        for blank in ["\"\"", "\"   \""] {
+            let c = registrant(&format!(
+                "{GB_BASE}phone = \"+44.7793601890\"\naddress2 = {blank}\n"
+            ));
+            assert_eq!(c.address_mailing.address2, None, "blank {blank}");
+        }
+    }
+
+    #[test]
+    fn non_empty_address2_is_preserved() {
+        let c = registrant(&format!(
+            "{GB_BASE}phone = \"+44.7793601890\"\naddress2 = \"Flat 2\"\n"
+        ));
+        assert_eq!(c.address_mailing.address2.as_deref(), Some("Flat 2"));
+    }
+
+    #[test]
+    fn blank_optional_text_fields_are_omitted() {
+        let c = registrant(&format!(
+            "{GB_BASE}phone = \"+44.7793601890\"\norganization = \"\"\njob_title = \"\"\nname_middle = \"\"\nfax = \"\"\n"
+        ));
+        assert_eq!(c.organization, None);
+        assert_eq!(c.job_title, None);
+        assert_eq!(c.name_middle, None);
+        assert_eq!(c.fax, None);
+    }
+
+    #[test]
+    fn present_fax_is_normalized() {
+        let c = registrant(&format!(
+            "{GB_BASE}phone = \"+44.7793601890\"\nfax = \"07793 601891\"\n"
+        ));
+        assert_eq!(c.fax.as_deref(), Some("+44.7793601891"));
     }
 
     #[test]

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -233,246 +233,280 @@ fn with_record_write_args(spec: CommandSpec) -> CommandSpec {
 
 pub fn module() -> Module {
     Module::new("DNS", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new("dns", "Manage a domain's DNS records"))
-            // --- list -------------------------------------------------------
-            .with_command(RuntimeCommandSpec::new_with_context(
-                CommandSpec::new("list", "List DNS records for a domain")
-                    .with_system("domain")
-                    .with_tier(Tier::Read)
-                    .with_default_fields("type,name,data,ttl")
-                    .with_json_schema::<types::DnsRecord>()
-                    .with_scopes(&[DOMAINS_READ_SCOPE])
-                    .with_arg(
-                        clap::Arg::new("domain")
-                            .value_name("DOMAIN")
-                            .required(true)
-                            .help("Domain whose records to list (e.g. example.com)"),
-                    )
-                    .with_arg(
-                        clap::Arg::new("type")
-                            .long("type")
-                            .value_name("TYPE")
-                            .value_parser(parse_type_arg)
-                            .help(
-                                "Only records of this type (A, AAAA, CNAME, MX, NS, SOA, SRV, TXT)",
-                            ),
-                    )
-                    .with_arg(
-                        clap::Arg::new("name")
-                            .long("name")
-                            .value_name("NAME")
-                            // The API only filters by name within a type, so clap
-                            // enforces `--name` requires `--type` at parse time.
-                            .requires("type")
-                            .help("Only records with this name (requires --type)"),
-                    ),
-                // Output pagination is the engine's job: the global, client-side
-                // `--limit`/`--offset` flags slice the returned list. We don't
-                // expose the API's server-side offset/limit (it would double-skip
-                // against the client-side `--offset`), so `record_get` is called
-                // without them.
-                |ctx| async move {
-                    let domain = arg_str(&ctx, "domain").unwrap_or_default();
-                    // `--type` is validated + upper-cased by clap's value parser,
-                    // and `--name` requires `--type`, so these can be used as-is.
-                    let type_opt = arg_str(&ctx, "type");
-                    let name_opt = arg_str(&ctx, "name");
-
-                    let client = make_client(&ctx).await?;
-                    let records = match (type_opt.as_deref(), name_opt.as_deref()) {
-                        (None, _) => client
-                            .record_get_all()
-                            .domain(domain.as_str())
-                            .send()
-                            .await
-                            .map_err(|e| {
-                                CliCoreError::message(format!("listing DNS records failed: {e}"))
-                            })?
-                            .into_inner(),
-                        (Some(record_type), None) => client
-                            .record_get_by_type()
-                            .domain(domain.as_str())
-                            .type_(record_type)
-                            .send()
-                            .await
-                            .map_err(|e| {
-                                CliCoreError::message(format!("listing DNS records failed: {e}"))
-                            })?
-                            .into_inner(),
-                        (Some(record_type), Some(name)) => client
-                            .record_get()
-                            .domain(domain.as_str())
-                            .type_(record_type)
-                            .name(name)
-                            .send()
-                            .await
-                            .map_err(|e| {
-                                CliCoreError::message(format!("listing DNS records failed: {e}"))
-                            })?
-                            .into_inner(),
-                    };
-
-                    // Serialize each record to an object so `--fields` and the
-                    // default-field projection have `type`/`name`/`data`/`ttl`.
-                    let out: Vec<Value> = records
-                        .iter()
-                        .map(serde_json::to_value)
-                        .collect::<Result<_, _>>()
-                        .map_err(|e| {
-                            CliCoreError::message(format!("failed to serialize DNS records: {e}"))
-                        })?;
-                    Ok(CommandResult::new(json!(out)))
-                },
-            ))
-            // --- add --------------------------------------------------------
-            .with_command(RuntimeCommandSpec::new_with_context(
-                with_record_write_args(
-                    CommandSpec::new(
-                        "add",
-                        "Add DNS records to a domain (appends; non-destructive)",
-                    )
-                    .with_system("domain")
-                    .with_tier(Tier::Mutate)
-                    .with_default_fields("domain,type,name,records")
-                    .with_output_schema::<DnsWriteResult>()
-                    .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE]),
-                ),
-                |ctx| async move {
-                    let domain = arg_str(&ctx, "domain").unwrap_or_default();
-                    // `--type` is validated + upper-cased by clap's value parser.
-                    let record_type = arg_str(&ctx, "type").unwrap_or_default();
-                    let name = arg_str(&ctx, "name").unwrap_or_default();
-                    let data = string_list(&ctx, "data");
-                    let ty = types::DnsRecordType::try_from(record_type.as_str())
-                        .expect("--type value parser guarantees a valid record type");
-                    let opts = RecordOptions::from_ctx(&ctx);
-                    let records = dns_records(&name, ty, &data, &opts);
-                    let count = records.len();
-
-                    let client = make_client(&ctx).await?;
-                    client
-                        .record_add()
-                        .domain(domain.as_str())
-                        .body(records)
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            CliCoreError::message(format!("adding DNS records failed: {e}"))
-                        })?;
-
-                    Ok(CommandResult::new(json!({
-                        "domain": domain,
-                        "type": record_type,
-                        "name": name,
-                        "records": count,
-                        "action": "add",
-                    })))
-                },
-            ))
-            // --- set --------------------------------------------------------
-            .with_command(RuntimeCommandSpec::new_with_context(
-                with_record_write_args(
-                    CommandSpec::new(
-                        "set",
-                        "Replace all records for a type+name (destructive: overwrites existing)",
-                    )
-                    .with_system("domain")
-                    .with_tier(Tier::Destructive)
-                    .with_default_fields("domain,type,name,records")
-                    .with_output_schema::<DnsWriteResult>()
-                    .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE]),
-                ),
-                |ctx| async move {
-                    let domain = arg_str(&ctx, "domain").unwrap_or_default();
-                    // `--type` is validated + upper-cased by clap's value parser.
-                    let record_type = arg_str(&ctx, "type").unwrap_or_default();
-                    let name = arg_str(&ctx, "name").unwrap_or_default();
-                    let data = string_list(&ctx, "data");
-                    let opts = RecordOptions::from_ctx(&ctx);
-                    let records = create_type_name_records(&data, &opts);
-                    let count = records.len();
-
-                    let client = make_client(&ctx).await?;
-                    client
-                        .record_replace_type_name()
-                        .domain(domain.as_str())
-                        .type_(record_type.as_str())
-                        .name(name.as_str())
-                        .body(records)
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            CliCoreError::message(format!("replacing DNS records failed: {e}"))
-                        })?;
-
-                    Ok(CommandResult::new(json!({
-                        "domain": domain,
-                        "type": record_type,
-                        "name": name,
-                        "records": count,
-                        "action": "replace",
-                    })))
-                },
-            ))
-            // --- delete -----------------------------------------------------
-            .with_command(RuntimeCommandSpec::new_with_context(
-                CommandSpec::new(
-                    "delete",
-                    "Delete all records for a type+name (destructive: removes existing)",
+        RuntimeGroupSpec::new(
+            GroupSpec::new("dns", "Manage a domain's DNS records").with_long(
+                "Create, read, and delete DNS records for a GoDaddy-managed domain. \
+                 `add` appends new records without touching existing ones; `set` replaces \
+                 every record for a given type+name pair; `delete` removes all records for \
+                 a type+name pair. `set` and `delete` are destructive; pass `--dry-run` to \
+                 preview the change without writing it.",
+            ),
+        )
+        // --- list -------------------------------------------------------
+        .with_command(RuntimeCommandSpec::new_with_context(
+            CommandSpec::new("list", "List DNS records for a domain")
+                .with_long(
+                    "Retrieves DNS records for a domain. Without filters, returns all \
+                         record types. Use `--type` to narrow to one record type, and \
+                         `--name` (requires `--type`) to further narrow to a specific name. \
+                         Requires the `domains.domain:read` scope.",
                 )
                 .with_system("domain")
-                .with_tier(Tier::Destructive)
-                .with_default_fields("domain,type,name,deleted")
-                .with_output_schema::<DnsDeleteResult>()
-                .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE])
+                .with_tier(Tier::Read)
+                .with_default_fields("type,name,data,ttl")
+                .with_json_schema::<types::DnsRecord>()
+                .with_scopes(&[DOMAINS_READ_SCOPE])
                 .with_arg(
                     clap::Arg::new("domain")
                         .value_name("DOMAIN")
                         .required(true)
-                        .help("Domain whose records to delete (e.g. example.com)"),
+                        .help("Domain whose records to list (e.g. example.com)"),
                 )
                 .with_arg(
                     clap::Arg::new("type")
                         .long("type")
                         .value_name("TYPE")
-                        .required(true)
-                        .value_parser(parse_deletable_type_arg)
-                        .help("Record type (one of A, AAAA, CNAME, MX, SRV, TXT)"),
+                        .value_parser(parse_type_arg)
+                        .help("Only records of this type (A, AAAA, CNAME, MX, NS, SOA, SRV, TXT)"),
                 )
                 .with_arg(
                     clap::Arg::new("name")
                         .long("name")
                         .value_name("NAME")
-                        .required(true)
-                        .help("Record name relative to the domain (e.g. www)"),
+                        // The API only filters by name within a type, so clap
+                        // enforces `--name` requires `--type` at parse time.
+                        .requires("type")
+                        .help("Only records with this name (requires --type)"),
                 ),
-                |ctx| async move {
-                    let domain = arg_str(&ctx, "domain").unwrap_or_default();
-                    // `--type` is validated (and NS/SOA rejected) + upper-cased by
-                    // clap's value parser, so it converts to the delete enum cleanly.
-                    let record_type = arg_str(&ctx, "type").unwrap_or_default();
-                    let name = arg_str(&ctx, "name").unwrap_or_default();
+            // Output pagination is the engine's job: the global, client-side
+            // `--limit`/`--offset` flags slice the returned list. We don't
+            // expose the API's server-side offset/limit (it would double-skip
+            // against the client-side `--offset`), so `record_get` is called
+            // without them.
+            |ctx| async move {
+                let domain = arg_str(&ctx, "domain").unwrap_or_default();
+                // `--type` is validated + upper-cased by clap's value parser,
+                // and `--name` requires `--type`, so these can be used as-is.
+                let type_opt = arg_str(&ctx, "type");
+                let name_opt = arg_str(&ctx, "name");
 
-                    let client = make_client(&ctx).await?;
-                    client
-                        .record_delete_type_name()
+                let client = make_client(&ctx).await?;
+                let records = match (type_opt.as_deref(), name_opt.as_deref()) {
+                    (None, _) => client
+                        .record_get_all()
                         .domain(domain.as_str())
-                        .type_(record_type.as_str())
-                        .name(name.as_str())
                         .send()
                         .await
                         .map_err(|e| {
-                            CliCoreError::message(format!("deleting DNS records failed: {e}"))
-                        })?;
+                            CliCoreError::message(format!("listing DNS records failed: {e}"))
+                        })?
+                        .into_inner(),
+                    (Some(record_type), None) => client
+                        .record_get_by_type()
+                        .domain(domain.as_str())
+                        .type_(record_type)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            CliCoreError::message(format!("listing DNS records failed: {e}"))
+                        })?
+                        .into_inner(),
+                    (Some(record_type), Some(name)) => client
+                        .record_get()
+                        .domain(domain.as_str())
+                        .type_(record_type)
+                        .name(name)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            CliCoreError::message(format!("listing DNS records failed: {e}"))
+                        })?
+                        .into_inner(),
+                };
 
-                    Ok(CommandResult::new(json!({
-                        "domain": domain,
-                        "type": record_type,
-                        "name": name,
-                        "deleted": true,
-                    })))
-                },
-            ))
+                // Serialize each record to an object so `--fields` and the
+                // default-field projection have `type`/`name`/`data`/`ttl`.
+                let out: Vec<Value> = records
+                    .iter()
+                    .map(serde_json::to_value)
+                    .collect::<Result<_, _>>()
+                    .map_err(|e| {
+                        CliCoreError::message(format!("failed to serialize DNS records: {e}"))
+                    })?;
+                Ok(CommandResult::new(json!(out)))
+            },
+        ))
+        // --- add --------------------------------------------------------
+        .with_command(RuntimeCommandSpec::new_with_context(
+            with_record_write_args(
+                CommandSpec::new(
+                    "add",
+                    "Add DNS records to a domain (appends; non-destructive)",
+                )
+                .with_long(
+                    "Appends one or more DNS records to a domain without modifying any \
+                         existing records. Pass `--data` once per record value to add \
+                         multiple records for the same type+name in a single call. \
+                         Use `dns set` instead if you need to replace the full record \
+                         set for a type+name.",
+                )
+                .with_system("domain")
+                .with_tier(Tier::Mutate)
+                .with_default_fields("domain,type,name,records")
+                .with_output_schema::<DnsWriteResult>()
+                .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE]),
+            ),
+            |ctx| async move {
+                let domain = arg_str(&ctx, "domain").unwrap_or_default();
+                // `--type` is validated + upper-cased by clap's value parser.
+                let record_type = arg_str(&ctx, "type").unwrap_or_default();
+                let name = arg_str(&ctx, "name").unwrap_or_default();
+                let data = string_list(&ctx, "data");
+                let ty = types::DnsRecordType::try_from(record_type.as_str())
+                    .expect("--type value parser guarantees a valid record type");
+                let opts = RecordOptions::from_ctx(&ctx);
+                let records = dns_records(&name, ty, &data, &opts);
+                let count = records.len();
+
+                let client = make_client(&ctx).await?;
+                client
+                    .record_add()
+                    .domain(domain.as_str())
+                    .body(records)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        CliCoreError::message(format!("adding DNS records failed: {e}"))
+                    })?;
+
+                Ok(CommandResult::new(json!({
+                    "domain": domain,
+                    "type": record_type,
+                    "name": name,
+                    "records": count,
+                    "action": "add",
+                })))
+            },
+        ))
+        // --- set --------------------------------------------------------
+        .with_command(RuntimeCommandSpec::new_with_context(
+            with_record_write_args(
+                CommandSpec::new(
+                    "set",
+                    "Replace all records for a type+name (destructive: overwrites existing)",
+                )
+                .with_long(
+                    "Replaces every DNS record for the given type+name pair with the \
+                         values supplied via `--data`, discarding any records that were \
+                         there before. This operation is destructive and irreversible — \
+                         use `dns list --type <type> --name <name>` to review the current \
+                         state first. Use `dns add` to append records without removing \
+                         existing ones.",
+                )
+                .with_system("domain")
+                .with_tier(Tier::Destructive)
+                .with_default_fields("domain,type,name,records")
+                .with_output_schema::<DnsWriteResult>()
+                .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE]),
+            ),
+            |ctx| async move {
+                let domain = arg_str(&ctx, "domain").unwrap_or_default();
+                // `--type` is validated + upper-cased by clap's value parser.
+                let record_type = arg_str(&ctx, "type").unwrap_or_default();
+                let name = arg_str(&ctx, "name").unwrap_or_default();
+                let data = string_list(&ctx, "data");
+                let opts = RecordOptions::from_ctx(&ctx);
+                let records = create_type_name_records(&data, &opts);
+                let count = records.len();
+
+                let client = make_client(&ctx).await?;
+                client
+                    .record_replace_type_name()
+                    .domain(domain.as_str())
+                    .type_(record_type.as_str())
+                    .name(name.as_str())
+                    .body(records)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        CliCoreError::message(format!("replacing DNS records failed: {e}"))
+                    })?;
+
+                Ok(CommandResult::new(json!({
+                    "domain": domain,
+                    "type": record_type,
+                    "name": name,
+                    "records": count,
+                    "action": "replace",
+                })))
+            },
+        ))
+        // --- delete -----------------------------------------------------
+        .with_command(RuntimeCommandSpec::new_with_context(
+            CommandSpec::new(
+                "delete",
+                "Delete all records for a type+name (destructive: removes existing)",
+            )
+            .with_long(
+                "Removes every DNS record matching the given type+name pair. This \
+                     operation is destructive and irreversible — all matching records are \
+                     deleted in one call. NS and SOA records are GoDaddy-managed and \
+                     cannot be deleted. Use `dns list` to confirm what will be removed \
+                     before running this command.",
+            )
+            .with_system("domain")
+            .with_tier(Tier::Destructive)
+            .with_default_fields("domain,type,name,deleted")
+            .with_output_schema::<DnsDeleteResult>()
+            .with_scopes(&[DOMAINS_DNS_UPDATE_SCOPE])
+            .with_arg(
+                clap::Arg::new("domain")
+                    .value_name("DOMAIN")
+                    .required(true)
+                    .help("Domain whose records to delete (e.g. example.com)"),
+            )
+            .with_arg(
+                clap::Arg::new("type")
+                    .long("type")
+                    .value_name("TYPE")
+                    .required(true)
+                    .value_parser(parse_deletable_type_arg)
+                    .help("Record type (one of A, AAAA, CNAME, MX, SRV, TXT)"),
+            )
+            .with_arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_name("NAME")
+                    .required(true)
+                    .help("Record name relative to the domain (e.g. www)"),
+            ),
+            |ctx| async move {
+                let domain = arg_str(&ctx, "domain").unwrap_or_default();
+                // `--type` is validated (and NS/SOA rejected) + upper-cased by
+                // clap's value parser, so it converts to the delete enum cleanly.
+                let record_type = arg_str(&ctx, "type").unwrap_or_default();
+                let name = arg_str(&ctx, "name").unwrap_or_default();
+
+                let client = make_client(&ctx).await?;
+                client
+                    .record_delete_type_name()
+                    .domain(domain.as_str())
+                    .type_(record_type.as_str())
+                    .name(name.as_str())
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        CliCoreError::message(format!("deleting DNS records failed: {e}"))
+                    })?;
+
+                Ok(CommandResult::new(json!({
+                    "domain": domain,
+                    "type": record_type,
+                    "name": name,
+                    "deleted": true,
+                })))
+            },
+        ))
     })
 }
 

--- a/rust/src/domain/mod.rs
+++ b/rust/src/domain/mod.rs
@@ -353,9 +353,10 @@ struct ApiErrorBody {
     fields: Vec<ApiFieldError>,
 }
 
-/// One entry in a validation error's `fields` array. The API's `message` is
-/// deliberately not surfaced to users — it embeds raw regex — but is captured so
-/// the shape deserializes cleanly.
+/// One entry in a validation error's `fields` array. Only `code` and `path` are
+/// deserialized; the API's per-field `message` is intentionally dropped (it embeds
+/// raw regex we don't want to surface), and serde tolerates that and any other
+/// unknown fields.
 #[derive(serde::Deserialize)]
 struct ApiFieldError {
     #[serde(default)]

--- a/rust/src/domain/mod.rs
+++ b/rust/src/domain/mod.rs
@@ -315,10 +315,15 @@ fn format_api_error(
     debug: bool,
 ) -> String {
     let body = body.trim();
-    let mut msg = if body.is_empty() {
-        format!("{action} failed (HTTP {status_display})")
-    } else {
-        format!("{action} failed (HTTP {status_display}): {body}")
+    // When the body is a structured validation error (`INVALID_BODY` with a
+    // `fields` array), translate each field into plain English rather than pasting
+    // the raw JSON — whose per-field `message` strings embed the failing regex
+    // (e.g. a full UK-postcode pattern), which is noise to a user.
+    let friendly = friendly_field_errors(body);
+    let mut msg = match &friendly {
+        Some(detail) => format!("{action} failed (HTTP {status_display}):\n{detail}"),
+        None if body.is_empty() => format!("{action} failed (HTTP {status_display})"),
+        None => format!("{action} failed (HTTP {status_display}): {body}"),
     };
     if status == 402 {
         msg.push_str(
@@ -327,10 +332,142 @@ fn format_api_error(
              purchases), then try again.",
         );
     }
-    if debug && let Some(id) = request_id.map(str::trim).filter(|s| !s.is_empty()) {
-        msg.push_str(&format!("\n\nRequest ID: {id}"));
+    if debug {
+        // When we replaced the raw body with a friendly summary, the original JSON
+        // is still useful for debugging — surface it (only) here.
+        if friendly.is_some() && !body.is_empty() {
+            msg.push_str(&format!("\n\nResponse body: {body}"));
+        }
+        if let Some(id) = request_id.map(str::trim).filter(|s| !s.is_empty()) {
+            msg.push_str(&format!("\n\nRequest ID: {id}"));
+        }
     }
     msg
+}
+
+/// A Domains API validation error body: `{"code":..., "message":..., "fields":[...]}`.
+/// Only `fields` is needed to build friendly output; the rest is ignored.
+#[derive(serde::Deserialize)]
+struct ApiErrorBody {
+    #[serde(default)]
+    fields: Vec<ApiFieldError>,
+}
+
+/// One entry in a validation error's `fields` array. The API's `message` is
+/// deliberately not surfaced to users — it embeds raw regex — but is captured so
+/// the shape deserializes cleanly.
+#[derive(serde::Deserialize)]
+struct ApiFieldError {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    path: String,
+}
+
+/// Render a structured validation error as a plain-English bullet list, or `None`
+/// when `body` isn't a field-level validation error (so the caller falls back to
+/// the raw body). `None` also covers non-JSON bodies and JSON without `fields`.
+fn friendly_field_errors(body: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<ApiErrorBody>(body).ok()?;
+    if parsed.fields.is_empty() {
+        return None;
+    }
+    let lines: Vec<String> = parsed
+        .fields
+        .iter()
+        .map(|f| format!("  • {}", describe_field_error(f)))
+        .collect();
+    Some(format!("some fields are invalid:\n{}", lines.join("\n")))
+}
+
+/// One readable line for a field error, e.g.
+/// `registrant mailing address line 2 is too short (leave it blank to omit it)`.
+fn describe_field_error(f: &ApiFieldError) -> String {
+    let name = friendly_field_name(&f.path);
+    let problem = match f.code.as_str() {
+        "LENGTH_UNDER" | "MIN_LENGTH" | "TOO_SHORT" => "is too short",
+        "LENGTH_OVER" | "MAX_LENGTH" | "TOO_LONG" => "is too long",
+        "PATTERN" | "INVALID_FORMAT" | "INVALID_PATTERN" => "is not in the required format",
+        "REQUIRED" | "MISSING" | "MISSING_REQUIRED_FIELD" => "is required",
+        _ => "is invalid",
+    };
+    match field_hint(&f.path, &f.code) {
+        Some(hint) => format!("{name} {problem} ({hint})"),
+        None => format!("{name} {problem}"),
+    }
+}
+
+/// A field-specific hint keyed on the path's leaf and the error code, or `None`.
+fn field_hint(path: &str, code: &str) -> Option<&'static str> {
+    let leaf = path.rsplit('.').next().unwrap_or(path);
+    match (leaf, code) {
+        ("phone", _) | ("fax", _) => Some("expected a format like +1.4805551212"),
+        ("postalCode", "PATTERN" | "INVALID_FORMAT" | "INVALID_PATTERN") => {
+            Some("some countries require a specific format, e.g. UK SW1A 2AA")
+        }
+        ("address2", "LENGTH_UNDER" | "MIN_LENGTH" | "TOO_SHORT") => {
+            Some("leave it blank to omit it")
+        }
+        _ => None,
+    }
+}
+
+/// Turn an API field path (`body.contacts.registrant.addressMailing.address2`)
+/// into a human phrase (`registrant mailing address line 2`). Falls back to a
+/// space-joined, camelCase-split rendering for unrecognized paths.
+fn friendly_field_name(path: &str) -> String {
+    let trimmed = path.strip_prefix("body.").unwrap_or(path);
+    let segments: Vec<&str> = trimmed.split('.').filter(|s| !s.is_empty()).collect();
+    // contacts.<role>.<rest...> — lead with the role so the user knows which
+    // contact (registrant/admin/billing/tech) the error is about.
+    if let ["contacts", role, rest @ ..] = segments.as_slice() {
+        let mut parts = vec![humanize_segment(role)];
+        parts.extend(rest.iter().map(|s| humanize_segment(s)));
+        return parts.join(" ");
+    }
+    if segments.is_empty() {
+        return path.to_string();
+    }
+    segments
+        .iter()
+        .map(|s| humanize_segment(s))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Humanize a single path segment, mapping the API's contact/address field names
+/// to friendly words and otherwise splitting camelCase into lowercase words.
+fn humanize_segment(seg: &str) -> String {
+    match seg {
+        "addressMailing" => "mailing address".to_string(),
+        "addressBilling" => "billing address".to_string(),
+        "address1" => "line 1".to_string(),
+        "address2" => "line 2".to_string(),
+        "postalCode" => "postal code".to_string(),
+        "nameFirst" => "first name".to_string(),
+        "nameLast" => "last name".to_string(),
+        "nameMiddle" => "middle name".to_string(),
+        "jobTitle" => "job title".to_string(),
+        "agreedAt" => "agreed-at timestamp".to_string(),
+        other => split_camel_case(other),
+    }
+}
+
+/// Split a camelCase identifier into space-separated lowercase words
+/// (`nationalNumber` → `national number`). Leaves already-lowercase words as-is.
+fn split_camel_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.char_indices() {
+        if ch.is_ascii_uppercase() {
+            if i != 0 {
+                out.push(' ');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 /// `DomainPurchase` request fields this CLI can populate (other than the four
@@ -418,9 +555,24 @@ pub fn module() -> Module {
         RuntimeGroupSpec::new(GroupSpec::new(
             "domain",
             "List your domains, check availability, and get suggestions",
+        ).with_long(
+            "Work with domains on your GoDaddy account and the public registry.\n\
+             \n\
+             • list / get        — your existing domains and their details\n\
+             • available / suggest — find a name to register\n\
+             • agreements / schema — see what a TLD requires before you buy\n\
+             • purchase          — register a new domain (charges your account)\n\
+             \n\
+             Reads need the `domains.domain:read` scope; purchase also needs\n\
+             `domains.domain:create`. Manage a domain's DNS with `gddy dns`.",
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
             CommandSpec::new("list", "List the domains in your account")
+                .with_long(
+                    "List the domains registered to your account. Shows domain, status, \
+                     expiry, and auto-renew by default; use --fields to pick columns and \
+                     --status to filter (repeatable).",
+                )
                 .with_system("domain")
                 .with_tier(Tier::Read)
                 .with_default_fields("domain,status,expires,renewAuto")
@@ -465,6 +617,11 @@ pub fn module() -> Module {
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
             CommandSpec::new("get", "Show full details for one of your domains")
+                .with_long(
+                    "Show every detail for a single domain in your account (status, \
+                     expiry, contacts, nameservers, and more). Unlike `list`, this shows \
+                     all fields by default. The domain must be one you own.",
+                )
                 .with_system("domain")
                 .with_tier(Tier::Read)
                 // No default fields: `get` is a single-domain deep-dive, so show
@@ -501,6 +658,12 @@ pub fn module() -> Module {
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
             CommandSpec::new("available", "Check whether a domain is available")
+                .with_long(
+                    "Check whether a domain can be registered, and at what price. \
+                     --check-type fast trades accuracy for speed; full is authoritative \
+                     (the `definitive` field tells you which you got). Pass --for-transfer \
+                     to also report names available to transfer in.",
+                )
                 .with_system("domain")
                 .with_tier(Tier::Read)
                 .with_default_fields("domain,available,definitive,price,currency")
@@ -597,6 +760,12 @@ pub fn module() -> Module {
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
             CommandSpec::new("suggest", "Suggest available domains for a query")
+                .with_long(
+                    "Suggest available domains from a seed word, phrase, or domain. \
+                     Narrow results with --tlds (repeatable), cap them with --limit, and \
+                     bias toward a region with --country/--city. Feed a promising result \
+                     straight into `gddy domain available`.",
+                )
                 .with_system("domain")
                 .with_tier(Tier::Read)
                 .with_default_fields("domain")
@@ -694,6 +863,11 @@ pub fn module() -> Module {
                 "agreements",
                 "Show the legal agreements required to register a TLD",
             )
+            .with_long(
+                "List the legal agreements you must consent to before registering under \
+                 a TLD. Review these before running `gddy domain purchase --agree`, which \
+                 records consent to exactly these agreements on your behalf.",
+            )
             .with_system("domain")
             .with_tier(Tier::Read)
             .with_default_fields("agreementKey,title,url")
@@ -767,6 +941,12 @@ pub fn module() -> Module {
                 "schema",
                 "Show a TLD's requirements for registering a domain",
             )
+            .with_long(
+                "Show what a TLD requires to register under it — which contact roles are \
+                 mandatory and any TLD-specific fields (e.g. eligibility for some \
+                 country-code TLDs). Check this before `gddy domain purchase` so you know \
+                 which contacts to populate in contacts.toml.",
+            )
             .with_system("domain")
             .with_tier(Tier::Read)
             .with_default_fields("required")
@@ -798,6 +978,24 @@ pub fn module() -> Module {
         ))
         .with_command(RuntimeCommandSpec::new_with_context(
             CommandSpec::new("purchase", "Register a domain (paid; charges your account)")
+                .with_long(
+                    "Register a domain. This charges your GoDaddy account and cannot be \
+                     undone, so it is gated behind --confirm.\n\
+                     \n\
+                     Before it charges, the command checks the TLD's requirements and the \
+                     domain's availability, then records your consent to the TLD's legal \
+                     agreements (--agree). Contacts come from your account by default; to \
+                     override them, define registrant/admin/billing/tech in contacts.toml \
+                     (scaffold one with `gddy domain contacts init`). A usable payment \
+                     method must be on file — add one with `gddy payments add`.\n\
+                     \n\
+                     Typical flow:\n  \
+                     1. gddy domain available example.com\n  \
+                     2. gddy domain agreements --tld com   # review what --agree consents to\n  \
+                     3. gddy domain purchase example.com --agree --confirm\n\
+                     \n\
+                     See `gddy guide domain-purchase` for the full walkthrough.",
+                )
                 .with_system("domain")
                 .with_tier(Tier::Destructive)
                 .with_default_fields("domain,status,price,currency")
@@ -1086,9 +1284,20 @@ pub fn module() -> Module {
             RuntimeGroupSpec::new(GroupSpec::new(
                 "contacts",
                 "Manage saved default contacts for domain purchases",
+            ).with_long(
+                "Manage the optional contacts.toml that supplies registrant/admin/billing/\
+                 tech contacts for `gddy domain purchase`. When a role is absent the \
+                 purchase falls back to your account's default contact for that role.",
             ))
             .with_command(RuntimeCommandSpec::new_with_context(
                 CommandSpec::new("init", "Write a starter contacts.toml you can edit")
+                    .with_long(
+                        "Scaffold a starter contacts.toml in your config directory with \
+                         every role commented out (so it's inert until you edit it). Fill \
+                         in any roles you want to override the account defaults for. Pass \
+                         --force to overwrite an existing file. Phone numbers are \
+                         normalized automatically, so common formats are accepted.",
+                    )
                     .with_system("domain")
                     // Local file write, no API call: dry-run aware, no auth.
                     .with_tier(Tier::Mutate)
@@ -1287,6 +1496,84 @@ mod tests {
         // Empty body omits the trailing colon.
         let empty = format_api_error("domain schema", 404, "404 Not Found", "", None, false);
         assert!(empty.ends_with("(HTTP 404 Not Found)"), "{empty}");
+    }
+
+    #[test]
+    fn validation_fields_render_as_plain_english_without_regex() {
+        // The #14 / #33 regression: an INVALID_BODY with a `fields` array must be
+        // translated, not pasted raw — and the raw per-field regex/message must not
+        // leak into the default (non-debug) output.
+        let body = r#"{"code":"INVALID_BODY","fields":[{"code":"LENGTH_UNDER","message":"does not meet minimum length of 1","path":"body.contacts.registrant.addressMailing.address2"}],"message":"Request body doesn't fulfill schema, see details in `fields`"}"#;
+        let msg = format_api_error(
+            "domain purchase",
+            422,
+            "422 Unprocessable Entity",
+            body,
+            None,
+            false,
+        );
+        assert!(msg.contains("registrant mailing address line 2"), "{msg}");
+        assert!(msg.contains("is too short"), "{msg}");
+        assert!(msg.contains("leave it blank to omit"), "{msg}");
+        // Raw path and the schema boilerplate message are suppressed.
+        assert!(!msg.contains("body.contacts"), "{msg}");
+        assert!(!msg.contains("minimum length of 1"), "{msg}");
+        assert!(!msg.contains("fulfill schema"), "{msg}");
+    }
+
+    #[test]
+    fn pattern_failure_gives_guidance_not_regex() {
+        // A postcode PATTERN failure: the API message would carry the full regex;
+        // we surface guidance instead.
+        let body = r#"{"code":"INVALID_BODY","fields":[{"code":"PATTERN","message":"must match ^([A-Z]{1,2}\\d[A-Z\\d]? ?\\d[A-Z]{2})$","path":"body.contacts.registrant.addressMailing.postalCode"}]}"#;
+        let msg = format_api_error(
+            "domain purchase",
+            422,
+            "422 Unprocessable Entity",
+            body,
+            None,
+            false,
+        );
+        assert!(
+            msg.contains("registrant mailing address postal code"),
+            "{msg}"
+        );
+        assert!(msg.contains("is not in the required format"), "{msg}");
+        assert!(msg.contains("SW1A 2AA"), "{msg}");
+        assert!(!msg.contains("[A-Z]"), "{msg}"); // no regex leaked
+    }
+
+    #[test]
+    fn phone_field_error_gives_dotted_example() {
+        let body = r#"{"fields":[{"code":"PATTERN","path":"body.contacts.registrant.phone"}]}"#;
+        let msg = format_api_error("domain purchase", 422, "422", body, None, false);
+        assert!(msg.contains("registrant phone"), "{msg}");
+        assert!(msg.contains("+1.4805551212"), "{msg}");
+    }
+
+    #[test]
+    fn raw_body_recoverable_under_debug_for_field_errors() {
+        let body = r#"{"fields":[{"code":"LENGTH_UNDER","path":"body.contacts.registrant.addressMailing.address2"}]}"#;
+        let debug = format_api_error("domain purchase", 422, "422", body, None, true);
+        assert!(debug.contains("Response body:"), "{debug}");
+        assert!(debug.contains("address2"), "{debug}"); // raw json present under --debug
+    }
+
+    #[test]
+    fn fieldless_json_body_is_passed_through() {
+        // No `fields` array -> keep the raw body (existing behavior relied on by the
+        // 402 path and any non-validation JSON error).
+        let body = r#"{"code":"INVALID_PAYMENT_INFO","message":"Unable to authorize credit"}"#;
+        let msg = format_api_error(
+            "domain purchase",
+            402,
+            "402 Payment Required",
+            body,
+            None,
+            false,
+        );
+        assert!(msg.contains("INVALID_PAYMENT_INFO"), "{msg}");
+        assert!(!msg.contains("some fields are invalid"), "{msg}");
     }
 
     #[test]

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -73,104 +73,134 @@ fn active_env() -> String {
 
 pub fn module() -> Module {
     Module::new("Admin", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new("env", "Manage active GoDaddy environment"))
-            .with_command(RuntimeCommandSpec::new(
-                CommandSpec::new("list", "List available environments")
-                    .with_system("env")
-                    .with_tier(Tier::Read)
-                    .with_output_schema::<EnvSummary>()
-                    .no_auth(true),
-                |_cred, _args| async move {
-                    let current = active_env();
-                    let mut resolved = environments::listable().map_err(map_err)?;
-                    // If the active env is defined only via `<ENV>_API_URL` (so it's
-                    // excluded from `listable`), still show it — otherwise the list
-                    // has no `active: true` entry and callers can't tell what's active.
-                    if !resolved.iter().any(|e| e.name == current)
-                        && let Ok(active) = environments::resolve(&current)
-                    {
-                        resolved.push(active);
-                    }
-                    let envs: Vec<_> = resolved
-                        .into_iter()
-                        .map(|e| {
-                            json!({
-                                "name": e.name,
-                                "active": e.name == current,
-                                "apiUrl": e.api_url,
-                            })
+        RuntimeGroupSpec::new(
+            GroupSpec::new("env", "Manage active GoDaddy environment").with_long(
+                "Control which GoDaddy environment (e.g. prod, ote) all commands talk to.\n\
+                     The active environment determines the API endpoints used for \
+                     every request.\n\
+                     Use `gddy env set` to switch environments; the selection is \
+                     persisted to ~/.gdenv and survives new shell sessions.",
+            ),
+        )
+        .with_command(RuntimeCommandSpec::new(
+            CommandSpec::new("list", "List available environments")
+                .with_long(
+                    "Lists the environments the CLI can target (prod, ote). \
+                         The currently active environment is marked `active: true`.",
+                )
+                .with_system("env")
+                .with_tier(Tier::Read)
+                .with_output_schema::<EnvSummary>()
+                .no_auth(true),
+            |_cred, _args| async move {
+                let current = active_env();
+                let mut resolved = environments::listable().map_err(map_err)?;
+                // If the active env is defined only via `<ENV>_API_URL` (so it's
+                // excluded from `listable`), still show it — otherwise the list
+                // has no `active: true` entry and callers can't tell what's active.
+                if !resolved.iter().any(|e| e.name == current)
+                    && let Ok(active) = environments::resolve(&current)
+                {
+                    resolved.push(active);
+                }
+                let envs: Vec<_> = resolved
+                    .into_iter()
+                    .map(|e| {
+                        json!({
+                            "name": e.name,
+                            "active": e.name == current,
+                            "apiUrl": e.api_url,
                         })
-                        .collect();
-                    Ok(CommandResult::new(json!(envs)))
-                },
-            ))
-            .with_command(RuntimeCommandSpec::new(
-                CommandSpec::new("get", "Get the active environment")
-                    .with_system("env")
-                    .with_tier(Tier::Read)
-                    .with_output_schema::<EnvActive>()
-                    .no_auth(true),
-                |_cred, _args| async move {
-                    let env = active_env();
-                    let resolved = environments::resolve(&env).map_err(map_err)?;
-                    Ok(CommandResult::new(json!({
-                        "env": resolved.name,
-                        "apiUrl": resolved.api_url,
-                    })))
-                },
-            ))
-            .with_command(RuntimeCommandSpec::new_with_context(
-                CommandSpec::new("set", "Set the active environment")
-                    .with_system("env")
-                    .with_tier(Tier::Mutate)
-                    .with_output_schema::<EnvActive>()
-                    .no_auth(true)
-                    .with_arg(
-                        // Distinct id from the global `--env` flag (also id "env");
-                        // a shared id makes the positional collide with the flag's
-                        // default, so `env set <X>` would ignore <X>.
-                        clap::Arg::new("environment")
-                            .value_name("ENV")
-                            .required(true)
-                            .help("Environment to activate (ote|prod)"),
-                    ),
-                |ctx| async move {
-                    let env = ctx
-                        .args
-                        .get("environment")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_owned();
-                    // Resolve up front: validates the env exists (built-in, env
-                    // var, or local config) and yields its API URL for the reply.
-                    let resolved = environments::resolve(&env).map_err(map_err)?;
-                    set_env(&env).map_err(|e| {
-                        cli_engine::CliCoreError::message(format!(
-                            "failed to write .gdenv state file: {e}"
-                        ))
-                    })?;
-                    Ok(CommandResult::new(json!({
-                        "env": resolved.name,
-                        "apiUrl": resolved.api_url,
-                    })))
-                },
-            ))
-            .with_command(RuntimeCommandSpec::new(
-                CommandSpec::new("info", "Show details for the active environment")
-                    .with_system("env")
-                    .with_tier(Tier::Read)
-                    .with_output_schema::<EnvInfo>()
-                    .no_auth(true),
-                |_cred, _args| async move {
-                    let env = active_env();
-                    let resolved = environments::resolve(&env).map_err(map_err)?;
-                    Ok(CommandResult::new(json!({
-                        "env": resolved.name,
-                        "apiUrl": resolved.api_url,
-                        "graphqlUrl": format!("{}/v1/applications/graphql", resolved.api_url),
-                    })))
-                },
-            ))
+                    })
+                    .collect();
+                Ok(CommandResult::new(json!(envs)))
+            },
+        ))
+        .with_command(RuntimeCommandSpec::new(
+            CommandSpec::new("get", "Get the active environment")
+                .with_long(
+                    "Prints the name and API base URL of the currently active \
+                         environment.\n\
+                         If no environment has been set with `gddy env set`, \
+                         the default environment is used.",
+                )
+                .with_system("env")
+                .with_tier(Tier::Read)
+                .with_output_schema::<EnvActive>()
+                .no_auth(true),
+            |_cred, _args| async move {
+                let env = active_env();
+                let resolved = environments::resolve(&env).map_err(map_err)?;
+                Ok(CommandResult::new(json!({
+                    "env": resolved.name,
+                    "apiUrl": resolved.api_url,
+                })))
+            },
+        ))
+        .with_command(RuntimeCommandSpec::new_with_context(
+            CommandSpec::new("set", "Set the active environment")
+                .with_long(
+                    "Switches the active environment and persists the choice to \
+                         ~/.gdenv so all subsequent commands use the new environment \
+                         without needing `--env`.\n\
+                         The value must be a known environment name (prod or ote).",
+                )
+                .with_system("env")
+                .with_tier(Tier::Mutate)
+                .with_output_schema::<EnvActive>()
+                .no_auth(true)
+                .with_arg(
+                    // Distinct id from the global `--env` flag (also id "env");
+                    // a shared id makes the positional collide with the flag's
+                    // default, so `env set <X>` would ignore <X>.
+                    clap::Arg::new("environment")
+                        .value_name("ENV")
+                        .required(true)
+                        .help("Environment name to activate (prod or ote)"),
+                ),
+            |ctx| async move {
+                let env = ctx
+                    .args
+                    .get("environment")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_owned();
+                // Resolve up front: validates the env exists (built-in, env
+                // var, or local config) and yields its API URL for the reply.
+                let resolved = environments::resolve(&env).map_err(map_err)?;
+                set_env(&env).map_err(|e| {
+                    cli_engine::CliCoreError::message(format!(
+                        "failed to write .gdenv state file: {e}"
+                    ))
+                })?;
+                Ok(CommandResult::new(json!({
+                    "env": resolved.name,
+                    "apiUrl": resolved.api_url,
+                })))
+            },
+        ))
+        .with_command(RuntimeCommandSpec::new(
+            CommandSpec::new("info", "Show details for the active environment")
+                .with_long(
+                    "Prints extended details for the active environment, \
+                         including both the REST API base URL and the GraphQL \
+                         endpoint used by application commands.\n\
+                         Use `gddy env get` for a shorter summary.",
+                )
+                .with_system("env")
+                .with_tier(Tier::Read)
+                .with_output_schema::<EnvInfo>()
+                .no_auth(true),
+            |_cred, _args| async move {
+                let env = active_env();
+                let resolved = environments::resolve(&env).map_err(map_err)?;
+                Ok(CommandResult::new(json!({
+                    "env": resolved.name,
+                    "apiUrl": resolved.api_url,
+                    "graphqlUrl": format!("{}/v1/applications/graphql", resolved.api_url),
+                })))
+            },
+        ))
     })
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -31,6 +31,20 @@ async fn main() -> ExitCode {
 
     let cli = Cli::new(
         CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+            .with_long(
+                "gddy is the command-line interface to the GoDaddy developer platform.\n\
+                 \n\
+                 What you can do:\n  \
+                 • domain   — list your domains, check availability, get suggestions, and register new ones\n  \
+                 • dns      — view and edit a domain's DNS records\n  \
+                 • api      — explore and call GoDaddy REST API endpoints directly\n  \
+                 • application — build, configure, and deploy platform applications\n  \
+                 • payments — manage the payment methods used for purchases\n\
+                 \n\
+                 Most commands need authentication; run `gddy auth login` first (or just run a\n\
+                 command and follow the prompt). Use `--env` to target an environment and\n\
+                 `gddy tree` to see every command. New here? Try `gddy domain available <name>`.",
+            )
             .with_build(BuildInfo::new(env!("CARGO_PKG_VERSION")))
             .with_default_auth_provider("godaddy")
             .with_auth_provider(auth_provider)
@@ -43,7 +57,7 @@ async fn main() -> ExitCode {
                         .default_value(
                             get_env().unwrap_or_else(|| environments::DEFAULT_ENV.to_owned()),
                         )
-                        .help("Target environment (ote|prod)"),
+                        .help("Target environment: prod or ote"),
                 )
             }))
             .with_apply_flags(Arc::new(|matches, mw| {

--- a/rust/src/payments/mod.rs
+++ b/rust/src/payments/mod.rs
@@ -16,8 +16,16 @@ fn map_env_err(e: environments::EnvError) -> CliCoreError {
 
 pub fn module() -> Module {
     Module::new("Payments", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new("payments", "Manage payment methods"))
-            .with_command(add_command())
+        RuntimeGroupSpec::new(
+            GroupSpec::new("payments", "Manage payment methods").with_long(
+                "Manage the payment methods on your GoDaddy account.\n\
+                     A saved payment method is required before you can run \
+                     `gddy domain purchase`.\n\
+                     Use `gddy payments add` to open the GoDaddy payment methods \
+                     page in your browser.",
+            ),
+        )
+        .with_command(add_command())
     })
 }
 

--- a/rust/src/webhook/mod.rs
+++ b/rust/src/webhook/mod.rs
@@ -6,36 +6,47 @@ use crate::application::client::api_url_for_env;
 
 pub fn module() -> Module {
     Module::new("GPA", |_ctx| {
-        RuntimeGroupSpec::new(GroupSpec::new("webhook", "Manage webhook event types")).with_command(
-            RuntimeCommandSpec::new_with_context(
-                CommandSpec::new("events", "List available webhook event types")
-                    .with_system("webhooks")
-                    .with_tier(Tier::Read),
-                |ctx| async move {
-                    let token = ctx.credential().await?.token;
-                    let base_url = api_url_for_env(&ctx.middleware.env);
-                    let url = format!("{base_url}/v1/apis/webhook-event-types");
-                    let resp = crate::application::client::make_http_client()
-                        .get(&url)
-                        .bearer_auth(&token)
-                        .header("x-request-id", uuid::Uuid::new_v4().to_string())
-                        .send()
-                        .await
-                        .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                    if !resp.status().is_success() {
-                        let status = resp.status().as_u16();
-                        let body = resp.text().await.unwrap_or_default();
-                        return Err(cli_engine::CliCoreError::message(format!(
-                            "webhook events request failed ({status}): {body}"
-                        )));
-                    }
-                    let data: serde_json::Value = resp
-                        .json()
-                        .await
-                        .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                    Ok(CommandResult::new(data))
-                },
+        RuntimeGroupSpec::new(
+            GroupSpec::new("webhook", "Manage webhook event types").with_long(
+                "Inspect the webhook event types your application can subscribe to.\n\
+                     Use `gddy application add subscription` to attach a webhook \
+                     subscription to an application.",
             ),
         )
+        .with_command(RuntimeCommandSpec::new_with_context(
+            CommandSpec::new("events", "List available webhook event types")
+                .with_long(
+                    "Returns the full list of event types that can be used when \
+                         creating a webhook subscription.\n\
+                         Pass an event type from this list to \
+                         `gddy application add subscription`.",
+                )
+                .with_system("webhooks")
+                .with_tier(Tier::Read),
+            |ctx| async move {
+                let token = ctx.credential().await?.token;
+                let base_url = api_url_for_env(&ctx.middleware.env);
+                let url = format!("{base_url}/v1/apis/webhook-event-types");
+                let resp = crate::application::client::make_http_client()
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .header("x-request-id", uuid::Uuid::new_v4().to_string())
+                    .send()
+                    .await
+                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                if !resp.status().is_success() {
+                    let status = resp.status().as_u16();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(cli_engine::CliCoreError::message(format!(
+                        "webhook events request failed ({status}): {body}"
+                    )));
+                }
+                let data: serde_json::Value = resp
+                    .json()
+                    .await
+                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                Ok(CommandResult::new(data))
+            },
+        ))
     })
 }


### PR DESCRIPTION
Addresses four data-formatting issues from the [API Transformation MVP tracker](https://godaddy-corp.atlassian.net/wiki/spaces/CTOPLAT/pages/4479091080/) bug bash (#12, #14, #27, #33).

## #12 — phone normalization (`contacts/mod.rs`)
`Contact::to_api()` now normalizes `phone` (and `fax`) to the Domains API's required `+<country-code>.<number>` format using the new `phonenumber` crate, parsed with the contact's `country` as the default region. Inputs like `+447793601890`, `+44 7793 601890`, and a local `07793 601890` all become `+44.7793601890`; unparseable input fails fast with a plain-English error and an example.

## #33 — omit blank optional fields (`contacts/mod.rs`)
Blank optional contact fields (`address2`, `name_middle`, `organization`, `job_title`, `fax`) are coerced to `None` so they're omitted rather than sent as `""`, which the API rejected with `LENGTH_UNDER`.

## #14 — translate validation errors (`domain/mod.rs`)
`format_api_error` parses the API's `fields[]` array and renders a plain-English bullet list (friendly field name + problem + hint), e.g. *"registrant mailing address line 2 is too short (leave it blank to omit it)"*. The raw regex-bearing messages are suppressed; the full JSON body stays available under `--debug`. Non-validation bodies (incl. the 402 path) keep their existing passthrough behavior.

## #27 — comprehensive help pass
Root long help in `main.rs`, plus `.with_long()` and argument-help review across `domain`, `dns`, `api`, `application`, `env`, `payments`, `webhook`, and `actions`. Corrected an inaccurate "requires `--reason`" claim (the CLI registers no authorizer, so `--reason` is audit-only) and removed custom/local-environment language from user-facing help.

## Testing
- `cargo test` — 195 passing (14 new unit tests across `contacts` and `domain`)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Spot-checked rendered `--help` for root, `domain purchase`, `dns`, `api call`, `application add subscription`, and `env` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)