### PR TITLE
[DEVEX-704] fix: activate release and promote app to ACTIVE on deploy

### DIFF
--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -128,6 +128,18 @@ impl ApplicationClient {
         .await
     }
 
+    pub async fn activate_release(
+        &self,
+        application_id: &str,
+        release_id: &str,
+    ) -> Result<Value, ClientError> {
+        self.query(json!({
+            "query": "mutation ActivateRelease($applicationId: ID!, $releaseId: ID!) { activateRelease(applicationId: $applicationId, releaseId: $releaseId) { id version description status activatedAt createdAt updatedAt } }",
+            "variables": { "applicationId": application_id, "releaseId": release_id }
+        }))
+        .await
+    }
+
     pub async fn enable_application(&self, input: Value) -> Result<Value, ClientError> {
         self.query(json!({
             "query": "mutation EnableApplication($input: MutationEnableStoreApplicationInput!) { enableStoreApplication(input: $input) { id } }",
@@ -220,7 +232,9 @@ pub fn api_url_for_env(env: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::api_url_for_env;
+    use httpmock::prelude::*;
+
+    use super::*;
 
     #[test]
     fn api_url_for_builtins_resolve_to_a_url() {
@@ -242,5 +256,96 @@ mod tests {
         // Don't hard-code the scheme: a built-in's URL is overridable (a dev
         // may point the default at an http:// local proxy).
         assert!(url.contains("://"), "{url:?}");
+    }
+
+    #[tokio::test]
+    async fn activate_release_posts_mutation_with_ids() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .header("authorization", "Bearer test-token")
+                    .matches(|req| {
+                        req.body
+                            .as_ref()
+                            .map(|b| {
+                                let body = String::from_utf8_lossy(b);
+                                body.contains("activateRelease")
+                                    && body.contains("app-123")
+                                    && body.contains("rel-456")
+                            })
+                            .unwrap_or(false)
+                    });
+                then.status(200).json_body(json!({
+                    "data": { "activateRelease": { "id": "rel-456", "status": "ACTIVE" } }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .activate_release("app-123", "rel-456")
+            .await
+            .expect("activate release");
+
+        mock.assert_async().await;
+        assert_eq!(data["activateRelease"]["status"], "ACTIVE");
+    }
+
+    #[tokio::test]
+    async fn activate_release_surfaces_graphql_errors() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/v1/apps/app-registry-subgraph");
+                // GraphQL reports failures as HTTP 200 with an `errors` array.
+                then.status(200).json_body(json!({
+                    "errors": [{ "message": "release not found" }]
+                }));
+            })
+            .await;
+
+        let err = ApplicationClient::new(server.base_url(), "test-token")
+            .activate_release("app-123", "missing")
+            .await
+            .expect_err("graphql errors should surface");
+
+        mock.assert_async().await;
+        assert!(
+            matches!(err, ClientError::GraphQL(msg) if msg.contains("release not found")),
+            "expected GraphQL error variant"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_application_promotes_to_active() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .matches(|req| {
+                        req.body
+                            .as_ref()
+                            .map(|b| {
+                                let body = String::from_utf8_lossy(b);
+                                body.contains("updateApplication")
+                                    && body.contains(r#""status":"ACTIVE""#)
+                            })
+                            .unwrap_or(false)
+                    });
+                then.status(200).json_body(json!({
+                    "data": { "updateApplication": { "id": "app-1", "status": "ACTIVE" } }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .update_application("app-1", json!({ "status": "ACTIVE" }))
+            .await
+            .expect("update application");
+
+        mock.assert_async().await;
+        assert_eq!(data["updateApplication"]["status"], "ACTIVE");
     }
 }

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -817,12 +817,46 @@ fn deploy_command() -> RuntimeCommandSpec {
                 .await?;
             }
 
+            finalize_deploy_activation(&client, &sender, &application_id, &release_id).await?;
+
             sender
                 .send(json!({ "type": "step", "name": "deploy", "status": "completed", "name": name, "extensions": total }))
                 .await;
             Ok(())
         },
     )
+}
+
+/// Finalize a deploy: activate the release, then promote the application to
+/// `ACTIVE`. Deploy must activate the release before promoting the application.
+async fn finalize_deploy_activation(
+    client: &ApplicationClient,
+    sender: &StreamSender,
+    application_id: &str,
+    release_id: &str,
+) -> cli_engine::Result<()> {
+    sender
+        .send(json!({ "type": "step", "name": "release.activate", "status": "started" }))
+        .await;
+    client
+        .activate_release(application_id, release_id)
+        .await
+        .map_err(client_err)?;
+    sender
+        .send(json!({ "type": "step", "name": "release.activate", "status": "completed" }))
+        .await;
+    sender
+        .send(json!({ "type": "step", "name": "application.activate", "status": "started" }))
+        .await;
+    client
+        .update_application(application_id, json!({ "status": "ACTIVE" }))
+        .await
+        .map_err(client_err)?;
+    sender
+        .send(json!({ "type": "step", "name": "application.activate", "status": "completed" }))
+        .await;
+
+    Ok(())
 }
 
 /// Collect extension source files from config, returning (name, source_path, ext_type) triples.


### PR DESCRIPTION
## Summary
`application deploy` uploaded artifacts but never activated the release or set the app to `ACTIVE`, leaving deployed apps inactive. Adds a finalize step that activates the release, then promotes the app. Resolves [DEVEX-704](https://godaddy-corp.atlassian.net/browse/DEVEX-704).

## Changes
- `client`: add `activate_release`
- `deploy`: call `finalize_deploy_activation` after the upload loop, `activateRelease` then `updateApplication(status: ACTIVE)`. (The ticket names only the `ACTIVE` step, but current TS version does both).
- `tests`: client-level httpmock for both mutations (+ GraphQL-error path).

## Testing
- `fmt` / `clippy -D warnings` / `test` green.
- Not manually tested E2E — `application` is gated experimental, open to a manual pass if there's a preferred way to test gated commands.