### PR TITLE
fix(payment-methods): rename gddy payments to gddy payment-methods (DEVEX-900)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Returns environment/auth snapshots and the full command tree.
 - `gddy application add extension checkout --name <name> --handle <handle> --source <source> --target <targets>`
 - `gddy application add extension blocks --source <source>`
 
-### Payments
+### Payment Methods
 
-- `gddy payments`
-- `gddy payments add` — opens your default browser to the GoDaddy payment methods management page. Only credit card or Good-as-Gold can be used for domain purchases.
+- `gddy payment-methods`
+- `gddy payment-methods add` — opens your default browser to the GoDaddy payment methods management page. Only credit card or Good-as-Gold can be used for domain purchases.
 
 ### Webhooks
 

--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -205,7 +205,7 @@ fn format_api_error(
     if status == 402 {
         msg.push_str(
             "\n\nThis usually means your account has no usable payment method. Add one with \
-             `gddy payments add` (a credit card or Good-as-Gold balance is required for domain \
+             `gddy payment-methods add` (a credit card or Good-as-Gold balance is required for domain \
              purchases), then try again.",
         );
     }
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn payment_required_error_points_to_payments_add() {
+    fn payment_required_error_points_to_payment_methods_add() {
         let msg = format_api_error(
             "domain purchase",
             402,
@@ -439,7 +439,7 @@ mod tests {
             false,
         );
         assert!(msg.contains("402 Payment Required"), "{msg}");
-        assert!(msg.contains("gddy payments add"), "{msg}");
+        assert!(msg.contains("gddy payment-methods add"), "{msg}");
     }
 
     #[test]

--- a/rust/src/domain/purchase.rs
+++ b/rust/src/domain/purchase.rs
@@ -146,7 +146,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                  `purchase` accepts the token, records your consent to the quote's legal \
                  agreements (--agree), then registers and waits for the registry to \
                  finish. A usable payment method must be on file — add one with \
-                 `gddy payments add`.\n\
+                 `gddy payment-methods add`.\n\
                  \n\
                  Typical flow:\n  \
                  1. gddy domain quote example.com          # review price + agreements\n  \

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,7 +13,7 @@ mod hosting;
 mod next_action;
 mod output_schema;
 mod pat;
-mod payments;
+mod payment_methods;
 mod quote_cache;
 mod scopes;
 mod update;
@@ -47,7 +47,7 @@ async fn main() -> ExitCode {
                  • api      — explore and call GoDaddy REST API endpoints directly\n  \
                  • application — build, configure, and deploy platform applications\n  \
                  • hosting  — manage Node.js PaaS applications (create, upload, deploy)\n  \
-                 • payments — manage the payment methods used for purchases\n\
+                 • payment-methods — manage the payment methods used for purchases\n\
                  \n\
                  Most commands need authentication; run `gddy auth login` first, or use a PAT via `gddy pat add` / `GDDY_PAT` for non-interactive workflows (or just run a\n\
                  command and follow the prompt). Use `--env` to target an environment and\n\
@@ -107,7 +107,7 @@ async fn main() -> ExitCode {
             .with_module(env::module())
             .with_module(hosting::module())
             .with_module(pat::module())
-            .with_module(payments::module())
+            .with_module(payment_methods::module())
             .with_module(update::module())
             .with_module(webhook::module()),
     );

--- a/rust/src/payment_methods/mod.rs
+++ b/rust/src/payment_methods/mod.rs
@@ -1,4 +1,4 @@
-//! `gddy payments` — payment method management.
+//! `gddy payment-methods` — payment method management.
 
 use cli_engine::{
     CliCoreError, CommandResult, CommandSpec, GroupSpec, Module, NextActionParam,
@@ -14,13 +14,13 @@ fn map_env_err(e: environments::EnvError) -> CliCoreError {
 }
 
 pub fn module() -> Module {
-    Module::new("Payments", |_ctx| {
+    Module::new("Payment Methods", |_ctx| {
         RuntimeGroupSpec::new(
-            GroupSpec::new("payments", "Manage payment methods").with_long(
+            GroupSpec::new("payment-methods", "Manage payment methods").with_long(
                 "Manage the payment methods on your GoDaddy account.\n\
                      A saved payment method is required before you can run \
                      `gddy domain purchase`.\n\
-                     Use `gddy payments add` to open the GoDaddy payment methods \
+                     Use `gddy payment-methods add` to open the GoDaddy payment methods \
                      page in your browser.",
             ),
         )
@@ -38,7 +38,7 @@ fn add_command() -> RuntimeCommandSpec {
             "Opens your default browser to the GoDaddy payment methods management page.\n\
                  Note: only credit card or Good-as-Gold can be used for domain purchases.",
         )
-        .with_system("payments")
+        .with_system("payment-methods")
         .with_tier(Tier::Mutate)
         .no_auth(true),
         |ctx| async move {


### PR DESCRIPTION
## Summary
- Rename the gddy payments command group to gddy payment-methods (module rust/src/payments/ -> rust/src/payment_methods/, clap group name, telemetry with_system tag).
- Update cross-referencing help/error text in domain purchase, domain/common.rs 402 error message, and README.md.
- Rename the common.rs test to match (payment_required_error_points_to_payment_methods_add).

rust/schemas/api/payments.json and the API-explorer "payments" API domain catalog entry are untouched (unrelated Payments API domain).

## Test plan
- [x] cargo build
- [x] cargo test (253 passed)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo run -- payment-methods add --help shows correct help text
- [x] cargo run -- payments add errors with "unknown command" (old name removed)
- [x] cargo run -- domain purchase --help cross-reference text says gddy payment-methods add

DEVEX-900