### PR TITLE
docs(skill): update gddy skill for payments -> payment-methods rename (DEVEX-900)

### DIFF
--- a/.agents/skills/gddy/SKILL.md
+++ b/.agents/skills/gddy/SKILL.md
@@ -58,9 +58,9 @@ gddy dns delete example.com --type A --name www
 
 `set` and `delete` are destructive. Run with `--dry-run` first and show the user what would change before applying it for real.
 
-## Payments
+## Payment Methods
 
-`gddy payments add` opens the browser to the account's payment-methods page — no card data is ever handled by the CLI itself. Purchases fail (403/422) without a valid payment method or sufficient account balance; check the error's `code` field, not just the HTTP status, to tell that apart from other failures.
+`gddy payment-methods add` opens the browser to the account's payment-methods page — no card data is ever handled by the CLI itself. Purchases fail (403/422) without a valid payment method or sufficient account balance; check the error's `code` field, not just the HTTP status, to tell that apart from other failures.
 
 ## Reference material
 

--- a/.agents/skills/gddy/reference/errors-and-limits.md
+++ b/.agents/skills/gddy/reference/errors-and-limits.md
@@ -55,7 +55,7 @@ These are the `code` values you'll actually see while quoting/registering a doma
 |---|---|---|
 | `DOMAIN_NOT_AVAILABLE` | Someone else registered the name first (race between check and purchase). | Re-check availability, suggest alternatives. |
 | `BILLING_DECLINED` | Payment method on file was charged and declined. | Surface to the user — they need to fix their payment method. |
-| `NO_PAYMENT_PROFILE` | No payment method on the account at all. | Direct the user to `gddy payments add` or the account's payment-methods page. |
+| `NO_PAYMENT_PROFILE` | No payment method on the account at all. | Direct the user to `gddy payment-methods add` or the account's payment-methods page. |
 | `QUOTE_MISMATCH` | The `period` (or other term) at execute time doesn't match what was quoted. | Reuse the exact period from the quote, or fetch a fresh quote. |
 | `INVALID_AGREEMENT_KEYS` | `agreementTypes` sent don't match the TLD's `requiredAgreements` from the quote. | Use the exact keys the quote response returned, not guessed/remembered ones. |
 | `MISSING_CONTACT` | No registrant contact configured on the account. | Set up contacts (`gddy domain contacts init`, then fill in the file) before quoting. |


### PR DESCRIPTION
## Summary
- Update `.agents/skills/gddy/SKILL.md` and `reference/errors-and-limits.md` to reference `gddy payment-methods add` instead of `gddy payments add`, matching the CLI rename in the companion PR against `rust-port`.

## Test plan
- [x] `grep -rn "gddy payments" .agents/skills/gddy/` returns no matches after the change.

DEVEX-900