### PR TITLE
fix(auth): validate requested OAuth scopes against the CLI's registry (DEVEX-894)

### DIFF
--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -126,7 +126,7 @@ fn validate_requested_scopes(requested: &[String]) -> Result<()> {
         return Ok(());
     }
     Err(CliCoreError::message(format!(
-        "unknown OAuth scope(s) requested: {} (not registered for the gddy OAuth client)",
+        "unsupported OAuth scope(s) requested: {}",
         unknown.join(", ")
     )))
 }
@@ -241,8 +241,7 @@ mod tests {
             .expect_err("scope is not in the registry");
         assert_eq!(
             err.to_string(),
-            "unknown OAuth scope(s) requested: domains.domain:write \
-             (not registered for the gddy OAuth client)"
+            "unsupported OAuth scope(s) requested: domains.domain:write"
         );
     }
 
@@ -266,8 +265,7 @@ mod tests {
             .expect_err("scope is not in the registry");
         assert_eq!(
             err.to_string(),
-            "unknown OAuth scope(s) requested: bogus:scope \
-             (not registered for the gddy OAuth client)"
+            "unsupported OAuth scope(s) requested: bogus:scope"
         );
     }
 }

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -115,16 +115,18 @@ fn log_resolved_oauth(env: &ResolvedEnv) {
 /// reject it anyway. Catching it here turns that into a clear, local error
 /// instead of the auth server's `invalid_scope`.
 fn validate_requested_scopes(requested: &[String]) -> Result<()> {
+    let mut seen = std::collections::HashSet::new();
     let unknown: Vec<&str> = requested
         .iter()
         .map(String::as_str)
         .filter(|scope| *scope != scopes::OFFLINE_ACCESS && !scopes::ALL.contains(scope))
+        .filter(|scope| seen.insert(*scope))
         .collect();
     if unknown.is_empty() {
         return Ok(());
     }
     Err(CliCoreError::message(format!(
-        "unsupported OAuth scope(s) requested: {}",
+        "unknown OAuth scope(s) requested: {} (not registered for the gddy OAuth client)",
         unknown.join(", ")
     )))
 }
@@ -237,7 +239,11 @@ mod tests {
     fn validate_requested_scopes_rejects_unregistered_scope() {
         let err = validate_requested_scopes(&["domains.domain:write".to_owned()])
             .expect_err("scope is not in the registry");
-        assert!(err.to_string().contains("domains.domain:write"));
+        assert_eq!(
+            err.to_string(),
+            "unknown OAuth scope(s) requested: domains.domain:write \
+             (not registered for the gddy OAuth client)"
+        );
     }
 
     #[test]
@@ -252,5 +258,16 @@ mod tests {
         assert!(message.contains("bogus:scope"));
         assert!(message.contains("another:bogus"));
         assert!(!message.contains(scopes::DOMAINS_READ));
+    }
+
+    #[test]
+    fn validate_requested_scopes_dedupes_repeated_unknown_scopes() {
+        let err = validate_requested_scopes(&["bogus:scope".to_owned(), "bogus:scope".to_owned()])
+            .expect_err("scope is not in the registry");
+        assert_eq!(
+            err.to_string(),
+            "unknown OAuth scope(s) requested: bogus:scope \
+             (not registered for the gddy OAuth client)"
+        );
     }
 }

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -6,6 +6,7 @@ use cli_engine::{
 
 use crate::environments::{self, ResolvedEnv};
 use crate::pat::{self, PatEntry};
+use crate::scopes;
 
 /// Single auth provider that dispatches to env-specific PKCE providers.
 ///
@@ -104,6 +105,30 @@ fn log_resolved_oauth(env: &ResolvedEnv) {
     );
 }
 
+/// Rejects any scope in `requested` that isn't registered in [`scopes`] —
+/// [`scopes::ALL`] plus the standalone [`scopes::OFFLINE_ACCESS`] directive
+/// scope.
+///
+/// A scope missing from that list is, by construction, either misspelled or
+/// was never registered on the CLI's OAuth client (see the "Adding a scope"
+/// steps in the [`scopes`] module docs), so the authorization server would
+/// reject it anyway. Catching it here turns that into a clear, local error
+/// instead of the auth server's `invalid_scope`.
+fn validate_requested_scopes(requested: &[String]) -> Result<()> {
+    let unknown: Vec<&str> = requested
+        .iter()
+        .map(String::as_str)
+        .filter(|scope| *scope != scopes::OFFLINE_ACCESS && !scopes::ALL.contains(scope))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    Err(CliCoreError::message(format!(
+        "unsupported OAuth scope(s) requested: {}",
+        unknown.join(", ")
+    )))
+}
+
 #[async_trait]
 impl AuthProvider for GoDaddyAuthProvider {
     fn name(&self) -> &str {
@@ -123,6 +148,21 @@ impl AuthProvider for GoDaddyAuthProvider {
         // configured, otherwise fall back to PKCE OAuth scope step-up.
         if let Some(entry) = pat::resolve_pat(req.env).await {
             return Ok(pat_credential(req.env, &entry));
+        }
+        // `Dispatcher::login_with_scopes` (the handler behind `auth login
+        // --scope`) synthesizes its `CredentialRequest` with an empty command
+        // path — no ordinary command routes through `get_credential_for` with
+        // `command` unset. That makes it the one place to validate explicitly
+        // *requested* scopes against the CLI's authoritative registry before
+        // asking the authorization server, so a misspelled or unregistered
+        // `--scope` fails fast with a readable message instead of surfacing as
+        // the auth server's opaque `invalid_scope`. Regular commands'
+        // `with_scopes`-declared scopes, and `api call --scope`'s ad-hoc
+        // catalog-derived scopes, are deliberately not re-validated here — see
+        // the module docs on [`scopes`] for why those fall outside the
+        // registry.
+        if req.command.is_empty() {
+            validate_requested_scopes(&req.meta.scopes)?;
         }
         let provider = self.provider_for(req.env)?;
         provider.get_credential_for(req).await
@@ -168,5 +208,49 @@ impl AuthProvider for GoDaddyAuthProvider {
             envs.extend(provider.list_environments().await.unwrap_or_default());
         }
         Ok(envs.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_requested_scopes_accepts_known_and_empty() {
+        assert!(validate_requested_scopes(&[]).is_ok());
+        assert!(validate_requested_scopes(&[scopes::DOMAINS_READ.to_owned()]).is_ok());
+        assert!(
+            validate_requested_scopes(&[
+                scopes::DOMAINS_READ.to_owned(),
+                scopes::HOSTING_APPS_READ.to_owned(),
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_requested_scopes_accepts_offline_access() {
+        assert!(validate_requested_scopes(&[scopes::OFFLINE_ACCESS.to_owned()]).is_ok());
+    }
+
+    #[test]
+    fn validate_requested_scopes_rejects_unregistered_scope() {
+        let err = validate_requested_scopes(&["domains.domain:write".to_owned()])
+            .expect_err("scope is not in the registry");
+        assert!(err.to_string().contains("domains.domain:write"));
+    }
+
+    #[test]
+    fn validate_requested_scopes_reports_every_unknown_scope() {
+        let err = validate_requested_scopes(&[
+            scopes::DOMAINS_READ.to_owned(),
+            "bogus:scope".to_owned(),
+            "another:bogus".to_owned(),
+        ])
+        .expect_err("two scopes are not in the registry");
+        let message = err.to_string();
+        assert!(message.contains("bogus:scope"));
+        assert!(message.contains("another:bogus"));
+        assert!(!message.contains(scopes::DOMAINS_READ));
     }
 }


### PR DESCRIPTION
## Summary
- `gddy auth login --scope <scope>` requesting an unregistered scope currently round-trips to the authorization server and fails with an opaque `invalid_scope` (DEVEX-894, linked GDDEVPLAT-18: `domains.domain:write` was never a registered scope — the actual write-side scopes are `domains.dns:update`, `domains.domain:create`, `domains.nameserver:update`).
- Validates explicitly-requested `--scope` flags against the CLI's authoritative registry (`scopes::ALL` + `scopes::OFFLINE_ACCESS`) before contacting the auth server, failing fast with a readable local error instead.
- Scoped to only the `auth login --scope` step-up path (detected via cli-engine's `Dispatcher::login_with_scopes` synthesizing an empty command path) — regular commands' `with_scopes`-declared scopes and `api call --scope`'s ad-hoc catalog-derived scopes are intentionally not re-validated, per the existing docs in `scopes.rs`.
- De-dupes repeated unknown scopes (order-preserving) so passing the same unregistered scope multiple times reports it once, not N times.

## Test plan
- [x] `cargo test --bin gddy` — 248/248 passing, including 5 unit tests for `validate_requested_scopes`
- [x] `cargo clippy --bin gddy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manually reproduced the ticket: `gddy auth login --env test --scope domains.domain:read --scope domains.domain:write` now fails immediately with a local error naming the unregistered scope, instead of round-tripping to the auth server
- [x] Manually confirmed `gddy auth login --env test --scope domains.domain:read` and plain `gddy auth login --env test` still proceed into the real PKCE browser flow (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)