### PR TITLE
[DEVEX-707] fix(application init): align with TS config seeding and validation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "zip",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2"] }
 iso_currency = "0.5.3"
+url = "2"
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -427,7 +427,8 @@ fn init_command() -> RuntimeCommandSpec {
             let secret = app["secret"].as_str().unwrap_or("").to_owned();
             let public_key = app["publicKey"].as_str().unwrap_or("").to_owned();
 
-            // Write godaddy.toml for the created application
+            // Best-effort local writes: app create already succeeded. Only paths that
+            // actually write are included in filesWritten.
             let config = crate::config::Config {
                 name: name.clone(),
                 client_id: client_id.clone(),
@@ -441,21 +442,6 @@ fn init_command() -> RuntimeCommandSpec {
                 dependencies: vec![],
                 extensions: None,
             };
-            if let Err(e) = crate::config::write_config(&config_path, &config) {
-                tracing::warn!(error = %e, "failed to write godaddy.toml; continuing");
-            }
-
-            // Best-effort: a failed .env write shouldn't fail the already-created app.
-            if let Err(e) = crate::config::write_env_file(
-                Some(&env),
-                &secret,
-                &public_key,
-                &client_id,
-                &client_secret,
-            ) {
-                tracing::warn!(error = %e, "failed to write .env; continuing");
-            }
-
             let cwd = match std::env::current_dir() {
                 Ok(dir) => dir,
                 Err(e) => {
@@ -466,10 +452,33 @@ fn init_command() -> RuntimeCommandSpec {
                     std::path::PathBuf::new()
                 }
             };
-            let files_written = json!({
-                "config": cwd.join(&config_path).display().to_string(),
-                "env": cwd.join(crate::config::env_path(Some(&env))).display().to_string(),
-            });
+
+            let mut files_written = serde_json::Map::new();
+            if let Err(e) = crate::config::write_config(&config_path, &config) {
+                tracing::warn!(error = %e, path = %config_path.display(), "failed to write config; continuing");
+            } else {
+                files_written.insert(
+                    "config".to_owned(),
+                    json!(cwd.join(&config_path).display().to_string()),
+                );
+            }
+
+            let env_file_path = crate::config::env_path(Some(&env));
+            if let Err(e) = crate::config::write_env_file(
+                Some(&env),
+                &secret,
+                &public_key,
+                &client_id,
+                &client_secret,
+            ) {
+                tracing::warn!(error = %e, path = %env_file_path.display(), "failed to write env file; continuing");
+            } else {
+                files_written.insert(
+                    "env".to_owned(),
+                    json!(cwd.join(&env_file_path).display().to_string()),
+                );
+            }
+
             let result = json!({
                 "id": app["id"].as_str().unwrap_or("").to_owned(),
                 "name": name,

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -318,13 +318,13 @@ fn init_command() -> RuntimeCommandSpec {
                 clap::Arg::new("url")
                     .long("url")
                     .value_name("URL")
-                    .help("Application URL (must be public HTTPS)"),
+                    .help("Application URL (must be public HTTP(S))"),
             )
             .with_arg(
                 clap::Arg::new("proxy-url")
                     .long("proxy-url")
                     .value_name("URL")
-                    .help("Proxy URL (must be public HTTPS)"),
+                    .help("Proxy URL (must be public HTTP(S))"),
             )
             .with_arg(
                 clap::Arg::new("scopes")

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -22,19 +22,16 @@ output_schema!(ApplicationSummary {
     "proxyUrl": "string", optional;
 });
 
-output_schema!(ApplicationCredentials {
+output_schema!(ApplicationInit {
     "id": "string";
-    "clientId": "string";
-    "clientSecret": "string";
     "name": "string";
-    "label": "string", optional;
-    "description": "string", optional;
     "status": "string";
-    "url": "string", optional;
-    "proxyUrl": "string", optional;
+    "clientId": "string";
+    "url": "string";
+    "proxyUrl": "string";
     "authorizationScopes": "[]string";
-    "secret": "string", optional;
-    "publicKey": "string", optional;
+    "oauthGrantTypes": "[]string";
+    "filesWritten": "object";
 });
 
 output_schema!(ApplicationUpdate {
@@ -297,13 +294,12 @@ fn init_command() -> RuntimeCommandSpec {
             .with_system("applications")
             .with_tier(Tier::Mutate)
             .with_scopes(&[APP_REGISTRY_READ, APP_REGISTRY_WRITE])
-            .with_output_schema::<ApplicationCredentials>()
+            .with_output_schema::<ApplicationInit>()
             .with_arg(
                 clap::Arg::new("name")
                     .long("name")
                     .short('n')
                     .value_name("NAME")
-                    .required(true)
                     .help("Application name (used as label if --label is not set)"),
             )
             .with_arg(
@@ -316,50 +312,100 @@ fn init_command() -> RuntimeCommandSpec {
                 clap::Arg::new("description")
                     .long("description")
                     .value_name("TEXT")
-                    .required(true)
                     .help("Application description"),
             )
             .with_arg(
                 clap::Arg::new("url")
                     .long("url")
                     .value_name("URL")
-                    .required(true)
                     .help("Application URL (must be public HTTPS)"),
             )
             .with_arg(
                 clap::Arg::new("proxy-url")
                     .long("proxy-url")
                     .value_name("URL")
-                    .help("Proxy URL (defaults to url)"),
+                    .help("Proxy URL (must be public HTTPS)"),
             )
             .with_arg(
                 clap::Arg::new("scopes")
                     .long("scopes")
                     .value_name("SCOPES")
                     .help("Comma-separated authorization scopes"),
+            )
+            .with_arg(
+                clap::Arg::new("config")
+                    .long("config")
+                    .short('c')
+                    .value_name("PATH")
+                    .help("Read defaults from this config file"),
             ),
         |ctx| async move {
-            let name = arg_str(&ctx, "name").to_owned();
-            let label = ctx
-                .args
-                .get("label")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&name)
-                .to_owned();
-            let description = arg_str(&ctx, "description").to_owned();
-            let url = arg_str(&ctx, "url").to_owned();
-            let proxy_url = ctx
-                .args
-                .get("proxy-url")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&url)
-                .to_owned();
-            let scopes: Vec<String> = ctx
-                .args
-                .get("scopes")
-                .and_then(|v| v.as_str())
-                .map(|s| s.split(',').map(|p| p.trim().to_owned()).collect())
-                .unwrap_or_else(|| vec!["apps.app-registry:read".to_owned()]);
+            let env = ctx.middleware.env.clone();
+            let config_path = crate::config::config_path(Some(&env));
+
+            // Seed defaults only from an explicit --config; a bad/missing --config is fatal.
+            let existing = match ctx.args.get("config").and_then(|v| v.as_str()) {
+                Some(path) => Some(
+                    crate::config::read_config(std::path::Path::new(path)).map_err(|e| {
+                        cli_engine::CliCoreError::message(format!("invalid config: {e}"))
+                    })?,
+                ),
+                None => None,
+            };
+
+            // Resolve each field: CLI flag, else the existing config's value, else a default.
+            let flag = |key: &str| ctx.args.get(key).and_then(|v| v.as_str());
+            let name = flag("name")
+                .map(str::to_owned)
+                .or_else(|| existing.as_ref().map(|c| c.name.clone()))
+                .unwrap_or_default();
+            let description = flag("description")
+                .map(str::to_owned)
+                .or_else(|| existing.as_ref().and_then(|c| c.description.clone()))
+                .unwrap_or_default();
+            let url = flag("url")
+                .map(str::to_owned)
+                .or_else(|| existing.as_ref().map(|c| c.url.clone()))
+                .unwrap_or_default();
+            let proxy_url = flag("proxy-url")
+                .map(str::to_owned)
+                .or_else(|| existing.as_ref().map(|c| c.proxy_url.clone()))
+                .unwrap_or_default();
+            let scopes: Vec<String> = flag("scopes")
+                .map(|s| {
+                    s.split(',')
+                        .map(str::trim)
+                        .filter(|p| !p.is_empty())
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .or_else(|| existing.as_ref().map(|c| c.authorization_scopes.clone()))
+                .unwrap_or_default();
+            let label = flag("label").unwrap_or(&name).to_owned();
+
+            for (message, empty) in [
+                ("Application name is required", name.is_empty()),
+                (
+                    "Application description is required",
+                    description.is_empty(),
+                ),
+                ("Application URL is required", url.is_empty()),
+                ("Proxy URL is required", proxy_url.is_empty()),
+                ("Authorization scopes are required", scopes.is_empty()),
+            ] {
+                if empty {
+                    return Err(cli_engine::CliCoreError::message(message));
+                }
+            }
+
+            for (field, u) in [("url", &url), ("proxyUrl", &proxy_url)] {
+                if !crate::application::public_url::is_public_routable_url(u) {
+                    return Err(cli_engine::CliCoreError::message(format!(
+                        "Invalid application configuration: {field} must be a publicly-resolvable \
+                         http(s) URL (localhost, loopback, and private IPs are not allowed)"
+                    )));
+                }
+            }
 
             let client = make_client(&ctx).await?;
             let data = client
@@ -375,31 +421,67 @@ fn init_command() -> RuntimeCommandSpec {
                 .map_err(client_err)?;
 
             let app = &data["createApplication"];
+            // Credentials/secrets the API returns (all selected by create_application).
             let client_id = app["clientId"].as_str().unwrap_or("").to_owned();
+            let client_secret = app["clientSecret"].as_str().unwrap_or("").to_owned();
+            let secret = app["secret"].as_str().unwrap_or("").to_owned();
+            let public_key = app["publicKey"].as_str().unwrap_or("").to_owned();
 
             // Write godaddy.toml for the created application
-            let config_path = crate::config::config_path(Some(ctx.middleware.env.as_str()));
             let config = crate::config::Config {
                 name: name.clone(),
                 client_id: client_id.clone(),
                 description: Some(description.clone()),
                 version: "0.0.0".to_owned(),
                 url: url.clone(),
-                proxy_url,
-                authorization_scopes: scopes,
+                proxy_url: proxy_url.clone(),
+                authorization_scopes: scopes.clone(),
                 actions: vec![],
-                subscriptions: None,
+                subscriptions: Some(crate::config::SubscriptionsConfig { webhook: vec![] }),
                 dependencies: vec![],
                 extensions: None,
             };
-            crate::config::write_config(&config_path, &config)
-                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            if let Err(e) = crate::config::write_config(&config_path, &config) {
+                tracing::warn!(error = %e, "failed to write godaddy.toml; continuing");
+            }
 
-            Ok(CommandResult::new(app.clone()).with_next_actions(vec![
-                next_action(
-                    "application add action --name <name> --url <url>",
-                    "Add an action to godaddy.toml",
-                ),
+            // Best-effort: a failed .env write shouldn't fail the already-created app.
+            if let Err(e) = crate::config::write_env_file(
+                Some(&env),
+                &secret,
+                &public_key,
+                &client_id,
+                &client_secret,
+            ) {
+                tracing::warn!(error = %e, "failed to write .env; continuing");
+            }
+
+            let cwd = match std::env::current_dir() {
+                Ok(dir) => dir,
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "current_dir failed; filesWritten paths will be relative"
+                    );
+                    std::path::PathBuf::new()
+                }
+            };
+            let files_written = json!({
+                "config": cwd.join(&config_path).display().to_string(),
+                "env": cwd.join(crate::config::env_path(Some(&env))).display().to_string(),
+            });
+            let result = json!({
+                "id": app["id"].as_str().unwrap_or("").to_owned(),
+                "name": name,
+                "status": app["status"].as_str().unwrap_or("").to_owned(),
+                "clientId": client_id,
+                "url": url,
+                "proxyUrl": proxy_url,
+                "authorizationScopes": scopes,
+                "oauthGrantTypes": ["authorization_code", "client_credentials"],
+                "filesWritten": files_written,
+            });
+            Ok(CommandResult::new(result).with_next_actions(vec![
                 next_action(
                     "application validate",
                     "Validate the generated godaddy.toml",

--- a/rust/src/application/mod.rs
+++ b/rust/src/application/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 mod commands;
+pub mod public_url;
 
 use cli_engine::{Module, Stage};
 

--- a/rust/src/application/public_url.rs
+++ b/rust/src/application/public_url.rs
@@ -10,6 +10,8 @@ use url::{Host, Url};
 ///  - IPv4 link-local `169.254.0.0/16`
 ///  - IPv6 link-local `fe80::/10`
 ///  - RFC1918 private IPv4 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+///  - CGNAT / shared address space `100.64.0.0/10` (RFC 6598)
+///  - IPv6 unique local addresses `fc00::/7` (RFC 4193)
 ///
 /// Enforced client-side so users get an actionable error immediately rather than
 /// an opaque 403 from the upstream WAF.
@@ -25,16 +27,27 @@ pub fn is_public_routable_url(value: &str) -> bool {
     match url.host() {
         Some(Host::Domain(domain)) => {
             let host = domain.to_ascii_lowercase();
-            !(host == "localhost" || host.ends_with(".localhost") || host.ends_with(".local"))
+            !(host == "localhost"
+                || host == "local"
+                || host.ends_with(".localhost")
+                || host.ends_with(".local"))
         }
         Some(Host::Ipv4(addr)) => {
-            !(addr.octets()[0] == 0
+            let octets = addr.octets();
+            let is_shared = octets[0] == 100 && (64..=127).contains(&octets[1]);
+            !(octets[0] == 0
                 || addr.is_loopback()
                 || addr.is_private()
-                || addr.is_link_local())
+                || addr.is_link_local()
+                || is_shared)
         }
         Some(Host::Ipv6(addr)) => {
-            !(addr.is_loopback() || addr.is_unspecified() || addr.is_unicast_link_local())
+            let seg0 = addr.segments()[0];
+            let is_unique_local = (seg0 & 0xfe00) == 0xfc00; // fc00::/7
+            !(addr.is_loopback()
+                || addr.is_unspecified()
+                || addr.is_unicast_link_local()
+                || is_unique_local)
         }
         None => false,
     }
@@ -58,6 +71,7 @@ mod tests {
     #[test]
     fn rejects_localhost_and_dot_local() {
         assert!(!is_public_routable_url("http://localhost"));
+        assert!(!is_public_routable_url("http://local"));
         assert!(!is_public_routable_url("https://api.localhost"));
         assert!(!is_public_routable_url("https://api.local"));
     }
@@ -73,9 +87,24 @@ mod tests {
     }
 
     #[test]
+    fn rejects_cgnat_shared_address_space() {
+        assert!(!is_public_routable_url("http://100.64.0.1"));
+        assert!(!is_public_routable_url("http://100.127.255.255"));
+        assert!(is_public_routable_url("http://100.63.255.255"));
+        assert!(is_public_routable_url("http://100.128.0.1"));
+    }
+
+    #[test]
     fn rejects_loopback_and_link_local_ipv6() {
         assert!(!is_public_routable_url("https://[::]"));
         assert!(!is_public_routable_url("https://[::1]"));
         assert!(!is_public_routable_url("https://[fe80::1]"));
+    }
+
+    #[test]
+    fn rejects_unique_local_ipv6() {
+        assert!(!is_public_routable_url("https://[fc00::1]"));
+        assert!(!is_public_routable_url("https://[fd12:3456:789a::1]"));
+        assert!(is_public_routable_url("https://[fe00::1]"));
     }
 }

--- a/rust/src/application/public_url.rs
+++ b/rust/src/application/public_url.rs
@@ -12,6 +12,7 @@ use url::{Host, Url};
 ///  - RFC1918 private IPv4 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
 ///  - CGNAT / shared address space `100.64.0.0/10` (RFC 6598)
 ///  - IPv6 unique local addresses `fc00::/7` (RFC 4193)
+///  - IPv6 reserved `fe00::/9` (not globally routable)
 ///
 /// Enforced client-side so users get an actionable error immediately rather than
 /// an opaque 403 from the upstream WAF.
@@ -44,10 +45,12 @@ pub fn is_public_routable_url(value: &str) -> bool {
         Some(Host::Ipv6(addr)) => {
             let seg0 = addr.segments()[0];
             let is_unique_local = (seg0 & 0xfe00) == 0xfc00; // fc00::/7
+            let is_reserved_fe00 = (seg0 & 0xff80) == 0xfe00; // fe00::/9
             !(addr.is_loopback()
                 || addr.is_unspecified()
                 || addr.is_unicast_link_local()
-                || is_unique_local)
+                || is_unique_local
+                || is_reserved_fe00)
         }
         None => false,
     }
@@ -105,6 +108,11 @@ mod tests {
     fn rejects_unique_local_ipv6() {
         assert!(!is_public_routable_url("https://[fc00::1]"));
         assert!(!is_public_routable_url("https://[fd12:3456:789a::1]"));
-        assert!(is_public_routable_url("https://[fe00::1]"));
+    }
+
+    #[test]
+    fn rejects_reserved_fe00_ipv6() {
+        assert!(!is_public_routable_url("https://[fe00::1]"));
+        assert!(!is_public_routable_url("https://[fe7f::1]"));
     }
 }

--- a/rust/src/application/public_url.rs
+++ b/rust/src/application/public_url.rs
@@ -1,0 +1,81 @@
+use url::{Host, Url};
+
+/// Returns true when `value` is a syntactically valid `http(s)` URL whose host
+/// is expected to be resolvable on the public internet.
+///
+/// The following host classes are rejected:
+///  - `localhost` and any `*.localhost` / `*.local` hostnames
+///  - IPv4 loopback `127.0.0.0/8`, unspecified `0.0.0.0/8`
+///  - IPv6 loopback `::1` and unspecified `::`
+///  - IPv4 link-local `169.254.0.0/16`
+///  - IPv6 link-local `fe80::/10`
+///  - RFC1918 private IPv4 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+///
+/// Enforced client-side so users get an actionable error immediately rather than
+/// an opaque 403 from the upstream WAF.
+pub fn is_public_routable_url(value: &str) -> bool {
+    let Ok(url) = Url::parse(value) else {
+        return false;
+    };
+
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return false;
+    }
+
+    match url.host() {
+        Some(Host::Domain(domain)) => {
+            let host = domain.to_ascii_lowercase();
+            !(host == "localhost" || host.ends_with(".localhost") || host.ends_with(".local"))
+        }
+        Some(Host::Ipv4(addr)) => {
+            !(addr.octets()[0] == 0
+                || addr.is_loopback()
+                || addr.is_private()
+                || addr.is_link_local())
+        }
+        Some(Host::Ipv6(addr)) => {
+            !(addr.is_loopback() || addr.is_unspecified() || addr.is_unicast_link_local())
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_public_https_url() {
+        assert!(is_public_routable_url("https://example.com"));
+        assert!(is_public_routable_url("https://[2606:4700::1111]"));
+    }
+
+    #[test]
+    fn rejects_non_http_scheme() {
+        assert!(!is_public_routable_url("ftp://example.com/x"));
+    }
+
+    #[test]
+    fn rejects_localhost_and_dot_local() {
+        assert!(!is_public_routable_url("http://localhost"));
+        assert!(!is_public_routable_url("https://api.localhost"));
+        assert!(!is_public_routable_url("https://api.local"));
+    }
+
+    #[test]
+    fn rejects_loopback_and_private_ipv4() {
+        assert!(!is_public_routable_url("http://127.0.0.1"));
+        assert!(!is_public_routable_url("http://0.0.0.0"));
+        assert!(!is_public_routable_url("http://10.0.0.1"));
+        assert!(!is_public_routable_url("http://172.16.0.1"));
+        assert!(!is_public_routable_url("http://192.168.1.1"));
+        assert!(!is_public_routable_url("http://169.254.1.1"));
+    }
+
+    #[test]
+    fn rejects_loopback_and_link_local_ipv6() {
+        assert!(!is_public_routable_url("https://[::]"));
+        assert!(!is_public_routable_url("https://[::1]"));
+        assert!(!is_public_routable_url("https://[fe80::1]"));
+    }
+}

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -129,3 +129,127 @@ pub fn config_path(env: Option<&str>) -> std::path::PathBuf {
         Some(e) => std::path::PathBuf::from(format!("godaddy.{e}.toml")),
     }
 }
+
+/// Path to the env file for a given env, parallel to [`config_path`]:
+/// `None` / `"prod"` → `.env`, other envs → `.env.<env>`.
+pub fn env_path(env: Option<&str>) -> std::path::PathBuf {
+    match env {
+        None | Some("prod") => std::path::PathBuf::from(".env"),
+        Some(e) => std::path::PathBuf::from(format!(".env.{e}")),
+    }
+}
+
+/// JSON-encode after stripping NULs, so a newline
+///  / `#` / `=` in a secret can't corrupt the `.env`.
+fn format_env_value(value: &str) -> String {
+    serde_json::to_string(&value.replace('\0', "")).unwrap_or_default()
+}
+
+/// Build the new `.env`: overwrite the four `GODADDY_*` keys in place, keep every
+/// other line verbatim, and append any key the file lacked.
+fn merge_env_content(
+    existing: Option<&str>,
+    secret: &str,
+    public_key: &str,
+    client_id: &str,
+    client_secret: &str,
+) -> String {
+    let owned = [
+        ("GODADDY_WEBHOOK_SECRET", secret),
+        ("GODADDY_PUBLIC_KEY", public_key),
+        ("GODADDY_CLIENT_ID", client_id),
+        ("GODADDY_CLIENT_SECRET", client_secret),
+    ];
+    let render = |name: &str, value: &str| format!("{name}={}", format_env_value(value));
+
+    let mut seen = [false; 4];
+    let mut out: Vec<String> = Vec::new();
+
+    // Rewrite our keys where they sit; every other line passes through unchanged.
+    for line in existing.unwrap_or_default().lines() {
+        let idx = if line.trim_start().starts_with('#') {
+            None
+        } else {
+            line.split_once('=')
+                .and_then(|(k, _)| owned.iter().position(|&(name, _)| name == k.trim()))
+        };
+        match idx {
+            Some(i) if !seen[i] => {
+                out.push(render(owned[i].0, owned[i].1));
+                seen[i] = true;
+            }
+            Some(_) => {}
+            None => out.push(line.to_string()),
+        }
+    }
+
+    // Append any key the file didn't already contain.
+    for (i, &(name, value)) in owned.iter().enumerate() {
+        if !seen[i] {
+            out.push(render(name, value));
+        }
+    }
+
+    out.join("\n")
+}
+
+/// Write the app secrets into the env file for `env`, preserving existing content.
+pub fn write_env_file(
+    env: Option<&str>,
+    secret: &str,
+    public_key: &str,
+    client_id: &str,
+    client_secret: &str,
+) -> Result<(), ConfigError> {
+    let path = env_path(env);
+    let existing = std::fs::read_to_string(&path).ok();
+    let contents = merge_env_content(
+        existing.as_deref(),
+        secret,
+        public_key,
+        client_id,
+        client_secret,
+    );
+    std::fs::write(&path, contents)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_path_matches_convention() {
+        use std::path::Path;
+        assert_eq!(env_path(None), Path::new(".env"));
+        assert_eq!(env_path(Some("prod")), Path::new(".env"));
+        assert_eq!(env_path(Some("ote")), Path::new(".env.ote"));
+    }
+
+    #[test]
+    fn merge_env_content_writes_fresh_keys() {
+        let result = merge_env_content(None, "secret", "pubkey", "cid", "csecret");
+        assert!(result.contains(r#"GODADDY_WEBHOOK_SECRET="secret""#));
+        assert!(result.contains(r#"GODADDY_PUBLIC_KEY="pubkey""#));
+        assert!(result.contains(r#"GODADDY_CLIENT_ID="cid""#));
+        assert!(result.contains(r#"GODADDY_CLIENT_SECRET="csecret""#));
+    }
+
+    #[test]
+    fn merge_env_content_preserves_existing() {
+        let existing = "FOO=bar\n# note\nGODADDY_CLIENT_ID=\"old\"";
+        let result = merge_env_content(Some(existing), "secret", "pubkey", "new_cid", "csecret");
+        assert!(result.contains("FOO=bar"));
+        assert!(result.contains("# note"));
+        assert!(result.contains(r#"GODADDY_CLIENT_ID="new_cid""#));
+        assert!(!result.contains("\"old\""));
+    }
+
+    #[test]
+    fn merge_env_content_dedupes_owned_keys() {
+        let existing = "GODADDY_CLIENT_ID=a\nGODADDY_CLIENT_ID=b";
+        let result = merge_env_content(Some(existing), "s", "p", "new", "cs");
+        assert_eq!(result.matches("GODADDY_CLIENT_ID=").count(), 1);
+        assert!(result.contains(r#"GODADDY_CLIENT_ID="new""#));
+    }
+}


### PR DESCRIPTION
## Summary
- Make init flags optional and seed missing values from `--config` (write still targets the default env `godaddy.toml` / `.env`)
- Validate required fields and reject non-public `url` / `proxy-url`
- Best-effort config + env file writes after create; include `filesWritten` in the JSON result
- Add `write_env_file` merge helper and `is_public_routable_url` with unit tests

## Test plan
- [x] `cargo build` / `cargo test` / `cargo clippy -- -D warnings` / `cargo fmt --check`
- [x] Manual local test: stubbed createApplication; confirmed flag/config merge, required-field errors, public URL rejection, and filesWritten paths without hitting the real API