### PR TITLE
feat: add `domain operation status` to poll async domain operations

### DIFF
--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -68,6 +68,29 @@ pub(super) fn headline_price(prices: &[types::TermPrice]) -> Option<&types::Term
         .or_else(|| prices.first())
 }
 
+/// Whether an async domain-operation status is terminal (no further polling).
+/// Only `COMPLETED`/`FAILED` are terminal; every other status (e.g. `SUBMITTED`,
+/// `PENDING`, `CONFIRMED`, `EXECUTING`) is treated as still in progress.
+pub(super) fn is_terminal_status(status: &str) -> bool {
+    matches!(status, "COMPLETED" | "FAILED")
+}
+
+/// Renders a `FAILED` operation's `error` payload (name/message) for the
+/// user-facing error, e.g. `" (DOMAIN_UNAVAILABLE: the domain is already
+/// registered)"`. Empty when the operation carried no error detail (e.g. it
+/// failed before an operation with a populated `error` was ever polled).
+pub(super) fn format_operation_error(error: Option<&types::Error>) -> String {
+    let Some(error) = error else {
+        return String::new();
+    };
+    match (error.name.as_deref(), error.message.as_deref()) {
+        (Some(name), Some(message)) => format!(" ({name}: {message})"),
+        (Some(name), None) => format!(" ({name})"),
+        (None, Some(message)) => format!(" ({message})"),
+        (None, None) => String::new(),
+    }
+}
+
 /// Build a Domains API client for the active environment, authenticating with
 /// the resolved OAuth bearer token.
 pub(crate) async fn make_client(ctx: &CommandContext) -> Result<domains_client::Client> {
@@ -383,5 +406,50 @@ mod tests {
         assert!(msg.contains("registrant address line 2"), "{msg}");
         assert!(msg.contains("is too short"), "{msg}");
         assert!(msg.contains("leave it blank to omit"), "{msg}");
+    }
+
+    #[test]
+    fn terminal_status_detection() {
+        assert!(is_terminal_status("COMPLETED"));
+        assert!(is_terminal_status("FAILED"));
+        assert!(!is_terminal_status("CONFIRMED"));
+        assert!(!is_terminal_status("EXECUTING"));
+        assert!(!is_terminal_status("SUBMITTED"));
+    }
+
+    #[test]
+    fn format_operation_error_includes_name_and_message() {
+        assert_eq!(format_operation_error(None), "");
+
+        let name_only = types::Error {
+            name: Some("DOMAIN_UNAVAILABLE".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_operation_error(Some(&name_only)),
+            " (DOMAIN_UNAVAILABLE)"
+        );
+
+        let message_only = types::Error {
+            message: Some("the domain is already registered".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_operation_error(Some(&message_only)),
+            " (the domain is already registered)"
+        );
+
+        let both = types::Error {
+            name: Some("DOMAIN_UNAVAILABLE".to_string()),
+            message: Some("the domain is already registered".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_operation_error(Some(&both)),
+            " (DOMAIN_UNAVAILABLE: the domain is already registered)"
+        );
+
+        let neither = types::Error::default();
+        assert_eq!(format_operation_error(Some(&neither)), "");
     }
 }

--- a/rust/src/domain/guides/domain-purchase.md
+++ b/rust/src/domain/guides/domain-purchase.md
@@ -19,8 +19,8 @@ Registration completes **asynchronously**: `purchase` submits the registration
 and waits briefly for the registry, reporting the operation's `status`
 (`COMPLETED` when done). The domain then appears in `gddy domain list`. If
 `purchase` gives up waiting before reaching a terminal status, it still
-succeeded — check on it later with `gddy domain operation status
-<operation-id>` (the ID it printed).
+succeeded — check on it later (the ID it printed) with:
+`gddy domain operation status <operation-id>`.
 
 ## The flow
 

--- a/rust/src/domain/guides/domain-purchase.md
+++ b/rust/src/domain/guides/domain-purchase.md
@@ -15,9 +15,7 @@ A purchase is **paid and not reversible**, so `purchase` has two gates
 (`--agree`, `--confirm`) on top of the token. Because the token locks the price
 and settings you reviewed, you're charged exactly what the quote showed.
 
-Registration completes **asynchronously**: `purchase` submits the registration
-and waits briefly for the registry, reporting the operation's `status`
-(`COMPLETED` when done). The domain then appears in `gddy domain list`.
+Registration completes **asynchronously**; `purchase` submits the registration and waits briefly for the registry, reporting the operation's `status` (`COMPLETED` when done). The domain then appears in `gddy domain list`. If `purchase` gives up waiting before reaching a terminal status, it still succeeded — check on it later with `gddy domain operation status <operation-id>` (the ID it printed).
 
 ## The flow
 

--- a/rust/src/domain/guides/domain-purchase.md
+++ b/rust/src/domain/guides/domain-purchase.md
@@ -15,7 +15,12 @@ A purchase is **paid and not reversible**, so `purchase` has two gates
 (`--agree`, `--confirm`) on top of the token. Because the token locks the price
 and settings you reviewed, you're charged exactly what the quote showed.
 
-Registration completes **asynchronously**; `purchase` submits the registration and waits briefly for the registry, reporting the operation's `status` (`COMPLETED` when done). The domain then appears in `gddy domain list`. If `purchase` gives up waiting before reaching a terminal status, it still succeeded — check on it later with `gddy domain operation status <operation-id>` (the ID it printed).
+Registration completes **asynchronously**: `purchase` submits the registration
+and waits briefly for the registry, reporting the operation's `status`
+(`COMPLETED` when done). The domain then appears in `gddy domain list`. If
+`purchase` gives up waiting before reaching a terminal status, it still
+succeeded — check on it later with `gddy domain operation status
+<operation-id>` (the ID it printed).
 
 ## The flow
 

--- a/rust/src/domain/mod.rs
+++ b/rust/src/domain/mod.rs
@@ -25,6 +25,7 @@ mod contacts;
 mod get;
 mod list;
 mod nameservers;
+mod operation;
 mod purchase;
 mod quote;
 mod suggest;
@@ -48,6 +49,7 @@ pub fn module() -> Module {
              • quote             — price a registration and see required agreements\n\
              • purchase          — register a new domain (charges your account)\n\
              • nameservers set   — point a domain at custom nameservers\n\
+             • operation status  — check on an async operation (e.g. a pending purchase)\n\
              \n\
              Reads need the `domains.domain:read` scope; purchase also needs\n\
              `domains.domain:create`, and `nameservers set` needs\n\
@@ -63,6 +65,7 @@ pub fn module() -> Module {
         .with_command(purchase::command())
         .with_group(nameservers::group())
         .with_group(contacts::group())
+        .with_group(operation::group())
     })
     .with_guides_from_markdown([(
         "domain-purchase.md",
@@ -83,7 +86,7 @@ mod tests {
     #[tokio::test]
     async fn domain_commands_require_auth() {
         const AUTH_FAILURE_EXIT: i32 = 2;
-        let cases: [&[&str]; 8] = [
+        let cases: [&[&str]; 9] = [
             &["gddy", "domain", "list", "--output", "json"],
             &["gddy", "domain", "get", "example.com", "--output", "json"],
             &[
@@ -128,6 +131,15 @@ mod tests {
                 "ns1.example.net",
                 "--reason",
                 "test",
+                "--output",
+                "json",
+            ],
+            &[
+                "gddy",
+                "domain",
+                "operation",
+                "status",
+                "dummy-op-id",
                 "--output",
                 "json",
             ],

--- a/rust/src/domain/operation.rs
+++ b/rust/src/domain/operation.rs
@@ -100,7 +100,10 @@ fn status_command() -> RuntimeCommandSpec {
                 // parens for inline sentence-appending (as `purchase.rs` uses it);
                 // strip that decoration since this is a standalone field value.
                 let detail = format_operation_error(Some(error));
-                let detail = detail.trim().trim_start_matches('(').trim_end_matches(')');
+                let detail = detail
+                    .strip_prefix(" (")
+                    .and_then(|s| s.strip_suffix(')'))
+                    .unwrap_or(&detail);
                 if !detail.is_empty() {
                     result["error"] = json!(detail);
                 }

--- a/rust/src/domain/operation.rs
+++ b/rust/src/domain/operation.rs
@@ -80,14 +80,13 @@ fn status_command() -> RuntimeCommandSpec {
                 .map(|id| id.to_string())
                 .unwrap_or(operation_id);
 
+            let op_type = op.type_.as_ref().map(|t| t.to_string()).unwrap_or_default();
             let mut result = json!({
                 "operationId": op_id,
+                "type": op_type,
                 "domain": domain,
                 "status": status,
             });
-            if let Some(t) = op.type_.as_ref() {
-                result["type"] = json!(t.to_string());
-            }
             if let Some(op_result) = op.result.as_ref() {
                 if let Some(order_id) = op_result.order_id.as_ref() {
                     result["orderId"] = json!(order_id);
@@ -109,7 +108,7 @@ fn status_command() -> RuntimeCommandSpec {
 
             let mut actions = Vec::new();
             if is_terminal_status(&status) {
-                if status == "COMPLETED" {
+                if status == "COMPLETED" && !domain.is_empty() {
                     actions.push(
                         NextAction::new("domain get <domain>", "See the domain's details")
                             .with_param("domain", NextActionParam::value(domain)),

--- a/rust/src/domain/operation.rs
+++ b/rust/src/domain/operation.rs
@@ -1,0 +1,139 @@
+//! `gddy domain operation status` — poll an async domain operation (v3).
+//!
+//! Every async domain mutation (register, nameserver updates, and eventually
+//! renew/transfer) returns an `operationId` that can be re-checked here via the
+//! same `GET /v3/domains/operations/{operationId}` endpoint `purchase`'s
+//! bounded poll loop already uses internally.
+
+use cli_engine::{
+    CommandResult, CommandSpec, GroupSpec, NextAction, NextActionParam, RuntimeCommandSpec,
+    RuntimeGroupSpec, Tier,
+};
+use serde_json::json;
+
+use domains_client::types;
+
+use super::common::{api_error, format_operation_error, is_terminal_status, make_client};
+use crate::output_schema::output_schema;
+use crate::scopes::DOMAINS_READ;
+
+output_schema!(DomainOperationStatusResult {
+    "operationId": "string";
+    "type": "string";
+    "domain": "string";
+    "status": "string";
+    // Only populated once the operation reaches a terminal state.
+    "orderId": "string", optional;
+    "expiresAt": "string", optional;
+    "error": "string", optional;
+});
+
+fn status_command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_with_context(
+        CommandSpec::new("status", "Check the status of an async domain operation")
+            .with_long(
+                "Check on a domain operation (registration, nameserver update, and \
+                 similar async mutations) by the `operationId` it returned. This is a \
+                 read-only check: even a FAILED operation is reported as data with exit \
+                 code 0, since the status check itself succeeded.",
+            )
+            .with_system("domain")
+            .with_tier(Tier::Read)
+            .with_default_fields("operationId,type,domain,status,orderId,expiresAt,error")
+            .with_output_schema::<DomainOperationStatusResult>()
+            .with_scopes(&[DOMAINS_READ])
+            .with_arg(
+                clap::Arg::new("operation-id")
+                    .value_name("OPERATION_ID")
+                    .required(true)
+                    .help("The operationId returned by an async domain mutation"),
+            ),
+        |ctx| async move {
+            let operation_id = ctx
+                .args
+                .get("operation-id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_owned();
+            let debug = !ctx.middleware.debug.is_empty();
+
+            let client = make_client(&ctx).await?;
+            let op = match client
+                .get_operation()
+                .operation_id(types::Uuid(operation_id.clone()))
+                .send()
+                .await
+            {
+                Ok(r) => r.into_inner(),
+                Err(e) => return Err(api_error("checking domain operation status", debug, e).await),
+            };
+
+            let status = op
+                .status
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let domain = op.domain.clone().unwrap_or_default();
+            let op_id = op
+                .operation_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or(operation_id);
+
+            let mut result = json!({
+                "operationId": op_id,
+                "domain": domain,
+                "status": status,
+            });
+            if let Some(t) = op.type_.as_ref() {
+                result["type"] = json!(t.to_string());
+            }
+            if let Some(op_result) = op.result.as_ref() {
+                if let Some(order_id) = op_result.order_id.as_ref() {
+                    result["orderId"] = json!(order_id);
+                }
+                if let Some(expires_at) = op_result.expires_at.as_ref() {
+                    result["expiresAt"] = json!(expires_at.to_string());
+                }
+            }
+            if let Some(error) = op.error.as_ref() {
+                // `format_operation_error` wraps its result in a leading space and
+                // parens for inline sentence-appending (as `purchase.rs` uses it);
+                // strip that decoration since this is a standalone field value.
+                let detail = format_operation_error(Some(error));
+                let detail = detail.trim().trim_start_matches('(').trim_end_matches(')');
+                if !detail.is_empty() {
+                    result["error"] = json!(detail);
+                }
+            }
+
+            let mut actions = Vec::new();
+            if is_terminal_status(&status) {
+                if status == "COMPLETED" {
+                    actions.push(
+                        NextAction::new("domain get <domain>", "See the domain's details")
+                            .with_param("domain", NextActionParam::value(domain)),
+                    );
+                }
+            } else {
+                actions.push(
+                    NextAction::new(
+                        "domain operation status <operation-id>",
+                        "Re-check whether the operation has finished",
+                    )
+                    .with_param("operation-id", NextActionParam::value(op_id)),
+                );
+            }
+
+            Ok(CommandResult::new(result).with_next_actions(actions))
+        },
+    )
+}
+
+pub(super) fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(GroupSpec::new(
+        "operation",
+        "Check the status of async domain operations",
+    ))
+    .with_command(status_command())
+}

--- a/rust/src/domain/purchase.rs
+++ b/rust/src/domain/purchase.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, make_client_with_cred};
+use super::common::{api_error, format_operation_error, is_terminal_status, make_client_with_cred};
 use crate::output_schema::output_schema;
 use crate::quote_cache;
 use crate::scopes::{DOMAINS_CREATE, DOMAINS_READ};
@@ -57,13 +57,6 @@ fn consent_principal(cred: &Credential) -> Result<String> {
     Ok(id.to_owned())
 }
 
-/// Whether an async domain-operation status is terminal (no further polling).
-/// Only `COMPLETED`/`FAILED` are terminal; every other status (e.g. `SUBMITTED`,
-/// `PENDING`, `CONFIRMED`, `EXECUTING`) is treated as still in progress.
-fn is_terminal_status(status: &str) -> bool {
-    matches!(status, "COMPLETED" | "FAILED")
-}
-
 /// Description for the `domain get <domain>` next-action, tailored to whether
 /// registration actually finished (`COMPLETED`) or bounded polling gave up
 /// while it was still non-terminal — the latter shouldn't claim the domain is
@@ -73,22 +66,6 @@ fn next_action_description(status: &str) -> &'static str {
         "See the registered domain's details"
     } else {
         "Check whether registration has finished (was still in progress after polling)"
-    }
-}
-
-/// Renders a `FAILED` operation's `error` payload (name/message) for the
-/// user-facing error, e.g. `" (DOMAIN_UNAVAILABLE: the domain is already
-/// registered)"`. Empty when the operation carried no error detail (e.g. it
-/// failed before an operation with a populated `error` was ever polled).
-fn format_operation_error(error: Option<&types::Error>) -> String {
-    let Some(error) = error else {
-        return String::new();
-    };
-    match (error.name.as_deref(), error.message.as_deref()) {
-        (Some(name), Some(message)) => format!(" ({name}: {message})"),
-        (Some(name), None) => format!(" ({name})"),
-        (None, Some(message)) => format!(" ({message})"),
-        (None, None) => String::new(),
     }
 }
 
@@ -402,12 +379,13 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // Bounded polling gave up before a terminal state (e.g. still
             // SUBMITTED/PENDING). It may still complete server-side, so tell the
             // user how to check rather than implying it finished.
-            if operation_id.is_some() && !is_terminal_status(&status) {
+            let still_pending = operation_id.is_some() && !is_terminal_status(&status);
+            if still_pending {
                 tracing::info!(
                     %domain,
                     %status,
                     "registration still in progress after polling; check later with \
-                     `gddy domain get {domain}`"
+                     `gddy domain operation status`"
                 );
             }
 
@@ -426,22 +404,31 @@ pub(super) fn command() -> RuntimeCommandSpec {
             if let Some(c) = currency.as_ref() {
                 result["currency"] = json!(c);
             }
-            Ok(CommandResult::new(result).with_next_actions(vec![
+            let mut actions = vec![
                 NextAction::new("domain get <domain>", next_action_description(&status))
                     .with_param("domain", NextActionParam::required()),
-            ]))
+            ];
+            if still_pending {
+                // `still_pending` implies `operation_id.is_some()`.
+                if let Some(op) = &operation_id {
+                    actions.push(
+                        NextAction::new(
+                            "domain operation status <operation-id>",
+                            "Check whether registration has finished since polling gave up",
+                        )
+                        .with_param("operation-id", NextActionParam::value(op.to_string())),
+                    );
+                }
+            }
+            Ok(CommandResult::new(result).with_next_actions(actions))
         },
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        consent_principal, format_operation_error, is_terminal_status, iso_datetime,
-        next_action_description, purchase_consent_types,
-    };
+    use super::{consent_principal, iso_datetime, next_action_description, purchase_consent_types};
     use cli_engine::Credential;
-    use domains_client::types;
 
     #[test]
     fn purchase_consent_requires_agree_then_confirm() {
@@ -503,15 +490,6 @@ mod tests {
     }
 
     #[test]
-    fn terminal_status_detection() {
-        assert!(is_terminal_status("COMPLETED"));
-        assert!(is_terminal_status("FAILED"));
-        assert!(!is_terminal_status("CONFIRMED"));
-        assert!(!is_terminal_status("EXECUTING"));
-        assert!(!is_terminal_status("SUBMITTED"));
-    }
-
-    #[test]
     fn next_action_description_reflects_final_status() {
         // A true COMPLETED gets the "already registered" wording.
         assert_eq!(
@@ -527,42 +505,6 @@ mod tests {
                 "status {status:?} must not claim the domain is registered: {desc}"
             );
         }
-    }
-
-    #[test]
-    fn format_operation_error_includes_name_and_message() {
-        assert_eq!(format_operation_error(None), "");
-
-        let name_only = types::Error {
-            name: Some("DOMAIN_UNAVAILABLE".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            format_operation_error(Some(&name_only)),
-            " (DOMAIN_UNAVAILABLE)"
-        );
-
-        let message_only = types::Error {
-            message: Some("the domain is already registered".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            format_operation_error(Some(&message_only)),
-            " (the domain is already registered)"
-        );
-
-        let both = types::Error {
-            name: Some("DOMAIN_UNAVAILABLE".to_string()),
-            message: Some("the domain is already registered".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            format_operation_error(Some(&both)),
-            " (DOMAIN_UNAVAILABLE: the domain is already registered)"
-        );
-
-        let neither = types::Error::default();
-        assert_eq!(format_operation_error(Some(&neither)), "");
     }
 
     #[test]

--- a/rust/src/domain/purchase.rs
+++ b/rust/src/domain/purchase.rs
@@ -380,12 +380,13 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // SUBMITTED/PENDING). It may still complete server-side, so tell the
             // user how to check rather than implying it finished.
             let still_pending = operation_id.is_some() && !is_terminal_status(&status);
-            if still_pending {
+            if let Some(op) = operation_id.as_ref().filter(|_| still_pending) {
                 tracing::info!(
                     %domain,
                     %status,
+                    operation_id = %op,
                     "registration still in progress after polling; check later with \
-                     `gddy domain operation status`"
+                     `gddy domain operation status {op}`"
                 );
             }
 


### PR DESCRIPTION
## Summary
- Add `gddy domain operation status <operation-id>`, a read-only command wrapping the existing `getOperation` endpoint, so any async domain mutation (purchase today; nameserver/renew/transfer later) has a "check on it later" story once bounded polling gives up.
- FAILED operations are reported as data (exit 0, `status: "FAILED"` + error detail) since the status *check* succeeded — this is a query, not the paid action itself.
- Hoist `format_operation_error`/`is_terminal_status` out of `purchase.rs` into `common.rs` so both commands share them.
- `purchase` now points at `domain operation status <operation-id>` as a next-action when its bounded poll loop gives up before a terminal state.
- Cross-reference the new command from the `domain-purchase` guide.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (214 passed, including updated `domain_commands_require_auth`)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: `gddy domain quote` → `gddy domain purchase --quote-token ... --agree --confirm` → `gddy domain operation status <operation-id>` against a sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)