### PR TITLE
fix: make -h an alias for --help on every command

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -21,7 +21,7 @@ mod webhook;
 
 use std::{process::ExitCode, sync::Arc};
 
-use clap::Arg;
+use clap::{Arg, ArgAction};
 use cli_engine::{BuildInfo, Cli, CliConfig};
 
 use crate::env::get_env;
@@ -61,16 +61,28 @@ async fn main() -> ExitCode {
             .with_default_auth_provider("godaddy")
             .with_auth_provider(auth_provider)
             .with_register_flags(Arc::new(|cmd| {
-                cmd.arg(
-                    Arg::new("env")
-                        .long("env")
-                        .global(true)
-                        .value_name("ENV")
-                        .default_value(
-                            get_env().unwrap_or_else(|| environments::DEFAULT_ENV.to_owned()),
-                        )
-                        .help("Target environment: prod or ote"),
-                )
+                cmd.disable_help_flag(true)
+                    .arg(
+                        // clap's default help arg shows a short summary for
+                        // `-h` and the full text for `--help`. Override it so
+                        // both flags print the same full help everywhere.
+                        Arg::new("help")
+                            .short('h')
+                            .long("help")
+                            .action(ArgAction::HelpLong)
+                            .global(true)
+                            .help("Print help"),
+                    )
+                    .arg(
+                        Arg::new("env")
+                            .long("env")
+                            .global(true)
+                            .value_name("ENV")
+                            .default_value(
+                                get_env().unwrap_or_else(|| environments::DEFAULT_ENV.to_owned()),
+                            )
+                            .help("Target environment: prod or ote"),
+                    )
             }))
             .with_apply_flags(Arc::new(|matches, mw| {
                 if let Some(env) = matches.get_one::<String>("env") {


### PR DESCRIPTION
## Summary
- clap's default help arg shows an abbreviated summary for `-h` and the full help text for `--help`.
- Registers a global custom `help` arg using `ArgAction::HelpLong`, disabling clap's default help flag, so both `-h` and `--help` print identical, full help text everywhere.

## Changes
- `rust/src/main.rs`: disable the default help flag on the root command and register a global `-h`/`--help` arg with `ArgAction::HelpLong`.

## Test plan
- [x] `cargo run -- -h` and `cargo run -- --help` print identical output at the root command
- [x] Same check on a subcommand (e.g. `cargo run -- domain list -h` vs `--help`)
