### PR TITLE
feat: add more next-actions across commands

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Test
         run: cargo test

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-test-
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Test
         run: cargo test

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -560,9 +560,33 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.4.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6786efadc13f2a6202786e2149e4aa6f9dcb6326202a26a75c747e7202af7b17"
+checksum = "35b4759ac63483df8b4fb0b2a88010d71c830d42eee81405808d58b4ae77a8fa"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "clap",
+ "clap_complete",
+ "jmespath",
+ "regex",
+ "reqwest",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml_edit 0.22.27",
+ "tracing",
+]
+
+[[package]]
+name = "cli-engine"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666d8e4bf199623eda4f64cc3f6273143e5cbd080517cb378df40a5fdd3fe0ba"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -942,7 +966,7 @@ name = "domains-client"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "cli-engine",
+ "cli-engine 0.3.5",
  "futures",
  "httpmock",
  "openapiv3",
@@ -1302,7 +1326,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "cli-engine",
+ "cli-engine 0.4.1",
  "dirs",
  "domains-client",
  "fancy-regex",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.4.0" }
+cli-engine = { features = ["pkce-auth"], version = "0.4.1" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -1,5 +1,6 @@
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CommandResult, CommandSpec, GroupSpec, Module, NextAction, NextActionParam, RuntimeCommandSpec,
+    RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
@@ -85,7 +86,10 @@ pub fn module() -> Module {
                     .iter()
                     .map(|(name, description)| json!({ "name": name, "description": description }))
                     .collect();
-                Ok(CommandResult::new(json!({ "actions": actions })))
+                Ok(CommandResult::new(json!({ "actions": actions })).with_next_actions(vec![
+                    NextAction::new("actions describe <action>", "See an action's full schema")
+                        .with_param("action", NextActionParam::required()),
+                ]))
             },
         ))
         .with_command(RuntimeCommandSpec::new_with_context(

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -19,8 +19,8 @@
 //! `--dry-run` short-circuits them with a preview.
 
 use cli_engine::{
-    CliCoreError, CommandContext, CommandResult, CommandSpec, GroupSpec, Module,
-    RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CliCoreError, CommandContext, CommandResult, CommandSpec, GroupSpec, Module, NextAction,
+    NextActionParam, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
 };
 use serde_json::{Value, json};
 
@@ -353,6 +353,18 @@ fn summarize_delete_outcomes(
 /// the success JSON payload when *every* record was created, or an error message
 /// (a non-zero exit) with a per-record breakdown if any failed. Pure — no I/O —
 /// so the aggregation and the success/failure decision are unit-testable.
+/// Next action pointing back at `dns list` to verify a write, pre-filled with
+/// the domain/type/name the write just touched.
+fn verify_with_list_action(domain: &str, record_type: &str, name: &str) -> NextAction {
+    NextAction::new(
+        "dns list <domain> --type <type> --name <name>",
+        "Verify the records for this type+name",
+    )
+    .with_param("domain", NextActionParam::value(domain))
+    .with_param("type", NextActionParam::value(record_type))
+    .with_param("name", NextActionParam::value(name))
+}
+
 fn summarize_add_outcomes(
     domain: &str,
     record_type: &str,
@@ -665,7 +677,13 @@ pub fn module() -> Module {
                 // All-created → success payload; any failure → non-zero error
                 // with a per-record breakdown.
                 summarize_add_outcomes(&domain, &record_type, &name, outcomes)
-                    .map(CommandResult::new)
+                    .map(|v| {
+                        CommandResult::new(v).with_next_actions(vec![verify_with_list_action(
+                            &domain,
+                            &record_type,
+                            &name,
+                        )])
+                    })
                     .map_err(CliCoreError::message)
             },
         ))
@@ -781,7 +799,13 @@ pub fn module() -> Module {
                 }
 
                 summarize_set_outcomes(&domain, &record_type, &name, &outcomes)
-                    .map(CommandResult::new)
+                    .map(|v| {
+                        CommandResult::new(v).with_next_actions(vec![verify_with_list_action(
+                            &domain,
+                            &record_type,
+                            &name,
+                        )])
+                    })
                     .map_err(CliCoreError::message)
             },
         ))
@@ -870,7 +894,13 @@ pub fn module() -> Module {
                 }
 
                 summarize_delete_outcomes(&domain, &record_type, &name, &outcomes)
-                    .map(CommandResult::new)
+                    .map(|v| {
+                        CommandResult::new(v).with_next_actions(vec![verify_with_list_action(
+                            &domain,
+                            &record_type,
+                            &name,
+                        )])
+                    })
                     .map_err(CliCoreError::message)
             },
         ))

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -348,11 +348,6 @@ fn summarize_delete_outcomes(
     }))
 }
 
-/// Summarize the per-record create outcomes of `dns add` (each `--data` value
-/// paired with `Ok(())` or an `Err(message)`), preserving input order. Returns
-/// the success JSON payload when *every* record was created, or an error message
-/// (a non-zero exit) with a per-record breakdown if any failed. Pure — no I/O —
-/// so the aggregation and the success/failure decision are unit-testable.
 /// Next action pointing back at `dns list` to verify a write, pre-filled with
 /// the domain/type/name the write just touched.
 fn verify_with_list_action(domain: &str, record_type: &str, name: &str) -> NextAction {
@@ -365,6 +360,11 @@ fn verify_with_list_action(domain: &str, record_type: &str, name: &str) -> NextA
     .with_param("name", NextActionParam::value(name))
 }
 
+/// Summarize the per-record create outcomes of `dns add` (each `--data` value
+/// paired with `Ok(())` or an `Err(message)`), preserving input order. Returns
+/// the success JSON payload when *every* record was created, or an error message
+/// (a non-zero exit) with a per-record breakdown if any failed. Pure — no I/O —
+/// so the aggregation and the success/failure decision are unit-testable.
 fn summarize_add_outcomes(
     domain: &str,
     record_type: &str,

--- a/rust/src/domain/agreements.rs
+++ b/rust/src/domain/agreements.rs
@@ -1,6 +1,8 @@
 //! `gddy domain agreements` — the legal agreements a TLD requires (v1).
 
-use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
+use cli_engine::{
+    CommandResult, CommandSpec, NextAction, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+};
 use serde_json::json;
 
 use domains_client::types;
@@ -68,7 +70,20 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     })
                 })
                 .collect();
-            Ok(CommandResult::new(json!(agreements)))
+            Ok(
+                CommandResult::new(json!(agreements)).with_next_actions(vec![
+                    NextAction::new(
+                        "domain quote <domain>",
+                        "Price a registration and see the agreements for a specific domain",
+                    )
+                    .with_param("domain", NextActionParam::required()),
+                    NextAction::new(
+                        "domain purchase --quote-token <quote-token> --agree --confirm",
+                        "Register once you have a quote",
+                    )
+                    .with_param("quote-token", NextActionParam::required()),
+                ]),
+            )
         },
     )
 }

--- a/rust/src/domain/nameservers.rs
+++ b/rust/src/domain/nameservers.rs
@@ -1,7 +1,8 @@
 //! `gddy domain nameservers` — manage a domain's nameservers (v3).
 
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CommandResult, CommandSpec, GroupSpec, NextAction, NextActionParam, RuntimeCommandSpec,
+    RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
@@ -91,7 +92,10 @@ pub(super) fn group() -> RuntimeGroupSpec {
             if let Some(status) = op.status.as_ref() {
                 result["status"] = json!(status.to_string());
             }
-            Ok(CommandResult::new(result))
+            Ok(CommandResult::new(result).with_next_actions(vec![
+                NextAction::new("domain get <domain>", "Confirm the updated nameservers")
+                    .with_param("domain", NextActionParam::value(domain)),
+            ]))
         },
     ))
 }

--- a/rust/src/domain/quote.rs
+++ b/rust/src/domain/quote.rs
@@ -319,10 +319,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 }
                 next_actions.push(
                     NextAction::new(
-                        "domain purchase --quote-token <token> --agree --confirm",
+                        "domain purchase --quote-token <quote-token> --agree --confirm",
                         "Register at the quoted price (within ~10 minutes)",
                     )
-                    .with_param("quote-token", NextActionParam::required()),
+                    .with_param("quote-token", NextActionParam::value(token)),
                 );
             } else {
                 // Not available (or no token was issued): point at discovery, the

--- a/rust/src/hosting/nodejs/mod.rs
+++ b/rust/src/hosting/nodejs/mod.rs
@@ -454,7 +454,18 @@ fn status_command() -> RuntimeCommandSpec {
             let app_id = required_str(&ctx, "app-id", "--app-id")?;
             let client = make_client(&ctx, &[APPS_READ]).await?;
             let data = client.get_app_status(&app_id).await.map_err(client_err)?;
-            Ok(CommandResult::new(data))
+            Ok(CommandResult::new(data).with_next_actions(vec![
+                NextAction::new(
+                    "hosting nodejs deployment list --app-id <app-id>",
+                    "List deployments for this application",
+                )
+                .with_param("app-id", NextActionParam::value(app_id.clone())),
+                NextAction::new(
+                    "hosting nodejs logs --app-id <app-id>",
+                    "View application logs",
+                )
+                .with_param("app-id", NextActionParam::value(app_id)),
+            ]))
         },
     )
 }

--- a/rust/src/pat/mod.rs
+++ b/rust/src/pat/mod.rs
@@ -526,7 +526,7 @@ mod tests {
             "token".to_owned(),
             serde_json::Value::String("  gd_pat_a_12345678  \n".to_owned()),
         );
-        let token = resolve_token_arg(&args).await.unwrap();
+        let token = resolve_token_arg(&args).await.expect("token arg resolves");
         assert_eq!(token, "gd_pat_a_12345678");
         assert!(is_valid_pat(&token));
     }
@@ -536,7 +536,7 @@ mod tests {
         assert!(parse_stdin_token("", 0).is_err());
         assert!(parse_stdin_token("  \n", 3).is_err());
         assert_eq!(
-            parse_stdin_token("  gd_pat_a_12345678  \n", 23).unwrap(),
+            parse_stdin_token("  gd_pat_a_12345678  \n", 23).expect("token parses"),
             "gd_pat_a_12345678"
         );
     }
@@ -582,7 +582,7 @@ mod tests {
             "GDDY_PAT" => Some("gd_pat_default_12345678".to_owned()),
             _ => None,
         };
-        let entry = resolve_pat_with("prod", env, Some(&registry)).unwrap();
+        let entry = resolve_pat_with("prod", env, Some(&registry)).expect("pat resolves");
         assert_eq!(entry.token, "gd_pat_prod_12345678");
         assert_eq!(entry.name, "env");
     }
@@ -594,7 +594,7 @@ mod tests {
             "GDDY_PAT" => Some("gd_pat_default_12345678".to_owned()),
             _ => None,
         };
-        let entry = resolve_pat_with("prod", env, Some(&registry)).unwrap();
+        let entry = resolve_pat_with("prod", env, Some(&registry)).expect("pat resolves");
         assert_eq!(entry.token, "gd_pat_default_12345678");
         assert_eq!(entry.name, "env");
     }
@@ -607,7 +607,7 @@ mod tests {
             "GDDY_PAT" => Some("gd_pat_default_12345678".to_owned()),
             _ => None,
         };
-        let entry = resolve_pat_with("prod", env, Some(&registry)).unwrap();
+        let entry = resolve_pat_with("prod", env, Some(&registry)).expect("pat resolves");
         assert_eq!(entry.token, "gd_pat_default_12345678");
     }
 
@@ -615,7 +615,7 @@ mod tests {
     fn registry_entry_returned_when_no_env_vars() {
         let registry = test_registry_with("prod", "gd_pat_registry_12345678");
         let env = |_var: &str| None;
-        let entry = resolve_pat_with("prod", env, Some(&registry)).unwrap();
+        let entry = resolve_pat_with("prod", env, Some(&registry)).expect("pat resolves");
         assert_eq!(entry.token, "gd_pat_registry_12345678");
         assert_eq!(entry.name, "stored");
     }

--- a/rust/src/payments/mod.rs
+++ b/rust/src/payments/mod.rs
@@ -1,8 +1,8 @@
 //! `gddy payments` — payment method management.
 
 use cli_engine::{
-    CliCoreError, CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec,
-    RuntimeGroupSpec, Tier,
+    CliCoreError, CommandResult, CommandSpec, GroupSpec, Module, NextAction, NextActionParam,
+    RuntimeCommandSpec, RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
@@ -52,7 +52,14 @@ fn add_command() -> RuntimeCommandSpec {
                     "Could not open browser. Visit the URL above to add a payment method. \
                      Only credit card or Good-as-Gold can be used for domain purchases."
                 }
-            })))
+            }))
+            .with_next_actions(vec![
+                NextAction::new(
+                    "domain quote <domain>",
+                    "Price a domain registration now that a payment method is on file",
+                )
+                .with_param("domain", NextActionParam::required()),
+            ]))
         },
     )
 }


### PR DESCRIPTION
## Summary
- Bumps `cli-engine` to the now-published `0.4.1`.
- Fixes 6 `clippy::unwrap_used` violations in `pat/mod.rs` tests, and closes the CI gap that let them merge unblocked: `cargo clippy` was missing `--all-targets`, so test-target code wasn't linted (fixed in both `cicd.yml` and `rust-port-alpha.yaml`).
- Adds `NextAction` suggestions to more command outputs:
  - `actions list` → `actions describe <action>`
  - `dns add/set/delete` → `dns list` (verify the write)
  - `domain agreements` → `domain quote` / `domain purchase`
  - `domain nameservers set` → `domain get` (confirm the update)
  - `hosting nodejs status` → `deployment list` / `logs`
  - `payments add` → `domain quote`
- Fixes `domain quote`'s next-action placeholder (`<quote-token>`, matching the param name) and pre-fills it with the actual token value instead of leaving it required.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` (212 passed)