### PR TITLE
Reorganize module categories and set feature-flag stages

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -560,9 +560,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d8e4bf199623eda4f64cc3f6273143e5cbd080517cb378df40a5fdd3fe0ba"
+checksum = "2f613a33a8bb60112a754a438943ce971bfb950e226df2c41c81d13260f39f25"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.4.1" }
+cli-engine = { features = ["pkce-auth"], version = "0.4.2" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -1,6 +1,6 @@
 use cli_engine::{
     CommandResult, CommandSpec, GroupSpec, Module, NextAction, NextActionParam, RuntimeCommandSpec,
-    RuntimeGroupSpec, Tier,
+    RuntimeGroupSpec, Stage, Tier,
 };
 use serde_json::json;
 
@@ -59,7 +59,7 @@ fn load_action_schema(name: &str) -> Option<serde_json::Value> {
 }
 
 pub fn module() -> Module {
-    Module::new("Contracts", |_ctx| {
+    Module::new("GPA", |_ctx| {
         RuntimeGroupSpec::new(
             GroupSpec::new("actions", "Discover available GoDaddy action contracts")
                 .with_long(
@@ -127,4 +127,5 @@ pub fn module() -> Module {
             },
         ))
     })
+    .with_feature_flag("actions", Stage::Experimental)
 }

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -240,7 +240,7 @@ fn search_endpoints<'a>(catalog: &'a [Domain], query: &str) -> Vec<(&'a Domain, 
 // ---------------------------------------------------------------------------
 
 pub fn module() -> Module {
-    Module::new("Contracts", |_ctx| {
+    Module::new("API", |_ctx| {
         RuntimeGroupSpec::new(
             GroupSpec::new("api", "Explore and call GoDaddy API endpoints").with_long(
                 "Browse the GoDaddy API catalog and make authenticated requests \

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -1274,7 +1274,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
 
 #[cfg(test)]
 mod tests {
-    use cli_engine::{Cli, CliConfig};
+    use cli_engine::{Cli, CliConfig, Stage};
 
     /// API commands must stay fail-closed: `application list` calls the backend,
     /// so it must require authentication. Built with **no auth provider
@@ -1286,6 +1286,7 @@ mod tests {
     async fn application_list_requires_auth() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Experimental)
                 .with_default_auth_provider("godaddy")
                 .with_module(super::super::module()),
         );

--- a/rust/src/application/mod.rs
+++ b/rust/src/application/mod.rs
@@ -1,8 +1,9 @@
 pub mod client;
 mod commands;
 
-use cli_engine::Module;
+use cli_engine::{Module, Stage};
 
 pub fn module() -> Module {
     Module::new("GPA", |_ctx| commands::application_group())
+        .with_feature_flag("application", Stage::Experimental)
 }

--- a/rust/src/hosting/mod.rs
+++ b/rust/src/hosting/mod.rs
@@ -1,6 +1,6 @@
 pub mod nodejs;
 
-use cli_engine::{GroupSpec, Module, RuntimeGroupSpec};
+use cli_engine::{GroupSpec, Module, RuntimeGroupSpec, Stage};
 
 pub fn module() -> Module {
     Module::new("Hosting", |_ctx| {
@@ -13,4 +13,5 @@ pub fn module() -> Module {
         )
         .with_group(nodejs::nodejs_group())
     })
+    .with_feature_flag("hosting", Stage::Beta)
 }

--- a/rust/src/pat/mod.rs
+++ b/rust/src/pat/mod.rs
@@ -281,7 +281,7 @@ fn registry_path_err() -> Result<std::path::PathBuf, CliCoreError> {
 }
 
 pub fn module() -> Module {
-    Module::new("Authentication", |_ctx| {
+    Module::new("Admin", |_ctx| {
         RuntimeGroupSpec::new(
             GroupSpec::new("pat", "Manage Personal Access Tokens (PATs)").with_long(
                 "Store and manage Personal Access Tokens for non-interactive GoDaddy \

--- a/rust/src/webhook/mod.rs
+++ b/rust/src/webhook/mod.rs
@@ -1,5 +1,6 @@
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec, RuntimeGroupSpec, Stage,
+    Tier,
 };
 
 use crate::application::client::api_url_for_env;
@@ -61,4 +62,5 @@ pub fn module() -> Module {
             },
         ))
     })
+    .with_feature_flag("webhook", Stage::Experimental)
 }


### PR DESCRIPTION
## Summary
- Bump `cli-engine` to 0.4.2 to pick up the new `Stage`/`FeatureFlag` API
- Move `pat` under the Admin category; rename the Contracts category to API
- Move `actions_catalog` under GPA and `api_explorer` under API
- Mark every GPA-category module (`application`, `webhook`, `actions`) as `Stage::Experimental`
- Mark `hosting` as `Stage::Beta`

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (214 passed)
- [x] Manually checked `gddy flags list` and `gddy --help` to confirm categories/stages resolved as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)