### PR TITLE
fix(release): gate npm release workflow to manual dispatch only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary
- `release.yaml` published to npm on every push to `main` with no other trigger (no `workflow_dispatch`, no schedule).
- Once commits resume landing on this branch post branch-rename (part of the `rust-port`→`main` swap, DEVEX-924), that automatic publish path needs to be closed off.
- Switches the trigger to `workflow_dispatch` only, removing automatic firing while preserving the ability to manually cut an emergency npm patch release.

Jira: DEVEX-925 (part of epic DEVEX-924)

## Test plan
- [x] Diff reviewed: only the `on:` trigger block changed, rest of workflow untouched.
- [ ] Confirm workflow still shows up under Actions with a manual "Run workflow" button after merge.