### PR TITLE
fix(ci): repoint CI/CodeQL triggers from main to original (DEVEX-926)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CICD
 on: 
   push:
     branches:
-      - 'main'
+      - 'original'
   pull_request:
     branches:
      - '*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ original ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ original ]
   schedule:
     - cron: '19 21 * * 3'
 


### PR DESCRIPTION
## Summary
- Ahead of the `main`/`rust-port` branch swap, repoint `cicd.yml` and `codeql-analysis.yml` push triggers from `branches: [main]` to `branches: [original]` so CI keeps running on the renamed old-CLI branch instead of going dark.
- Also updated `codeql-analysis.yml`'s `pull_request` trigger to `[original]` to keep it a subset of the push branches, per the file's own comment.
- `cicd.yml`'s `pull_request` trigger is already `branches: '*'` and needs no change.

Jira: DEVEX-926 (parent: DEVEX-924)

## Test plan
- [ ] Confirm workflow YAML is valid (no syntax errors)
- [ ] After the branch rename lands, verify a push to `original` triggers both CICD and CodeQL workflows