### PR TITLE
[DEVEX-698] fix(docs): Remove pretty flag reference

### DIFF
--- a/.agents/skills/godaddy-cli/SKILL.md
+++ b/.agents/skills/godaddy-cli/SKILL.md
@@ -124,7 +124,6 @@ If `truncated` is `true`, the complete data is at the `full_output` file path. R
 
 | Flag | Alias | Effect |
 |------|-------|--------|
-| `--pretty` | | Pretty-print JSON with 2-space indentation |
 | `--env <env>` | `-e` | Override environment for this command (`ote` or `prod`) |
 | `--verbose` | `-v` | Log HTTP requests/responses to stderr |
 | `--debug` | `-vv` | Full verbose output to stderr |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ All executable commands emit JSON envelopes:
 
 `--help` remains standard CLI help text.
 `--output` has been removed; all executable command paths return JSON envelopes.
-Use `--pretty` to format envelopes with 2-space indentation for human readability.
 Long-running operations can stream typed NDJSON events with `--follow`, ending with a terminal `result` or `error` event.
 
 ## Root Discovery
@@ -63,7 +62,6 @@ Returns environment/auth snapshots and the full command tree.
 
 - `-e, --env <environment>`: validate target environment (`ote`, `prod`)
 - `--debug`: enable debug logging (stderr only)
-- `--pretty`: pretty-print JSON envelopes (2-space indentation)
 
 ## Commands
 


### PR DESCRIPTION
There're few references of `--pretty` flag for docs. This output style is now handled internally with the `--json` flag so there's no need to add It as an option.

References to that flag are removed within the docs where found. No references of that flag found on `cli-engine`.