### PR TITLE
fix(deploy): activate the release and application after deploy (DEVX-539)

### DIFF
--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -128,6 +128,18 @@ impl ApplicationClient {
         .await
     }
 
+    pub async fn activate_release(
+        &self,
+        application_id: &str,
+        release_id: &str,
+    ) -> Result<Value, ClientError> {
+        self.query(json!({
+            "query": "mutation ActivateRelease($applicationId: ID!, $releaseId: ID!) { activateRelease(applicationId: $applicationId, releaseId: $releaseId) { id version description status activatedAt createdAt updatedAt } }",
+            "variables": { "applicationId": application_id, "releaseId": release_id }
+        }))
+        .await
+    }
+
     pub async fn enable_application(&self, input: Value) -> Result<Value, ClientError> {
         self.query(json!({
             "query": "mutation EnableApplication($input: MutationEnableStoreApplicationInput!) { enableStoreApplication(input: $input) { id } }",
@@ -242,5 +254,34 @@ mod tests {
         // Don't hard-code the scheme: a built-in's URL is overridable (a dev
         // may point the default at an http:// local proxy).
         assert!(url.contains("://"), "{url:?}");
+    }
+
+    #[tokio::test]
+    async fn activate_release_sends_ids_and_returns_data() {
+        use httpmock::prelude::*;
+        use serde_json::json;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/apps/app-registry-subgraph")
+                .body_contains("activateRelease")
+                .body_contains("app-1")
+                .body_contains("rel-9");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "data": { "activateRelease": { "id": "rel-9", "version": "1.0.0", "status": "ACTIVE" } }
+            }));
+        });
+
+        let client = super::ApplicationClient::new(server.base_url(), "test-token");
+        let data = client
+            .activate_release("app-1", "rel-9")
+            .await
+            .expect("activate_release should succeed");
+
+        // The mutation was sent with both IDs, and the response data is returned.
+        mock.assert();
+        assert_eq!(data["activateRelease"]["status"], "ACTIVE");
+        assert_eq!(data["activateRelease"]["id"], "rel-9");
     }
 }

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -817,8 +817,34 @@ fn deploy_command() -> RuntimeCommandSpec {
                 .await?;
             }
 
+            // Activate the release, then set the application ACTIVE. This runs
+            // regardless of extension count — without it the app stays INACTIVE
+            // and can't be enabled, so a deploy that only uploads artifacts is
+            // effectively a no-op. (Parity with the TS deploy flow / PR #77.)
             sender
-                .send(json!({ "type": "step", "name": "deploy", "status": "completed", "name": name, "extensions": total }))
+                .send(json!({ "type": "step", "name": "release.activate", "status": "started", "releaseId": release_id }))
+                .await;
+            client
+                .activate_release(&application_id, &release_id)
+                .await
+                .map_err(client_err)?;
+            sender
+                .send(json!({ "type": "step", "name": "release.activate", "status": "completed", "releaseId": release_id }))
+                .await;
+
+            sender
+                .send(json!({ "type": "step", "name": "application.activate", "status": "started", "id": application_id }))
+                .await;
+            client
+                .update_application(&application_id, json!({ "status": "ACTIVE" }))
+                .await
+                .map_err(client_err)?;
+            sender
+                .send(json!({ "type": "step", "name": "application.activate", "status": "completed", "id": application_id }))
+                .await;
+
+            sender
+                .send(json!({ "type": "step", "name": "deploy", "status": "completed", "name": name, "extensions": total, "status_after": "ACTIVE" }))
                 .await;
             Ok(())
         },


### PR DESCRIPTION
## Problem

`gddy application deploy` bundled and uploaded extension artifacts but **never activated anything** — it ended after the extension loop. As a result every app deployed with the Rust CLI stayed **INACTIVE** and could not be enabled, so a deploy was effectively a no-op. Broken for both the extension path and the no-extension path.

## Fix

Ports the TS deploy behavior (PR #77):

- **`ApplicationClient`** — add `activate_release(applicationId, releaseId)`, mirroring the `ActivateRelease` GraphQL mutation (`$applicationId: ID!, $releaseId: ID!`).
- **`deploy_command`** — after the extension loop and **regardless of extension count**, call `activate_release` then `update_application(status: ACTIVE)`, streaming `release.activate` and `application.activate` step events, and reporting `status_after: ACTIVE` on the terminal `deploy` step.

Order matters: the release is activated **before** the application is set ACTIVE.

## Impact

- Deploy with 0 extensions → app ends **ACTIVE**.
- Deploy with ≥1 extension → app ends **ACTIVE**.
- The deployed release is actually usable/enable-able instead of stranded.

## Testing

- New `httpmock` test: `activate_release` sends both IDs and returns the response data.
- `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` — all clean.
- The full end-to-end deploy-flow integration test (T1 — mock credential + streaming) is deferred to the test-layer ticket; this PR covers the new client method directly and the wiring is a small, readable addition.

## Context

Part of the Track A "ship an app" golden path. The terminal streaming `result`/`error` event for `deploy --follow` (DEVX-544) builds on this activation step.
