### PR TITLE
fix(release): include actions, subscriptions, UI extensions in release (DEVX-540)

### DIFF
--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -122,7 +122,7 @@ impl ApplicationClient {
 
     pub async fn create_release(&self, input: Value) -> Result<Value, ClientError> {
         self.query(json!({
-            "query": "mutation CreateRelease($input: MutationCreateReleaseInput!) { createRelease(input: $input) { id version description createdAt } }",
+            "query": "mutation CreateRelease($input: MutationCreateReleaseInput!) { createRelease(input: $input) { id version description createdAt uiExtensions { id name handle type source target } } }",
             "variables": { "input": input }
         }))
         .await

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -654,6 +654,57 @@ fn archive_command() -> RuntimeCommandSpec {
     )
 }
 
+/// Build one `uiExtensions` release entry, enforcing the API's one-target-per-
+/// extension limit. `target` is omitted when the extension has no targets.
+fn ui_extension_entry(
+    name: &str,
+    handle: &str,
+    source: &str,
+    kind: &str,
+    targets: &[crate::config::ExtensionTarget],
+) -> cli_engine::Result<serde_json::Value> {
+    if targets.len() > 1 {
+        return Err(cli_engine::CliCoreError::message(format!(
+            "UI extension '{name}' has {} targets, but only one target is supported per extension during release",
+            targets.len()
+        )));
+    }
+    let mut entry = json!({ "name": name, "handle": handle, "source": source, "type": kind });
+    if let Some(t) = targets.first() {
+        entry["target"] = json!(t.target);
+    }
+    Ok(entry)
+}
+
+/// Map godaddy.toml extensions (embed / checkout / blocks) to the release
+/// `uiExtensions` input. Mirrors the TS release mapping (single target each).
+fn build_ui_extensions(
+    config: &crate::config::Config,
+) -> cli_engine::Result<Vec<serde_json::Value>> {
+    let mut out = Vec::new();
+    let Some(exts) = &config.extensions else {
+        return Ok(out);
+    };
+    for e in &exts.embed {
+        out.push(ui_extension_entry(
+            &e.name, &e.handle, &e.source, "embed", &e.targets,
+        )?);
+    }
+    for e in &exts.checkout {
+        out.push(ui_extension_entry(
+            &e.name, &e.handle, &e.source, "checkout", &e.targets,
+        )?);
+    }
+    if let Some(b) = &exts.blocks {
+        // Blocks carries no name/handle/targets in config; use the same fixed
+        // identifiers the TS release path uses.
+        out.push(
+            json!({ "name": "Blocks", "handle": "blocks", "source": b.source, "type": "blocks" }),
+        );
+    }
+    Ok(out)
+}
+
 fn release_command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_with_context(
         CommandSpec::new("release", "Create a new application release")
@@ -699,6 +750,42 @@ fn release_command() -> RuntimeCommandSpec {
             if let Some(desc) = description {
                 input["description"] = json!(desc);
             }
+
+            // Include actions, webhook subscriptions, and UI extensions from
+            // godaddy.toml so configured behavior is captured in the release.
+            // Without this, everything added via `application add` was silently
+            // dropped. A missing config is non-fatal (empty arrays); a config
+            // with too many targets per extension is a hard error.
+            let (actions, subscriptions, ui_extensions) = match crate::config::read_config(
+                &crate::config::config_path(Some(&ctx.middleware.env)),
+            ) {
+                Ok(config) => {
+                    let actions: Vec<serde_json::Value> = config
+                        .actions
+                        .iter()
+                        .map(|a| json!({ "name": a.name, "url": a.url }))
+                        .collect();
+                    let subscriptions: Vec<serde_json::Value> = config
+                        .subscriptions
+                        .as_ref()
+                        .map(|s| {
+                            s.webhook
+                                .iter()
+                                .map(
+                                    |w| json!({ "name": w.name, "events": w.events, "url": w.url }),
+                                )
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let ui_extensions = build_ui_extensions(&config)?;
+                    (actions, subscriptions, ui_extensions)
+                }
+                Err(_) => (Vec::new(), Vec::new(), Vec::new()),
+            };
+            input["actions"] = json!(actions);
+            input["subscriptions"] = json!(subscriptions);
+            input["uiExtensions"] = json!(ui_extensions);
+
             let client = make_client(&ctx).await?;
             let data = client.create_release(input).await.map_err(client_err)?;
             Ok(
@@ -1312,6 +1399,52 @@ mod tests {
             message.contains("provider"),
             "expected an auth-provider resolution error, got: {}",
             output.rendered
+        );
+    }
+
+    #[test]
+    fn ui_extension_entry_maps_fields_and_target() {
+        use crate::config::ExtensionTarget;
+
+        // No targets: `target` is omitted.
+        let none = super::ui_extension_entry("Widget", "widget", "src/w.ts", "embed", &[])
+            .expect("entry builds");
+        assert_eq!(none["name"], "Widget");
+        assert_eq!(none["handle"], "widget");
+        assert_eq!(none["type"], "embed");
+        assert_eq!(none["source"], "src/w.ts");
+        assert!(none.get("target").is_none());
+
+        // Exactly one target: `target` is set to that value.
+        let one = super::ui_extension_entry(
+            "Widget",
+            "widget",
+            "src/w.ts",
+            "checkout",
+            &[ExtensionTarget {
+                target: "checkout.block".to_owned(),
+            }],
+        )
+        .expect("entry builds");
+        assert_eq!(one["target"], "checkout.block");
+    }
+
+    #[test]
+    fn ui_extension_entry_rejects_multiple_targets() {
+        use crate::config::ExtensionTarget;
+        let targets = vec![
+            ExtensionTarget {
+                target: "a".to_owned(),
+            },
+            ExtensionTarget {
+                target: "b".to_owned(),
+            },
+        ];
+        let err = super::ui_extension_entry("Widget", "widget", "src/w.ts", "embed", &targets)
+            .expect_err("more than one target must be rejected");
+        assert!(
+            err.to_string().contains("only one target is supported"),
+            "unexpected error: {err}"
         );
     }
 }


### PR DESCRIPTION
## Problem

`gddy application release` built its `createRelease` input from CLI args only — `{ applicationId, version, description }`. Everything a developer adds to `godaddy.toml` via `application add` — **actions, webhook subscriptions, and UI extensions** — was silently dropped from the release, so those configs never reached the platform.

## Fix

Ports the TS release input (PR #58). `release_command` now reads `godaddy.toml` and includes:

- **`actions`** — from `config.actions` (`{ name, url }`)
- **`subscriptions`** — flattened from `config.subscriptions.webhook` (`{ name, events, url }`)
- **`uiExtensions`** — from `config.extensions` (embed / checkout / blocks), mapped to the release shape `{ name, handle, source, type, target? }`

Details:
- Missing `godaddy.toml` is **non-fatal** (empty arrays), matching the TS behavior.
- **One target per extension** is enforced (API limit) — more than one is a hard error.
- `blocks` maps to `name: "Blocks"`, `handle: "blocks"` (same fixed identifiers as the TS path); `target` is omitted when an extension has no targets.
- `createRelease` now also returns `uiExtensions` in its selection set, for verification (PR #58).

## Impact

Action hooks, webhook subscriptions, and UI extensions configured via `application add` are now actually included in the release instead of being dropped.

## Testing

- Unit tests: `ui_extension_entry` field/target mapping (no target omitted, one target set) and multi-target rejection.
- `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` — all clean.
- Full release-flow integration test (mock credential) deferred to the test-layer ticket; the mapping/validation logic is unit-tested directly.

## Context

Track A ("ship an app"). Pairs with DEVX-539 (deploy activation) and DEVX-541 (UI extension targets on `application add`, which populates the `targets` this maps from).
