### PR TITLE
fix(domain): validate domain and nameserver hostname shape before the API call

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "zip",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,7 +44,6 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2"] }
 iso_currency = "0.5.3"
-url = "2"
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2"] }
 iso_currency = "0.5.3"

--- a/rust/src/domain/available.rs
+++ b/rust/src/domain/available.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, format_money, headline_price, make_client};
+use super::common::{api_error, format_money, headline_price, make_client, validate_domain_name};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_READ;
@@ -53,12 +53,12 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     .help("Optimize for speed (fast) or accuracy (full)"),
             ),
         |ctx| async move {
-            let domain = ctx
-                .args
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_owned();
+            let domain = validate_domain_name(
+                ctx.args
+                    .get("domain")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(""),
+            )?;
             // --check-type fast|full → v3 optimizeFor SPEED|ACCURACY.
             let optimize_for = match ctx.args.get("check-type").and_then(|v| v.as_str()) {
                 Some("fast") => Some(types::OptimizationTarget::Speed),

--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -79,6 +79,59 @@ pub(super) fn term_for_period(
     prices.iter().find(|p| p.period == Some(period))
 }
 
+/// Validate that `raw` (trimmed) is syntactically a valid domain name. Rejects
+/// the shapes from DEVEX-885's bug report — embedded whitespace, null bytes, a
+/// "protocol://" prefix, a "/path" suffix — via `url::Host::parse`'s WHATWG
+/// forbidden-host-code-point + IDNA checks, then layers RFC 1035/1123 shape
+/// rules a real domain always satisfies: not a bare IP literal, >=2
+/// dot-separated LDH labels, each 1-63 bytes, total <=253 bytes, and a TLD
+/// that isn't all-numeric (ICANN disallows those). Returns the original
+/// trimmed input — not `Host::parse`'s ASCII/punycode form — so an
+/// already-working Unicode domain's wire format is unchanged.
+pub(super) fn validate_domain_name(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(CliCoreError::message("domain name is required"));
+    }
+    // `url::Host::parse`'s error `Display` is a single generic string
+    // ("invalid international domain name") regardless of what's actually
+    // wrong (a space, a "://" prefix, a "/path" suffix, ...), so it isn't
+    // worth including — it would just read as a confusing non-sequitur.
+    let host = url::Host::parse(trimmed)
+        .map_err(|_| CliCoreError::message(format!("{trimmed:?} is not a valid domain name")))?;
+    let url::Host::Domain(ascii) = host else {
+        return Err(CliCoreError::message(format!(
+            "{trimmed:?} is an IP address, not a domain name"
+        )));
+    };
+    let labels: Vec<&str> = ascii.split('.').collect();
+    let shape_ok = labels.len() >= 2
+        && ascii.len() <= 253
+        && labels.iter().all(|l| is_ldh_label(l))
+        && !labels
+            .last()
+            .is_some_and(|tld| tld.bytes().all(|b| b.is_ascii_digit()));
+    if !shape_ok {
+        return Err(CliCoreError::message(format!(
+            "{trimmed:?} doesn't look like a valid domain name (expected something like example.com)"
+        )));
+    }
+    Ok(trimmed.to_owned())
+}
+
+/// A single RFC 1035/1123 "LDH label": 1-63 bytes, alphanumeric, interior
+/// hyphens only (not leading/trailing).
+fn is_ldh_label(label: &str) -> bool {
+    let bytes = label.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 63
+        && bytes[0] != b'-'
+        && bytes[bytes.len() - 1] != b'-'
+        && bytes
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || *b == b'-')
+}
+
 /// Whether an async domain-operation status is terminal (no further polling).
 /// Only `COMPLETED`/`FAILED` are terminal; every other status (e.g. `SUBMITTED`,
 /// `PENDING`, `CONFIRMED`, `EXECUTING`) is treated as still in progress.
@@ -458,6 +511,79 @@ mod tests {
         assert!(msg.contains("registrant address line 2"), "{msg}");
         assert!(msg.contains("is too short"), "{msg}");
         assert!(msg.contains("leave it blank to omit"), "{msg}");
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_devex_885_repro_cases() {
+        // Every case from the DEVEX-885 bug report except the trailing-space
+        // one (which is accepted-after-trim; see the test below).
+        for bad in [
+            "not a domain",
+            "https://test.com",
+            "test.com/page",
+            "test\u{0}evil.com",
+        ] {
+            assert!(
+                validate_domain_name(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_domain_name_trims_whitespace_instead_of_rejecting() {
+        assert_eq!(
+            validate_domain_name("test.com ").expect("trimmed to valid"),
+            "test.com"
+        );
+        assert_eq!(
+            validate_domain_name("  test.com").expect("trimmed to valid"),
+            "test.com"
+        );
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_empty_or_whitespace_only() {
+        assert!(validate_domain_name("").is_err());
+        assert!(validate_domain_name("   ").is_err());
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_ip_literals() {
+        assert!(validate_domain_name("1.2.3.4").is_err());
+        assert!(validate_domain_name("::1").is_err());
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_missing_or_numeric_tld() {
+        assert!(validate_domain_name("example").is_err());
+        assert!(validate_domain_name("example.123").is_err());
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_leading_or_trailing_hyphen_labels() {
+        assert!(validate_domain_name("-example.com").is_err());
+        assert!(validate_domain_name("example-.com").is_err());
+    }
+
+    #[test]
+    fn validate_domain_name_accepts_well_formed_domains_unchanged() {
+        for good in ["example.com", "xn--fsq.com", "ns1.example.co.uk"] {
+            assert_eq!(validate_domain_name(good).expect("valid domain"), good);
+        }
+    }
+
+    #[test]
+    fn validate_domain_name_accepts_unicode_and_returns_original_not_punycode() {
+        // A real Unicode domain must pass (IDNA-processed for the shape check)
+        // but the returned string is the user's original input, not
+        // `Host::parse`'s ASCII/punycode form — no wire-format change for
+        // domains that already work today.
+        let input = "café.com";
+        assert_eq!(
+            validate_domain_name(input).expect("valid unicode domain"),
+            input
+        );
     }
 
     #[test]

--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -119,6 +119,20 @@ pub(super) fn validate_domain_name(raw: &str) -> Result<String> {
     Ok(trimmed.to_owned())
 }
 
+/// Validate every value of a repeatable `--nameserver`-style flag as a
+/// domain-shaped hostname, wrapping [`validate_domain_name`]'s generic error
+/// with the flag's own name — used by both `quote` (the registration
+/// profile's nameservers) and `nameservers set` (the target domain's
+/// nameservers) so a bad host isn't reported as if it were some other
+/// (already-valid) domain argument.
+pub(super) fn validate_nameserver_hosts(raw: Vec<String>) -> Result<Vec<String>> {
+    raw.into_iter()
+        .map(|h| {
+            validate_domain_name(&h).map_err(|e| CliCoreError::message(format!("--nameserver {e}")))
+        })
+        .collect()
+}
+
 /// A single RFC 1035/1123 "LDH label": 1-63 bytes, alphanumeric, interior
 /// hyphens only (not leading/trailing).
 fn is_ldh_label(label: &str) -> bool {
@@ -583,6 +597,35 @@ mod tests {
         assert_eq!(
             validate_domain_name(input).expect("valid unicode domain"),
             input
+        );
+    }
+
+    #[test]
+    fn validate_nameserver_hosts_rejects_bad_shape_with_flag_context() {
+        // Regression: `quote`'s and `nameservers set`'s `--nameserver` values
+        // must go through the same shape check as a domain arg, but the error
+        // must say `--nameserver`, not claim the bad value is "the domain".
+        let err = validate_nameserver_hosts(vec!["bad ns".to_string()])
+            .expect_err("malformed host should be rejected");
+        let msg = err.to_string();
+        assert!(msg.starts_with("--nameserver "), "{msg}");
+        assert!(msg.contains("bad ns"), "{msg}");
+    }
+
+    #[test]
+    fn validate_nameserver_hosts_passes_through_valid_hosts_unchanged() {
+        let hosts = vec!["ns1.example.com".to_string(), "ns2.example.com".to_string()];
+        assert_eq!(
+            validate_nameserver_hosts(hosts.clone()).expect("valid hosts"),
+            hosts
+        );
+    }
+
+    #[test]
+    fn validate_nameserver_hosts_empty_list_stays_empty() {
+        assert_eq!(
+            validate_nameserver_hosts(Vec::new()).expect("empty is valid"),
+            Vec::<String>::new()
         );
     }
 

--- a/rust/src/domain/get.rs
+++ b/rust/src/domain/get.rs
@@ -6,7 +6,7 @@ use cli_engine::{
 
 use domains_client::types;
 
-use super::common::{api_error, make_client};
+use super::common::{api_error, make_client, validate_domain_name};
 use crate::next_action::next_action;
 use crate::scopes::DOMAINS_READ;
 
@@ -29,12 +29,12 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     .help("Domain to look up (must be in your account), e.g. example.com"),
             ),
         |ctx| async move {
-            let domain = ctx
-                .args
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_owned();
+            let domain = validate_domain_name(
+                ctx.args
+                    .get("domain")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(""),
+            )?;
             let debug = !ctx.middleware.debug.is_empty();
             let client = make_client(&ctx).await?;
             let detail = match client

--- a/rust/src/domain/nameservers.rs
+++ b/rust/src/domain/nameservers.rs
@@ -1,14 +1,14 @@
 //! `gddy domain nameservers` — manage a domain's nameservers (v3).
 
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, NextActionParam, RuntimeCommandSpec, RuntimeGroupSpec,
-    Tier,
+    CliCoreError, CommandResult, CommandSpec, GroupSpec, NextActionParam, Result,
+    RuntimeCommandSpec, RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, make_client, string_list};
+use super::common::{api_error, make_client, string_list, validate_domain_name};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_NAMESERVER_UPDATE;
@@ -53,13 +53,22 @@ pub(super) fn group() -> RuntimeGroupSpec {
                     .help("Nameserver host (repeatable; replaces the full set)"),
             ),
         |ctx| async move {
-            let domain = ctx
-                .args
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_owned();
-            let hosts = string_list(&ctx, "nameserver");
+            let domain = validate_domain_name(
+                ctx.args
+                    .get("domain")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(""),
+            )?;
+            // `validate_domain_name` only judges shape, not which argument it
+            // came from — add that context here so a bad `--nameserver` value
+            // isn't reported as if it were the (already-valid) target domain.
+            let hosts = string_list(&ctx, "nameserver")
+                .into_iter()
+                .map(|h| {
+                    validate_domain_name(&h)
+                        .map_err(|e| CliCoreError::message(format!("--nameserver {e}")))
+                })
+                .collect::<Result<Vec<String>>>()?;
             let debug = !ctx.middleware.debug.is_empty();
 
             let client = make_client(&ctx).await?;

--- a/rust/src/domain/nameservers.rs
+++ b/rust/src/domain/nameservers.rs
@@ -1,14 +1,16 @@
 //! `gddy domain nameservers` — manage a domain's nameservers (v3).
 
 use cli_engine::{
-    CliCoreError, CommandResult, CommandSpec, GroupSpec, NextActionParam, Result,
-    RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CommandResult, CommandSpec, GroupSpec, NextActionParam, RuntimeCommandSpec, RuntimeGroupSpec,
+    Tier,
 };
 use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, make_client, string_list, validate_domain_name};
+use super::common::{
+    api_error, make_client, string_list, validate_domain_name, validate_nameserver_hosts,
+};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_NAMESERVER_UPDATE;
@@ -59,16 +61,7 @@ pub(super) fn group() -> RuntimeGroupSpec {
                     .and_then(|v| v.as_str())
                     .unwrap_or(""),
             )?;
-            // `validate_domain_name` only judges shape, not which argument it
-            // came from — add that context here so a bad `--nameserver` value
-            // isn't reported as if it were the (already-valid) target domain.
-            let hosts = string_list(&ctx, "nameserver")
-                .into_iter()
-                .map(|h| {
-                    validate_domain_name(&h)
-                        .map_err(|e| CliCoreError::message(format!("--nameserver {e}")))
-                })
-                .collect::<Result<Vec<String>>>()?;
+            let hosts = validate_nameserver_hosts(string_list(&ctx, "nameserver"))?;
             let debug = !ctx.middleware.debug.is_empty();
 
             let client = make_client(&ctx).await?;

--- a/rust/src/domain/quote.rs
+++ b/rust/src/domain/quote.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, format_money, make_client, string_list};
+use super::common::{api_error, format_money, make_client, string_list, validate_domain_name};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_READ;
@@ -228,12 +228,9 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     .help("Custom nameserver (repeatable); omit to use GoDaddy defaults"),
             ),
         |ctx| async move {
-            let domain = ctx
-                .args
-                .get("domain")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_owned();
+            let domain = validate_domain_name(
+                ctx.args.get("domain").and_then(|v| v.as_str()).unwrap_or(""),
+            )?;
             let period = ctx.args.get("period").and_then(|v| v.as_u64()).unwrap_or(1);
             let privacy = ctx
                 .args

--- a/rust/src/domain/quote.rs
+++ b/rust/src/domain/quote.rs
@@ -7,7 +7,10 @@ use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, format_money, make_client, string_list, validate_domain_name};
+use super::common::{
+    api_error, format_money, make_client, string_list, validate_domain_name,
+    validate_nameserver_hosts,
+};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_READ;
@@ -242,7 +245,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 .get("no-renew")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let name_servers = string_list(&ctx, "nameserver");
+            let name_servers = validate_nameserver_hosts(string_list(&ctx, "nameserver"))?;
             let debug = !ctx.middleware.debug.is_empty();
             let period_nz =
                 std::num::NonZeroU64::new(period).expect("clap value_parser enforces period >= 1");


### PR DESCRIPTION
## Summary

[DEVEX-885](https://godaddy-corp.atlassian.net/browse/DEVEX-885) reports that `gddy domain` commands send raw, unvalidated input straight to the API:

```
gddy domain available "not a domain"       # → available: false
gddy domain available "https://test.com"   # → available: false
gddy domain available "test.com/page"      # → available: false
gddy domain available "test.com "          # trailing space preserved in output
gddy domain available $'test\x00evil.com'  # null byte truncates to "test"
```

Users get a confusing "not available" instead of a clear validation error.

- Add `validate_domain_name` in `domain/common.rs`, backed by `url::Host::parse` (already resolved in the dependency graph transitively via `reqwest`/`cli-engine` — no new crate added to the supply chain, just a new direct-dependency line) plus RFC 1035/1123 shape rules: rejects bare IP literals, requires ≥2 dot-separated LDH labels, ≤253 bytes total, and a non-numeric TLD.
- Applied to the `domain` argument in `available`, `get`, `quote`, and `nameservers set`.
- Every repeatable `--nameserver` host — in both `nameservers set` and `quote`'s own `--nameserver` flag (registration-profile nameservers) — goes through the same check via a shared `validate_nameserver_hosts`, so a bad host is reported as `--nameserver "..." is not a valid domain name`, not misattributed to the target domain (caught by Copilot review on the first pass — the initial version only covered `nameservers set`, missing `quote`'s own flag).
- Left `suggest`'s `query` alone — it's documented as accepting free-text keywords, not just domains.
- The validator itself is generic ("is not a valid domain name"); callers add their own context for non-domain arguments.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (all passing, including new unit tests covering every case from the bug report plus IP literals, missing/numeric TLDs, hyphen-label edge cases, and the `--nameserver`-context wrapping)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually ran all 5 repro commands from the ticket against `domain available`, confirmed `domain quote --nameserver <bad>` and `domain nameservers set --nameserver <bad>` are both now rejected, and confirmed `domain suggest <keyword>` still works unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)