### PR TITLE
feat(env): consolidate onto cli-engine's shared Environments, wire feature-flag stages (DEVEX-929)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -566,9 +566,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f34184dcd279900e0822019ec221e3520ef92cca42025140f5ee5aa5f9578be"
+checksum = "c8a27dd2b1e961082ee9e3045980f862710ea71c523c114d202e05c2bfbd4608"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.4.7" }
+cli-engine = { features = ["pkce-auth"], version = "0.4.8" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use cli_engine::{
     CliCoreError, Credential, CredentialRequest, Result,
@@ -8,47 +10,44 @@ use crate::environments::{self, ResolvedEnv};
 use crate::pat::{self, PatEntry};
 use crate::scopes;
 
-/// Single auth provider that dispatches to env-specific PKCE providers.
-///
-/// Each env's provider is named after the env, so cli-engine's
-/// `PkceAuthProvider` picks up its per-env overrides automatically:
-///   `<PREFIX>_OAUTH_CLIENT_ID`, `<PREFIX>_OAUTH_AUTH_URL`, `<PREFIX>_OAUTH_TOKEN_URL`
-/// where `<PREFIX>` is the env name uppercased with `-` replaced by `_`
-/// (e.g. `OTE_OAUTH_CLIENT_ID`, `DEV_OAUTH_AUTH_URL`). The API base URL and the
-/// per-env defaults come from [`crate::environments`], which also resolves
-/// custom DEV/TEST environments from the local config file (see
-/// `crate::environments::environments_path`).
-#[derive(Debug, Default)]
-pub struct GoDaddyAuthProvider;
+#[derive(Debug)]
+pub struct GoDaddyAuthProvider {
+    provider: PkceAuthProvider,
+}
 
 impl GoDaddyAuthProvider {
     pub fn new() -> Self {
-        Self
+        Self {
+            provider: PkceAuthProvider::new(
+                "godaddy",
+                "",
+                "",
+                "",
+                environments::DEFAULT_OAUTH_SCOPES,
+            )
+            .with_app_id(environments::APP_ID)
+            .with_redirect_uri(environments::REDIRECT_URI)
+            .with_environments(Arc::clone(environments::instance())),
+        }
     }
 
-    /// Build a PKCE provider for the given env by resolving its endpoints.
+    /// Resolves `env` and logs the OAuth parameters that will be used
+    /// (see [`log_resolved_oauth`]).
     ///
-    /// Providers are constructed on demand (tokens persist in the OS keychain,
-    /// so there is nothing to cache across a one-shot CLI invocation). Works for
-    /// built-ins as well as any custom env defined via env var or local config.
-    fn provider_for(&self, env: &str) -> Result<PkceAuthProvider> {
-        let resolved =
-            environments::resolve(env).map_err(|e| CliCoreError::message(e.to_string()))?;
-        Ok(build_provider(&resolved))
+    /// Resolves up front (rather than relying solely on `.with_environments`'s
+    /// internal, silently-degrading resolution) so an unknown env surfaces a
+    /// clear error here instead of a confusing OAuth failure later.
+    fn resolve_and_log(&self, env: &str) -> Result<()> {
+        let resolved = environments::resolve(env)?;
+        log_resolved_oauth(&resolved);
+        Ok(())
     }
 }
 
-fn build_provider(env: &ResolvedEnv) -> PkceAuthProvider {
-    log_resolved_oauth(env);
-    PkceAuthProvider::new(
-        env.name.clone(),
-        env.auth_url.clone(),
-        env.token_url.clone(),
-        env.client_id.clone(),
-        environments::DEFAULT_OAUTH_SCOPES,
-    )
-    .with_app_id(environments::APP_ID)
-    .with_redirect_uri(environments::REDIRECT_URI)
+impl Default for GoDaddyAuthProvider {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Build a `Credential` from a PAT entry.
@@ -141,8 +140,8 @@ impl AuthProvider for GoDaddyAuthProvider {
         if let Some(entry) = pat::resolve_pat(env).await {
             return Ok(pat_credential(env, &entry));
         }
-        let provider = self.provider_for(env)?;
-        provider.get_credential(env, command, tier).await
+        self.resolve_and_log(env)?;
+        self.provider.get_credential(env, command, tier).await
     }
 
     async fn get_credential_for(&self, req: &CredentialRequest<'_>) -> Result<Credential> {
@@ -166,16 +165,16 @@ impl AuthProvider for GoDaddyAuthProvider {
         if req.command.is_empty() {
             validate_requested_scopes(&req.meta.scopes)?;
         }
-        let provider = self.provider_for(req.env)?;
-        provider.get_credential_for(req).await
+        self.resolve_and_log(req.env)?;
+        self.provider.get_credential_for(req).await
     }
 
     async fn status(&self, env: &str) -> Result<Credential> {
         if let Some(entry) = pat::resolve_pat(env).await {
             return Ok(pat_credential(env, &entry));
         }
-        let provider = self.provider_for(env)?;
-        provider.status(env).await
+        self.resolve_and_log(env)?;
+        self.provider.status(env).await
     }
 
     async fn logout(&self, env: &str) -> Result<()> {
@@ -184,17 +183,16 @@ impl AuthProvider for GoDaddyAuthProvider {
         if let Err(err) = pat::delete_pat(env).await {
             tracing::debug!(env, error = %err, "ignoring PAT delete error during logout");
         }
-        let provider = self.provider_for(env)?;
-        provider.logout(env).await
+        self.resolve_and_log(env)?;
+        self.provider.logout(env).await
     }
 
     async fn list_environments(&self) -> Result<Vec<String>> {
-        // Enumerate stored credentials across built-ins + locally-configured
-        // envs (env-var-only envs are excluded from `listable`, matching the
-        // `env list` contract). `listable` falls back to built-ins (logging a
-        // warning) on a malformed local config, so this never fails wholesale.
-        let listable =
-            environments::listable().map_err(|e| CliCoreError::message(e.to_string()))?;
+        // `PkceAuthProvider::list_environments` only reflects its own
+        // in-memory token cache (keyring/file storage can't be enumerated by
+        // prefix), so this is a single call now that credentials for every
+        // env share one provider instance — no need to loop per env
+        // constructing a fresh (always cache-empty) provider per iteration.
         let mut envs = std::collections::BTreeSet::new();
         match pat::registry_envs().await {
             Ok(pats) => envs.extend(pats),
@@ -205,10 +203,7 @@ impl AuthProvider for GoDaddyAuthProvider {
                 );
             }
         }
-        for resolved in listable {
-            let provider = build_provider(&resolved);
-            envs.extend(provider.list_environments().await.unwrap_or_default());
-        }
+        envs.extend(self.provider.list_environments().await.unwrap_or_default());
         Ok(envs.into_iter().collect())
     }
 }

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -10,44 +10,63 @@ use crate::environments::{self, ResolvedEnv};
 use crate::pat::{self, PatEntry};
 use crate::scopes;
 
-#[derive(Debug)]
-pub struct GoDaddyAuthProvider {
-    provider: PkceAuthProvider,
-}
+/// Single auth provider, built per call from gddy's own resolved (and
+/// gddy-specific-derived) endpoints, then wired via `.with_environments` for
+/// the `<ENV>_OAUTH_*` override layer.
+///
+/// cli-engine's shared `Environments` never derives `auth_url`/`token_url`
+/// from `api_url` the way [`crate::environments::adapt`] does — that
+/// derivation is gddy-specific and only happens in this crate's own
+/// resolution. Passing static empty base args to a single, long-lived
+/// `PkceAuthProvider` (as this used to) would mean any environment relying
+/// on that derivation (e.g. the real `dev`/`test` file entries, which only
+/// set `client_id`) tries to hit an empty auth/token URL — a real,
+/// reproduced bug, not a hypothetical one. So each call resolves `env`
+/// through gddy's own adapter first and passes the fully-derived values in
+/// as the provider's base args.
+///
+/// The provider is still always constructed with the fixed name `"godaddy"`
+/// (not `env`), so cli-engine's credential storage key
+/// (`app_id`/`provider_name`/`env`) stays `(app_id, "godaddy", env)`
+/// regardless of how many times this rebuilds the provider — the one-time
+/// credential-key change (and required re-login) from collapsing gddy's
+/// former per-env-named providers happens exactly once, not per call.
+#[derive(Debug, Default)]
+pub struct GoDaddyAuthProvider;
 
 impl GoDaddyAuthProvider {
     pub fn new() -> Self {
-        Self {
-            provider: PkceAuthProvider::new(
-                "godaddy",
-                "",
-                "",
-                "",
-                environments::DEFAULT_OAUTH_SCOPES,
-            )
-            .with_app_id(environments::APP_ID)
-            .with_redirect_uri(environments::REDIRECT_URI)
-            .with_environments(Arc::clone(environments::instance())),
-        }
+        Self
     }
 
-    /// Resolves `env` and logs the OAuth parameters that will be used
-    /// (see [`log_resolved_oauth`]).
+    /// Resolves `env`, logs the OAuth parameters that will be used (see
+    /// [`log_resolved_oauth`]), and builds a `PkceAuthProvider` from the
+    /// fully-derived values.
     ///
     /// Resolves up front (rather than relying solely on `.with_environments`'s
     /// internal, silently-degrading resolution) so an unknown env surfaces a
     /// clear error here instead of a confusing OAuth failure later.
-    fn resolve_and_log(&self, env: &str) -> Result<()> {
+    fn provider_for(&self, env: &str) -> Result<PkceAuthProvider> {
         let resolved = environments::resolve(env)?;
-        log_resolved_oauth(&resolved);
-        Ok(())
+        Ok(build_provider(&resolved))
     }
 }
 
-impl Default for GoDaddyAuthProvider {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Builds a `PkceAuthProvider` named `"godaddy"` (not `env` — see
+/// [`GoDaddyAuthProvider`]'s doc) from an already-resolved (and
+/// gddy-specific-derived) environment.
+fn build_provider(env: &ResolvedEnv) -> PkceAuthProvider {
+    log_resolved_oauth(env);
+    PkceAuthProvider::new(
+        "godaddy",
+        env.auth_url.clone(),
+        env.token_url.clone(),
+        env.client_id.clone(),
+        environments::DEFAULT_OAUTH_SCOPES,
+    )
+    .with_app_id(environments::APP_ID)
+    .with_redirect_uri(environments::REDIRECT_URI)
+    .with_environments(Arc::clone(environments::instance()))
 }
 
 /// Build a `Credential` from a PAT entry.
@@ -140,8 +159,8 @@ impl AuthProvider for GoDaddyAuthProvider {
         if let Some(entry) = pat::resolve_pat(env).await {
             return Ok(pat_credential(env, &entry));
         }
-        self.resolve_and_log(env)?;
-        self.provider.get_credential(env, command, tier).await
+        let provider = self.provider_for(env)?;
+        provider.get_credential(env, command, tier).await
     }
 
     async fn get_credential_for(&self, req: &CredentialRequest<'_>) -> Result<Credential> {
@@ -165,16 +184,16 @@ impl AuthProvider for GoDaddyAuthProvider {
         if req.command.is_empty() {
             validate_requested_scopes(&req.meta.scopes)?;
         }
-        self.resolve_and_log(req.env)?;
-        self.provider.get_credential_for(req).await
+        let provider = self.provider_for(req.env)?;
+        provider.get_credential_for(req).await
     }
 
     async fn status(&self, env: &str) -> Result<Credential> {
         if let Some(entry) = pat::resolve_pat(env).await {
             return Ok(pat_credential(env, &entry));
         }
-        self.resolve_and_log(env)?;
-        self.provider.status(env).await
+        let provider = self.provider_for(env)?;
+        provider.status(env).await
     }
 
     async fn logout(&self, env: &str) -> Result<()> {
@@ -183,16 +202,23 @@ impl AuthProvider for GoDaddyAuthProvider {
         if let Err(err) = pat::delete_pat(env).await {
             tracing::debug!(env, error = %err, "ignoring PAT delete error during logout");
         }
-        self.resolve_and_log(env)?;
-        self.provider.logout(env).await
+        let provider = self.provider_for(env)?;
+        provider.logout(env).await
     }
 
     async fn list_environments(&self) -> Result<Vec<String>> {
+        // Enumerate stored credentials across built-ins + locally-configured
+        // envs (env-var-only envs are excluded from `listable`, matching the
+        // `env list` contract). `listable` falls back to built-ins on a
+        // malformed local config, so this never fails wholesale.
+        //
         // `PkceAuthProvider::list_environments` only reflects its own
         // in-memory token cache (keyring/file storage can't be enumerated by
-        // prefix), so this is a single call now that credentials for every
-        // env share one provider instance — no need to loop per env
-        // constructing a fresh (always cache-empty) provider per iteration.
+        // prefix), so a freshly-built provider always returns an empty list
+        // here — this loop is a no-op in practice today, same as before this
+        // module built one provider per call. Kept for whenever cli-engine
+        // gains real storage enumeration.
+        let listable = environments::listable()?;
         let mut envs = std::collections::BTreeSet::new();
         match pat::registry_envs().await {
             Ok(pats) => envs.extend(pats),
@@ -203,7 +229,10 @@ impl AuthProvider for GoDaddyAuthProvider {
                 );
             }
         }
-        envs.extend(self.provider.list_environments().await.unwrap_or_default());
+        for resolved in listable {
+            let provider = build_provider(&resolved);
+            envs.extend(provider.list_environments().await.unwrap_or_default());
+        }
         Ok(envs.into_iter().collect())
     }
 }

--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -10,10 +10,6 @@ use domains_client::types;
 
 const USER_AGENT: &str = concat!("godaddy-cli/", env!("CARGO_PKG_VERSION"));
 
-fn map_env_err(e: environments::EnvError) -> CliCoreError {
-    CliCoreError::message(e.to_string())
-}
-
 /// Bridges domains-client's request/response observations into cli-engine's
 /// `--debug transport` logger. domains-client defines the `TransportObserver`
 /// extension point itself and has no compile-time dependency on cli-engine —
@@ -211,7 +207,7 @@ pub(crate) fn make_client_with_cred(
     cred: &Credential,
 ) -> Result<domains_client::Client> {
     ensure_transport_observer_registered();
-    let domains = environments::resolve_domains(env).map_err(map_env_err)?;
+    let domains = environments::resolve_domains(env)?;
     let authorization = format!("Bearer {}", cred.token);
     let request_id = uuid::Uuid::new_v4().to_string();
     domains_client::client_with_auth(&domains.base_url, &authorization, USER_AGENT, &request_id)

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -3,7 +3,7 @@ use cli_engine::{
 };
 use serde_json::json;
 
-use crate::environments::{self, EnvError};
+use crate::environments;
 use crate::output_schema::output_schema;
 
 output_schema!(EnvSummary {
@@ -49,19 +49,29 @@ fn gdenv_path() -> std::io::Result<std::path::PathBuf> {
         })
 }
 
-pub fn get_env() -> Option<String> {
+/// Reads the raw, unvalidated `.gdenv` contents. No dependency on
+/// [`environments`] — used by [`environments::instance`]'s own lazy
+/// initializer, so it must not call back into `environments` (which resolves
+/// against the very instance being built, and would deadlock re-entering its
+/// `OnceLock`).
+pub(crate) fn read_gdenv_raw() -> Option<String> {
     gdenv_path()
         .ok()
         .and_then(|path| std::fs::read_to_string(path).ok())
         .map(|s| s.trim().to_owned())
-        // Ignore empty or unrecognized values (e.g. a hand-edited/corrupted
-        // .gdenv) so callers fall back to DEFAULT_ENV instead of propagating an
-        // unknown environment. `is_known` accepts built-ins plus any env defined
-        // via env var or local config, so a persisted custom env (e.g. "dev")
+        .filter(|s| !s.is_empty())
+}
+
+pub fn get_env() -> Option<String> {
+    read_gdenv_raw()
+        // Ignore an unrecognized value (e.g. a hand-edited/corrupted .gdenv) so
+        // callers fall back to DEFAULT_ENV instead of propagating an unknown
+        // environment. `is_known` accepts built-ins plus any env defined via
+        // env var or local config, so a persisted custom env (e.g. "dev")
         // survives — except a config-only env is dropped if the config file
         // can't be read, since `is_known` then falls back to built-ins +
         // `<ENV>_API_URL` only.
-        .filter(|s| !s.is_empty() && environments::is_known(s))
+        .filter(|s| environments::is_known(s))
 }
 
 pub fn set_env(env: &str) -> std::io::Result<()> {
@@ -71,10 +81,6 @@ pub fn set_env(env: &str) -> std::io::Result<()> {
         // an actionable message — the raw write error omits it.
         std::io::Error::new(e.kind(), format!("{}: {e}", path.display()))
     })
-}
-
-fn map_err(e: EnvError) -> cli_engine::CliCoreError {
-    cli_engine::CliCoreError::message(e.to_string())
 }
 
 fn active_env() -> String {
@@ -104,7 +110,7 @@ pub fn module() -> Module {
                 .no_auth(true),
             |_cred, _args| async move {
                 let current = active_env();
-                let mut resolved = environments::listable().map_err(map_err)?;
+                let mut resolved = environments::listable()?;
                 // If the active env is defined only via `<ENV>_API_URL` (so it's
                 // excluded from `listable`), still show it — otherwise the list
                 // has no `active: true` entry and callers can't tell what's active.
@@ -140,7 +146,7 @@ pub fn module() -> Module {
                 .no_auth(true),
             |_cred, _args| async move {
                 let env = active_env();
-                let resolved = environments::resolve(&env).map_err(map_err)?;
+                let resolved = environments::resolve(&env)?;
                 Ok(CommandResult::new(json!({
                     "env": resolved.name,
                     "apiUrl": resolved.api_url,
@@ -153,7 +159,11 @@ pub fn module() -> Module {
                     "Switches the active environment and persists the choice to \
                          ~/.gdenv so all subsequent commands use the new environment \
                          without needing `--env`.\n\
-                         The value must be a known environment name (prod or ote).",
+                         The value must be a known environment name (prod or ote).\n\
+                         If a local environments.toml entry for this environment sets \
+                         min_stage/feature_overrides to reveal pre-release commands, \
+                         persisting it here (not a same-invocation `--env`) is what \
+                         makes those commands visible on the next run.",
                 )
                 .with_system("env")
                 .with_tier(Tier::Mutate)
@@ -179,7 +189,7 @@ pub fn module() -> Module {
                 // Resolve up front: validates the env exists (built-in, env
                 // var, or local config) and yields its API URL for the reply.
                 // Runs unconditionally, including under `--dry-run`.
-                let resolved = environments::resolve(&env).map_err(map_err)?;
+                let resolved = environments::resolve(&env)?;
                 if ctx.dry_run() {
                     return Ok(CommandResult::new(json!({
                         "env": resolved.name,
@@ -214,7 +224,7 @@ pub fn module() -> Module {
                 .no_auth(true),
             |_cred, _args| async move {
                 let env = active_env();
-                let resolved = environments::resolve(&env).map_err(map_err)?;
+                let resolved = environments::resolve(&env)?;
                 Ok(CommandResult::new(json!({
                     "env": resolved.name,
                     "apiUrl": resolved.api_url,

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -159,7 +159,9 @@ pub fn module() -> Module {
                     "Switches the active environment and persists the choice to \
                          ~/.gdenv so all subsequent commands use the new environment \
                          without needing `--env`.\n\
-                         The value must be a known environment name (prod or ote).\n\
+                         The value must be a known environment name: the built-in prod \
+                         or ote, one defined in a local environments.toml, or one \
+                         defined via a <PREFIX>_API_URL environment variable.\n\
                          If a local environments.toml entry for this environment sets \
                          min_stage/feature_overrides to reveal pre-release commands, \
                          persisting it here (not a same-invocation `--env`) is what \

--- a/rust/src/env/mod.rs
+++ b/rust/src/env/mod.rs
@@ -101,7 +101,8 @@ pub fn module() -> Module {
         .with_command(RuntimeCommandSpec::new(
             CommandSpec::new("list", "List available environments")
                 .with_long(
-                    "Lists the environments the CLI can target (prod, ote). \
+                    "Lists the environments the CLI can target: the built-in prod \
+                         and ote, plus any defined in a local environments.toml. \
                          The currently active environment is marked `active: true`.",
                 )
                 .with_system("env")

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -1,35 +1,57 @@
-//! Single source of truth for environment → endpoint resolution.
+//! Environment -> endpoint resolution, delegated to cli-engine's shared
+//! `Environments`/`EnvironmentDef` type.
 //!
-//! Built-in, public-safe environments (`ote`, `prod`) are compiled in. Internal
-//! DEV/TEST environments are supplied **at runtime** and never committed to this
-//! (OSS) repo, via two override mechanisms:
+//! Built-in, public-safe environments (`ote`, `prod`) are compiled in here.
+//! Internal DEV/TEST environments are supplied **at runtime** and never
+//! committed to this (OSS) repo, via two override mechanisms:
 //!
-//! * **Per-env environment variable** — `<PREFIX>_API_URL` overrides (or defines)
-//!   an environment's API base URL, where `<PREFIX>` is the env name uppercased
-//!   with `-` replaced by `_` (e.g. `DEV_API_URL`, `OTE_API_URL`). This mirrors
-//!   cli-engine's `<PREFIX>_OAUTH_CLIENT_ID` / `<PREFIX>_OAUTH_AUTH_URL` /
-//!   `<PREFIX>_OAUTH_TOKEN_URL` naming, which `PkceAuthProvider` reads
-//!   automatically when a provider is named after its environment.
+//! * **Per-env environment variable** — `<PREFIX>_API_URL` overrides (or, for a
+//!   name unknown to every other layer, *defines*) an environment's API base
+//!   URL, where `<PREFIX>` is the env name uppercased with `-` replaced by `_`
+//!   (e.g. `DEV_API_URL`). cli-engine's `Environments` only lets an env var
+//!   override a *field* of an already-known environment, not introduce a
+//!   brand new selectable one, so [`resolve`] falls back to a local,
+//!   env-var-only path for that case — internal hostnames still never need a
+//!   compiled or local config entry.
 //! * **Gitignored local config** — a `gddy/environments.toml` in the OS config
-//!   directory (`dirs::config_dir()`: `~/.config` on Linux/XDG, `%APPDATA%` on
-//!   Windows, `~/Library/Application Support` on macOS; see [`environments_path`])
-//!   listing custom environments. The file lives outside the repo, so internal
-//!   hostnames stay on the developer's machine.
+//!   directory, parsed by cli-engine's `Environments` file layer (which
+//!   accepts both a flat `[name]` table and gddy's already-shipped nested
+//!   `[environments.name]` table).
 //!
 //! Resolution order (later layers win): built-in base → local config entry →
-//! `<PREFIX>_API_URL` env var. Built-ins may be overridden by either layer.
+//! `<PREFIX>_*` env var. Unlike cli-engine's own layering (a later layer's
+//! blank/malformed value unconditionally overwrites a good earlier one), the
+//! final merged URL strings are still run through [`clean_url`] here, so a
+//! blank/malformed override is rejected rather than silently used.
 //!
-//! Security note: because a built-in's `api_url` is overridable (and `auth_url`
-//! /`token_url` derive from it), overriding e.g. `prod` redirects that env's
-//! OAuth and bearer traffic to the new host while still presenting the built-in
-//! client id — i.e. a real prod token could be sent to the overriding host. The
-//! override surface (a process env var or a file under the user's home dir)
-//! already implies local trust, so this is an accepted trade-off; only override
-//! a built-in on a machine you control.
+//! # Feature-flag visibility per environment
+//!
+//! gddy's global default (set on `CliConfig` in `main.rs`) keeps
+//! `min_stage` at `Stage::Ga`, hiding any module/command flagged below GA
+//! (e.g. `hosting` = Beta; `webhook`/`application`/`actions` = Experimental).
+//! An `environments.toml` entry can permanently opt a specific environment
+//! into those pre-release commands via the *same* recognized keys cli-engine
+//! parses on every `EnvironmentDef` — no gddy-specific plumbing needed:
+//!
+//! ```toml
+//! [environments.dev]
+//! api_url = "https://api.dev-godaddy.com"
+//! min_stage = "experimental"
+//!
+//! [environments.staging.feature_overrides]
+//! "some-flag-key" = "beta"
+//! ```
+//!
+//! `<ENV>_MIN_STAGE`/`<ENV>_FEATURE_<KEY>` env vars override the same fields.
+//! **Caveat:** this only takes effect for the environment active when the
+//! process *starts* — cli-engine computes the visible command tree once at
+//! `Cli::new`, before the global `--env` flag is applied, so a same-invocation
+//! `--env dev` does not reveal `dev`'s pre-release commands. Persist the
+//! environment first (`gddy env set dev`), then run the command.
 
-use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
 
-use serde::Deserialize;
+use cli_engine::{CliCoreError, Environment, EnvironmentDef, Environments};
 
 pub const DEFAULT_ENV: &str = "prod";
 /// Scopes requested at login by default. The authorization server may grant a
@@ -88,48 +110,6 @@ pub struct ResolvedDomains {
     pub base_url: String,
 }
 
-/// Schema of the local environments file (see [`environments_path`]).
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct EnvironmentsFile {
-    #[serde(default)]
-    pub environments: BTreeMap<String, EnvEntry>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct EnvEntry {
-    pub api_url: String,
-    #[serde(default)]
-    pub client_id: Option<String>,
-    #[serde(default)]
-    pub auth_url: Option<String>,
-    #[serde(default)]
-    pub token_url: Option<String>,
-    /// Override base URL for domain commands (defaults to `api_url`).
-    #[serde(default)]
-    pub domains_api_url: Option<String>,
-    /// Override base URL for the account management site (see [`ResolvedEnv::account_url`]).
-    #[serde(default)]
-    pub account_url: Option<String>,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum EnvError {
-    #[error("unknown environment {name:?}; known: {known}")]
-    Unknown { name: String, known: String },
-    #[error("failed to read {path}: {source}")]
-    Io {
-        path: String,
-        source: std::io::Error,
-    },
-    #[error("failed to parse {path}: {source}")]
-    Parse {
-        path: String,
-        source: toml::de::Error,
-    },
-}
-
-/// Environment-variable prefix for an env name, matching cli-engine's
-/// `PkceAuthProvider` derivation (uppercase, `-` → `_`).
 pub fn env_prefix(name: &str) -> String {
     name.to_uppercase().replace('-', "_")
 }
@@ -154,10 +134,11 @@ fn derive_token_url(api_url: &str) -> String {
 /// Validates and normalizes a candidate URL (api/auth/token): trims surrounding
 /// whitespace and any trailing slash, and requires an `http(s)://` scheme with a
 /// non-empty host (reqwest needs an absolute URL). Returns `None` for an
-/// empty/whitespace or schemeless value, so a blank or malformed override never
-/// clobbers a built-in or yields a relative/unusable URL. This is the single
-/// authority for "is this URL usable?" — `resolve`, `is_known`, `known_names`,
-/// and `listable` all defer to it.
+/// empty/whitespace or schemeless value, so a blank or malformed value never
+/// resolves to a relative/unusable URL. This is the single authority for "is
+/// this URL usable?" across [`adapt`] and [`resolve_from_env_var_only`] —
+/// unlike cli-engine's own file/env-var layers (which apply unconditionally,
+/// with no such check), a blank/malformed value here is treated as unset.
 fn clean_url(raw: &str) -> Option<String> {
     let trimmed = raw.trim().trim_end_matches('/');
     // Require an http(s):// scheme (case-insensitive per RFC 3986, so `HTTPS://`
@@ -179,115 +160,124 @@ fn clean_url(raw: &str) -> Option<String> {
     (!host.is_empty()).then(|| trimmed.to_owned())
 }
 
-/// Path to the local environments config file, if a config dir can be resolved.
+/// Scans the raw process argv for a `--env <value>` / `--env=<value>` token.
 ///
-/// Uses `dirs::config_dir()` which honors `XDG_CONFIG_HOME` (→ `~/.config`) on
-/// Linux, matching cli-engine's own credential-store location logic.
-pub fn environments_path() -> Option<std::path::PathBuf> {
-    dirs::config_dir().map(|d| d.join("gddy").join("environments.toml"))
+/// cli-engine's built-in global `--env` flag (and any command-local `--env`
+/// arg sharing that argv text, e.g. `pat add --env <name>`) validates against
+/// the shared `Environments` *directly* — bypassing this module's own
+/// [`resolve`] and its env-var-only fallback entirely. So a name defined only
+/// via `<PREFIX>_API_URL` must be pre-registered into the singleton itself
+/// (see [`build_environments`]) before cli-engine ever sees it, which means
+/// finding that name before clap has parsed anything.
+fn requested_env_from_argv() -> Option<String> {
+    requested_env_from(std::env::args().skip(1))
 }
 
-/// Load the local environments file. A missing file is not an error.
-fn load_file() -> Result<EnvironmentsFile, EnvError> {
-    let Some(path) = environments_path() else {
-        return Ok(EnvironmentsFile::default());
-    };
-    match std::fs::read_to_string(&path) {
-        Ok(contents) => toml::from_str(&contents).map_err(|source| EnvError::Parse {
-            path: path.display().to_string(),
-            source,
-        }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(EnvironmentsFile::default()),
-        Err(source) => Err(EnvError::Io {
-            path: path.display().to_string(),
-            source,
-        }),
-    }
-}
-
-fn builtin(name: &str) -> Option<&'static Builtin> {
-    BUILTINS.iter().find(|b| b.name == name)
-}
-
-fn known_names(file: &EnvironmentsFile) -> String {
-    let mut names: Vec<&str> = BUILTINS.iter().map(|b| b.name).collect();
-    // Only usable config entries (non-empty api_url) — match `is_known`, so the
-    // "known: …" list never advertises an env that can't actually resolve.
-    names.extend(
-        file.environments
-            .iter()
-            .filter(|(_, e)| clean_url(&e.api_url).is_some())
-            .map(|(k, _)| k.as_str()),
-    );
-    names.sort_unstable();
-    names.dedup();
-    names.join(", ")
-}
-
-/// Resolve an environment from an explicit file + env-var getter. Pure: all
-/// inputs are injected, so this is unit-testable without touching process state.
-fn resolve_with(
-    name: &str,
-    file: &EnvironmentsFile,
-    var: impl Fn(&str) -> Option<String>,
-) -> Result<ResolvedEnv, EnvError> {
-    // Layer 1: built-in base.
-    let (mut api_url, mut client_id) = match builtin(name) {
-        Some(b) => (Some(b.api_url.to_owned()), b.client_id.to_owned()),
-        None => (None, String::new()),
-    };
-    let mut auth_url: Option<String> = None;
-    let mut token_url: Option<String> = None;
-    let mut domains_api_url: Option<String> = None;
-    let mut account_url: Option<String> = None;
-
-    // Layer 2: local config entry (overrides/defines). An empty/whitespace
-    // api_url is ignored so it can't clobber a built-in default.
-    if let Some(entry) = file.environments.get(name) {
-        if let Some(url) = clean_url(&entry.api_url) {
-            api_url = Some(url);
+/// Pure scan over an arg iterator — unit-testable without touching the real
+/// process argv. See [`requested_env_from_argv`] for why this exists.
+fn requested_env_from(mut args: impl Iterator<Item = String>) -> Option<String> {
+    while let Some(arg) = args.next() {
+        if let Some(value) = arg.strip_prefix("--env=") {
+            return Some(value.to_owned());
         }
-        if let Some(cid) = &entry.client_id {
-            client_id = cid.clone();
+        if arg == "--env" {
+            return args.next();
         }
-        // Validate auth/token overrides the same way as api_url: a schemeless or
-        // empty value is ignored, falling back to the derived endpoints.
-        auth_url = entry.auth_url.as_deref().and_then(clean_url);
-        token_url = entry.token_url.as_deref().and_then(clean_url);
-        domains_api_url = entry.domains_api_url.as_deref().and_then(clean_url);
-        account_url = entry.account_url.as_deref().and_then(clean_url);
     }
+    None
+}
 
-    // Layer 3: per-env `<PREFIX>_*` overrides (highest precedence). Empty values
-    // are ignored (clean_url normalizes URLs and drops blanks).
-    let prefix = env_prefix(name);
-    if let Some(url) = var(&format!("{prefix}_API_URL")).and_then(|v| clean_url(&v)) {
-        api_url = Some(url);
+/// Builds the compiled-in `ote`/`prod` `Environments`, shared by
+/// `CliConfig::with_environments`, `PkceAuthProvider::with_environments`, and
+/// this module's own resolution helpers below.
+fn build_environments() -> Environments {
+    // `crate::env::read_gdenv_raw`, not `crate::env::get_env` — `get_env`
+    // validates via `is_known`, which resolves against this very instance and
+    // would deadlock re-entering `instance()`'s `OnceLock`
+    // mid-initialization.
+    let default = crate::env::read_gdenv_raw().unwrap_or_else(|| DEFAULT_ENV.to_owned());
+    let mut envs = Environments::new(default.clone())
+        .with_app_id(APP_ID)
+        .with_config_file(true);
+    for b in BUILTINS {
+        envs = envs.with_environment(
+            b.name,
+            EnvironmentDef::new()
+                .with_client_id(b.client_id)
+                .with_auth_url(derive_auth_url(b.api_url))
+                .with_token_url(derive_token_url(b.api_url))
+                .with_field("api_url", b.api_url),
+        );
     }
-    if let Some(url) = var(&format!("{prefix}_DOMAINS_API_URL")).and_then(|v| clean_url(&v)) {
-        domains_api_url = Some(url);
+    // Pre-register a placeholder for any candidate (the `.gdenv` default, or
+    // an explicit `--env <name>` on the command line) that's otherwise
+    // unknown to every layer but has a `<PREFIX>_API_URL` env var set —
+    // cli-engine's own env-var layer only overrides a bag key already
+    // present in a resolved record, it can't introduce a brand-new
+    // selectable environment on its own. An empty `api_url` placeholder
+    // gives that layer something to fill in; it's never registered for a
+    // name already known via a compiled/file entry, so a real value is
+    // never clobbered.
+    for candidate in [default].into_iter().chain(requested_env_from_argv()) {
+        if envs.list().contains(&candidate) {
+            continue;
+        }
+        let prefix = env_prefix(&candidate);
+        if std::env::var(format!("{prefix}_API_URL")).is_ok() {
+            envs =
+                envs.with_environment(candidate, EnvironmentDef::new().with_field("api_url", ""));
+        }
     }
-    if let Some(url) = var(&format!("{prefix}_ACCOUNT_URL")).and_then(|v| clean_url(&v)) {
-        account_url = Some(url);
-    }
+    envs
+}
 
-    // api_url is already trimmed/normalized by clean_url (and built-ins carry no
-    // trailing slash), so callers concatenating paths never produce `//`.
-    let api_url = api_url.ok_or_else(|| EnvError::Unknown {
-        name: name.to_owned(),
-        known: known_names(file),
-    })?;
+/// The shared `Environments` instance — built once, reused by every consumer
+/// (`main.rs`'s `CliConfig::with_environments`, `auth.rs`'s
+/// `PkceAuthProvider::with_environments`, and this module's own `resolve`/
+/// `listable`/`is_known`).
+pub fn instance() -> &'static Arc<Environments> {
+    static INSTANCE: OnceLock<Arc<Environments>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Arc::new(build_environments()))
+}
 
-    let auth_url = auth_url.unwrap_or_else(|| derive_auth_url(&api_url));
-    let token_url = token_url.unwrap_or_else(|| derive_token_url(&api_url));
-    // Domain endpoints default to the same host as the OAuth/api_url service.
-    let domains_api_url = domains_api_url.unwrap_or_else(|| api_url.clone());
-    let account_url = account_url.unwrap_or_else(|| derive_account_url(name));
-
+/// Adapts a resolved `cli_engine::environments::Environment` into gddy's own
+/// [`ResolvedEnv`] shape, applying the derivation/defaulting and URL
+/// validation that cli-engine's generic `extra` bag has no notion of.
+fn adapt(name: &str, env: Environment) -> cli_engine::Result<ResolvedEnv> {
+    let api_url = env
+        .extra
+        .get("api_url")
+        .and_then(|v| clean_url(v))
+        .ok_or_else(|| {
+            CliCoreError::message(format!(
+                "environment {name:?} has no usable api_url configured"
+            ))
+        })?;
+    let oauth = env.oauth.unwrap_or_default();
+    let auth_url = if oauth.auth_url.is_empty() {
+        derive_auth_url(&api_url)
+    } else {
+        oauth.auth_url
+    };
+    let token_url = if oauth.token_url.is_empty() {
+        derive_token_url(&api_url)
+    } else {
+        oauth.token_url
+    };
+    let domains_api_url = env
+        .extra
+        .get("domains_api_url")
+        .and_then(|v| clean_url(v))
+        .unwrap_or_else(|| api_url.clone());
+    let account_url = env
+        .extra
+        .get("account_url")
+        .and_then(|v| clean_url(v))
+        .unwrap_or_else(|| derive_account_url(name));
     Ok(ResolvedEnv {
         name: name.to_owned(),
         api_url,
-        client_id,
+        client_id: oauth.client_id,
         auth_url,
         token_url,
         domains_api_url,
@@ -295,55 +285,46 @@ fn resolve_with(
     })
 }
 
-/// Names listed by `env list`: built-ins + locally-configured entries only
-/// (env-var-only environments are intentionally excluded).
-fn listable_with(
-    file: &EnvironmentsFile,
-    var: impl Fn(&str) -> Option<String> + Copy,
-) -> Result<Vec<ResolvedEnv>, EnvError> {
-    let mut names: Vec<String> = BUILTINS.iter().map(|b| b.name.to_owned()).collect();
-    for (key, entry) in &file.environments {
-        // Skip unusable entries (empty or schemeless api_url): including one
-        // would make the whole `env list` / credential enumeration fail on a
-        // single bad entry.
-        if clean_url(&entry.api_url).is_some() && !names.iter().any(|n| n == key) {
-            names.push(key.clone());
-        }
-    }
-    names.iter().map(|n| resolve_with(n, file, var)).collect()
-}
-
-fn is_known_with(
+/// Falls back to a `<PREFIX>_API_URL`-only definition for a name unknown to
+/// every compiled/file layer — see the module doc for why this must survive
+/// the migration onto cli-engine's `Environments` (which cannot define a new
+/// environment from an env var alone). Pure: the var getter is injected so
+/// this is unit-testable without touching process state.
+fn resolve_from_env_var_only(
     name: &str,
-    file: &EnvironmentsFile,
     var: impl Fn(&str) -> Option<String>,
-) -> bool {
-    builtin(name).is_some()
-        || file
-            .environments
-            .get(name)
-            .is_some_and(|e| clean_url(&e.api_url).is_some())
-        || var(&format!("{}_API_URL", env_prefix(name))).is_some_and(|v| clean_url(&v).is_some())
+) -> Option<ResolvedEnv> {
+    let prefix = env_prefix(name);
+    let api_url = var(&format!("{prefix}_API_URL")).and_then(|v| clean_url(&v))?;
+    let domains_api_url = var(&format!("{prefix}_DOMAINS_API_URL"))
+        .and_then(|v| clean_url(&v))
+        .unwrap_or_else(|| api_url.clone());
+    let account_url = var(&format!("{prefix}_ACCOUNT_URL"))
+        .and_then(|v| clean_url(&v))
+        .unwrap_or_else(|| derive_account_url(name));
+    Some(ResolvedEnv {
+        name: name.to_owned(),
+        auth_url: derive_auth_url(&api_url),
+        token_url: derive_token_url(&api_url),
+        api_url,
+        client_id: String::new(),
+        domains_api_url,
+        account_url,
+    })
 }
 
-/// Resolve an environment by name (built-ins → local config → env var).
-pub fn resolve(name: &str) -> Result<ResolvedEnv, EnvError> {
-    match load_file() {
-        Ok(file) => resolve_with(name, &file, |k| std::env::var(k).ok()),
-        // The local config is optional; a malformed/unreadable file must not
-        // brick built-in or `<PREFIX>_API_URL`-defined envs. Retry against an
-        // empty file, and only surface the load error if `name` actually needed
-        // the file to resolve.
-        Err(load_err) => {
-            let empty = EnvironmentsFile::default();
-            resolve_with(name, &empty, |k| std::env::var(k).ok()).map_err(|_| load_err)
-        }
+/// Resolve an environment by name (built-ins → local config → env var, with a
+/// pure-env-var-only fallback for a name none of those layers define).
+pub fn resolve(name: &str) -> cli_engine::Result<ResolvedEnv> {
+    match instance().resolve(name) {
+        Ok(env) => adapt(name, env),
+        Err(err) => resolve_from_env_var_only(name, |k| std::env::var(k).ok()).ok_or(err),
     }
 }
 
 /// Resolve the domain-command view of an environment: its domains base URL.
 /// Thin wrapper over [`resolve`].
-pub fn resolve_domains(name: &str) -> Result<ResolvedDomains, EnvError> {
+pub fn resolve_domains(name: &str) -> cli_engine::Result<ResolvedDomains> {
     let env = resolve(name)?;
     Ok(ResolvedDomains {
         base_url: env.domains_api_url,
@@ -355,218 +336,182 @@ pub fn resolve_domains(name: &str) -> Result<ResolvedDomains, EnvError> {
 /// Infallible last-resort value (unlike [`resolve`], which can fail on a
 /// malformed local config), so callers never end up with an empty base URL.
 pub fn default_api_url() -> &'static str {
-    builtin(DEFAULT_ENV)
+    BUILTINS
+        .iter()
+        .find(|b| b.name == DEFAULT_ENV)
         .map(|b| b.api_url)
         .unwrap_or("https://api.godaddy.com")
 }
 
 /// Environments to show in `env list`: built-ins + local-config entries.
-pub fn listable() -> Result<Vec<ResolvedEnv>, EnvError> {
-    // Consistent with `resolve`/`is_known`: a malformed optional config must not
-    // brick `env list` / credential enumeration for built-ins. Fall back to
-    // built-ins only (warning) rather than failing wholesale.
-    let file = load_file().unwrap_or_else(|err| {
-        // `err` already includes the OS-resolved config path (Io/Parse carry it),
-        // so don't hard-code `~/.config/...` (wrong on Windows/macOS/XDG).
-        tracing::warn!(error = %err, "ignoring unreadable environments config; listing built-ins only");
-        EnvironmentsFile::default()
-    });
-    listable_with(&file, |k| std::env::var(k).ok())
+/// Env-var-only environments are intentionally excluded (matching cli-engine's
+/// own `Environments::list`, which can't discover a name defined only by an
+/// env var either).
+pub fn listable() -> cli_engine::Result<Vec<ResolvedEnv>> {
+    let envs = instance();
+    Ok(envs
+        .list()
+        .into_iter()
+        .filter_map(|name| envs.resolve(&name).ok().and_then(|e| adapt(&name, e).ok()))
+        .collect())
 }
 
 /// Whether `name` is a usable environment (built-in, locally configured, or
 /// defined via a `<PREFIX>_API_URL` env var).
 pub fn is_known(name: &str) -> bool {
-    match load_file() {
-        Ok(file) => is_known_with(name, &file, |k| std::env::var(k).ok()),
-        // If the config can't be read, fall back to built-ins + env vars so a
-        // broken file never hides the public environments.
-        Err(_) => {
-            builtin(name).is_some()
-                || std::env::var(format!("{}_API_URL", env_prefix(name)))
-                    .ok()
-                    .and_then(|v| clean_url(&v))
-                    .is_some()
-        }
-    }
+    resolve(name).is_ok()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn entry(api_url: &str) -> EnvEntry {
-        EnvEntry {
-            api_url: api_url.to_owned(),
-            client_id: None,
-            auth_url: None,
-            token_url: None,
-            domains_api_url: None,
-            account_url: None,
-        }
-    }
-
-    fn no_vars(_: &str) -> Option<String> {
-        None
+    fn test_environment(def: EnvironmentDef) -> Environment {
+        Environments::new("x")
+            .with_environment("x", def)
+            .resolve("x")
+            .expect("x resolves")
     }
 
     #[test]
-    fn builtin_resolves_with_derived_oauth_urls() {
-        let file = EnvironmentsFile::default();
-        let env = resolve_with("prod", &file, no_vars).expect("prod resolves");
-        assert_eq!(env.api_url, "https://api.godaddy.com");
-        assert_eq!(env.client_id, "bc87f347-af82-4892-833f-818f54a0e79e");
-        assert_eq!(env.auth_url, "https://api.godaddy.com/v2/oauth2/authorize");
-        assert_eq!(env.token_url, "https://api.godaddy.com/v2/oauth2/token");
+    fn adapt_derives_oauth_urls_from_api_url_when_unset() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.example.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(resolved.api_url, "https://api.example.test");
+        assert_eq!(resolved.client_id, "cid");
+        assert_eq!(
+            resolved.auth_url,
+            "https://api.example.test/v2/oauth2/authorize"
+        );
+        assert_eq!(
+            resolved.token_url,
+            "https://api.example.test/v2/oauth2/token"
+        );
     }
 
     #[test]
-    fn unknown_env_errors_with_known_list() {
-        let file = EnvironmentsFile::default();
-        let err = resolve_with("nope", &file, no_vars).expect_err("unknown errors");
-        let EnvError::Unknown { name, known } = err else {
-            unreachable!("expected Unknown variant");
-        };
-        assert_eq!(name, "nope");
-        assert!(known.contains("ote") && known.contains("prod"), "{known}");
+    fn adapt_prefers_explicit_oauth_urls_over_derived() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_auth_url("https://auth.example.test/authorize")
+                .with_token_url("https://auth.example.test/token")
+                .with_field("api_url", "https://api.example.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(resolved.auth_url, "https://auth.example.test/authorize");
+        assert_eq!(resolved.token_url, "https://auth.example.test/token");
     }
 
     #[test]
-    fn env_var_defines_a_new_env() {
-        let file = EnvironmentsFile::default();
+    fn adapt_rejects_missing_api_url() {
+        let env = test_environment(EnvironmentDef::new().with_client_id("cid"));
+        let err = adapt("dev", env).expect_err("no api_url");
+        assert!(err.to_string().contains("dev"));
+    }
+
+    #[test]
+    fn adapt_rejects_blank_api_url_final_value() {
+        // A blank override that made it all the way through cli-engine's own
+        // (unconditional) layering must still be treated as unset here.
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "   "),
+        );
+        assert!(adapt("dev", env).is_err());
+    }
+
+    #[test]
+    fn domains_api_url_defaults_to_api_url() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.example.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(resolved.domains_api_url, resolved.api_url);
+    }
+
+    #[test]
+    fn domains_api_url_override_is_respected() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.example.test")
+                .with_field("domains_api_url", "https://domains.example.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(resolved.domains_api_url, "https://domains.example.test");
+    }
+
+    #[test]
+    fn account_url_defaults_to_bare_domain_for_prod() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.godaddy.com"),
+        );
+        let resolved = adapt("prod", env).expect("adapts");
+        assert_eq!(resolved.account_url, "https://account.godaddy.com");
+    }
+
+    #[test]
+    fn account_url_defaults_to_prefixed_domain_for_non_prod() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.ote-godaddy.com"),
+        );
+        let resolved = adapt("ote", env).expect("adapts");
+        assert_eq!(resolved.account_url, "https://account.ote-godaddy.com");
+    }
+
+    #[test]
+    fn account_url_override_is_respected() {
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_field("api_url", "https://api.example.test")
+                .with_field("account_url", "https://account.override.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(resolved.account_url, "https://account.override.test");
+    }
+
+    #[test]
+    fn env_var_only_fallback_defines_a_new_env() {
         let var = |k: &str| (k == "DEV_API_URL").then(|| "https://dev.example.test".to_owned());
-        let env = resolve_with("dev", &file, var).expect("dev resolves from env var");
-        assert_eq!(env.api_url, "https://dev.example.test");
-        assert_eq!(env.auth_url, "https://dev.example.test/v2/oauth2/authorize");
-        assert!(env.client_id.is_empty());
-    }
-
-    #[test]
-    fn env_var_overrides_a_builtin() {
-        let file = EnvironmentsFile::default();
-        let var =
-            |k: &str| (k == "PROD_API_URL").then(|| "https://sandbox.example.test".to_owned());
-        let env = resolve_with("prod", &file, var).expect("prod resolves");
-        assert_eq!(env.api_url, "https://sandbox.example.test");
-        // Client id is retained from the built-in.
-        assert_eq!(env.client_id, "bc87f347-af82-4892-833f-818f54a0e79e");
-    }
-
-    #[test]
-    fn local_config_entry_resolves_and_respects_precedence() {
-        let mut file = EnvironmentsFile::default();
-        file.environments
-            .insert("test".to_owned(), entry("https://test.example.invalid"));
-        // No env var: local config wins.
-        let env = resolve_with("test", &file, no_vars).expect("test resolves");
-        assert_eq!(env.api_url, "https://test.example.invalid");
-        // Env var present: overrides the local config api_url.
-        let var =
-            |k: &str| (k == "TEST_API_URL").then(|| "https://override.example.test".to_owned());
-        let env = resolve_with("test", &file, var).expect("test resolves");
-        assert_eq!(env.api_url, "https://override.example.test");
-    }
-
-    #[test]
-    fn explicit_oauth_urls_and_client_id_in_local_config() {
-        let mut file = EnvironmentsFile::default();
-        file.environments.insert(
-            "dev".to_owned(),
-            EnvEntry {
-                api_url: "https://dev.example.invalid".to_owned(),
-                client_id: Some("custom-client".to_owned()),
-                auth_url: Some("https://auth.example.invalid/authorize".to_owned()),
-                token_url: Some("https://auth.example.invalid/token".to_owned()),
-                domains_api_url: None,
-                account_url: None,
-            },
-        );
-        let env = resolve_with("dev", &file, no_vars).expect("dev resolves");
-        assert_eq!(env.client_id, "custom-client");
-        assert_eq!(env.auth_url, "https://auth.example.invalid/authorize");
-        assert_eq!(env.token_url, "https://auth.example.invalid/token");
-    }
-
-    #[test]
-    fn oauth_urls_derive_from_custom_api_url_trimming_trailing_slash() {
-        let mut file = EnvironmentsFile::default();
-        // Custom env, no explicit auth/token URLs, api_url has a trailing slash.
-        file.environments
-            .insert("dev".to_owned(), entry("https://dev.example.invalid/"));
-        let env = resolve_with("dev", &file, no_vars).expect("dev resolves");
-        // api_url is normalized (trailing slash trimmed) so callers don't build `//`.
-        assert_eq!(env.api_url, "https://dev.example.invalid");
+        let resolved = resolve_from_env_var_only("dev", var).expect("dev resolves from env var");
+        assert_eq!(resolved.api_url, "https://dev.example.test");
         assert_eq!(
-            env.auth_url,
-            "https://dev.example.invalid/v2/oauth2/authorize"
+            resolved.auth_url,
+            "https://dev.example.test/v2/oauth2/authorize"
         );
-        assert_eq!(env.token_url, "https://dev.example.invalid/v2/oauth2/token");
+        assert!(resolved.client_id.is_empty());
     }
 
     #[test]
-    fn default_api_url_is_the_builtin_prod_url() {
-        assert_eq!(default_api_url(), "https://api.godaddy.com");
+    fn env_var_only_fallback_is_none_without_the_var() {
+        let var = |_: &str| None;
+        assert!(resolve_from_env_var_only("dev", var).is_none());
     }
 
     #[test]
-    fn empty_or_whitespace_override_does_not_clobber_builtin() {
-        let file = EnvironmentsFile::default();
-        let var = |k: &str| (k == "PROD_API_URL").then(|| "   ".to_owned());
-        let env = resolve_with("prod", &file, var).expect("prod resolves");
-        assert_eq!(env.api_url, "https://api.godaddy.com");
-    }
-
-    #[test]
-    fn is_known_rejects_empty_api_url_from_config_or_env() {
-        let mut file = EnvironmentsFile::default();
-        file.environments.insert("blank".to_owned(), entry(""));
-        // Empty config api_url -> not usable -> not known.
-        assert!(!is_known_with("blank", &file, no_vars));
-        // Empty env-var api_url -> not known either.
-        let blank_var = |k: &str| (k == "GHOST_API_URL").then(String::new);
-        assert!(!is_known_with(
-            "ghost",
-            &EnvironmentsFile::default(),
-            blank_var
-        ));
-    }
-
-    #[test]
-    fn schemeless_auth_token_overrides_fall_back_to_derived() {
-        let mut file = EnvironmentsFile::default();
-        file.environments.insert(
-            "dev".to_owned(),
-            EnvEntry {
-                api_url: "https://dev.example.invalid".to_owned(),
-                client_id: None,
-                auth_url: Some("auth.example.invalid/authorize".to_owned()), // no scheme
-                token_url: Some("   ".to_owned()),                           // blank
-                domains_api_url: None,
-                account_url: None,
-            },
-        );
-        let env = resolve_with("dev", &file, no_vars).expect("dev resolves");
-        // Invalid/blank overrides are ignored; endpoints derive from api_url.
-        assert_eq!(
-            env.auth_url,
-            "https://dev.example.invalid/v2/oauth2/authorize"
-        );
-        assert_eq!(env.token_url, "https://dev.example.invalid/v2/oauth2/token");
-    }
-
-    #[test]
-    fn schemeless_api_url_is_rejected_but_http_is_accepted() {
-        let mut file = EnvironmentsFile::default();
-        // No http(s):// scheme -> unusable -> not known, and resolve errors.
-        file.environments
-            .insert("bare".to_owned(), entry("api.dev.invalid"));
-        assert!(!is_known_with("bare", &file, no_vars));
-        assert!(resolve_with("bare", &file, no_vars).is_err());
-        // http:// (e.g. a local proxy) is accepted.
-        file.environments
-            .insert("local".to_owned(), entry("http://localhost:8080"));
-        let env = resolve_with("local", &file, no_vars).expect("http accepted");
-        assert_eq!(env.api_url, "http://localhost:8080");
+    fn env_var_only_fallback_respects_domains_and_account_overrides() {
+        let var = |k: &str| match k {
+            "DEV_API_URL" => Some("https://dev.example.test".to_owned()),
+            "DEV_DOMAINS_API_URL" => Some("https://domains.dev.example.test".to_owned()),
+            "DEV_ACCOUNT_URL" => Some("https://account.dev.example.test".to_owned()),
+            _ => None,
+        };
+        let resolved = resolve_from_env_var_only("dev", var).expect("dev resolves");
+        assert_eq!(resolved.domains_api_url, "https://domains.dev.example.test");
+        assert_eq!(resolved.account_url, "https://account.dev.example.test");
     }
 
     #[test]
@@ -575,18 +520,16 @@ mod tests {
             clean_url("https://api.example.test/"),
             Some("https://api.example.test".to_owned())
         );
-        assert!(clean_url("https:///path").is_none()); // empty host
+        assert!(clean_url("https:///path").is_none());
         assert!(clean_url("https://").is_none());
-        assert!(clean_url("https://?x").is_none()); // query, no host
-        assert!(clean_url("ftp://x").is_none()); // wrong scheme
-        assert!(clean_url("api.example.test").is_none()); // no scheme
+        assert!(clean_url("https://?x").is_none());
+        assert!(clean_url("ftp://x").is_none());
+        assert!(clean_url("api.example.test").is_none());
         assert!(clean_url("not a url").is_none());
-        // Scheme is case-insensitive (RFC 3986); host case is preserved.
         assert_eq!(
             clean_url("HTTPS://api.Example.test"),
             Some("HTTPS://api.Example.test".to_owned())
         );
-        // A path/port is preserved (trailing slash trimmed).
         assert_eq!(
             clean_url("http://localhost:8080/api/"),
             Some("http://localhost:8080/api".to_owned())
@@ -594,118 +537,46 @@ mod tests {
     }
 
     #[test]
-    fn listable_includes_builtins_and_local_but_not_env_var_only() {
-        let mut file = EnvironmentsFile::default();
-        file.environments
-            .insert("test".to_owned(), entry("https://test.example.invalid"));
-        // `foo` is defined only via an env var and must NOT appear in the list.
-        let var = |k: &str| (k == "FOO_API_URL").then(|| "https://foo.example.test".to_owned());
-        let listed = listable_with(&file, var).expect("listable");
-        let names: Vec<&str> = listed.iter().map(|e| e.name.as_str()).collect();
-        assert!(names.contains(&"ote"));
-        assert!(names.contains(&"prod"));
-        assert!(names.contains(&"test"));
-        assert!(!names.contains(&"foo"), "env-var-only env leaked into list");
+    fn default_api_url_is_the_builtin_prod_url() {
+        assert_eq!(default_api_url(), "https://api.godaddy.com");
     }
 
     #[test]
-    fn is_known_covers_builtin_local_and_env_var() {
-        let mut file = EnvironmentsFile::default();
-        file.environments
-            .insert("test".to_owned(), entry("https://test.example.invalid"));
-        let var = |k: &str| (k == "FOO_API_URL").then(|| "https://foo.example.test".to_owned());
-        assert!(is_known_with("prod", &file, var)); // built-in
-        assert!(is_known_with("test", &file, var)); // local config
-        assert!(is_known_with("foo", &file, var)); // env var
-        assert!(!is_known_with("missing", &file, var));
+    fn env_prefix_uppercases_and_replaces_hyphen() {
+        assert_eq!(env_prefix("ote"), "OTE");
+        assert_eq!(env_prefix("prod-us"), "PROD_US");
+    }
+
+    fn argv(args: &[&str]) -> impl Iterator<Item = String> {
+        args.iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     #[test]
-    fn domains_api_url_defaults_to_api_url() {
-        let file = EnvironmentsFile::default();
-        let env = resolve_with("prod", &file, no_vars).expect("prod resolves");
-        assert_eq!(env.domains_api_url, env.api_url);
-    }
-
-    #[test]
-    fn domains_url_from_local_config() {
-        let mut file = EnvironmentsFile::default();
-        file.environments.insert(
-            "dev".to_owned(),
-            EnvEntry {
-                api_url: "https://dev.example.invalid".to_owned(),
-                client_id: None,
-                auth_url: None,
-                token_url: None,
-                domains_api_url: Some("https://domains.dev.example.invalid".to_owned()),
-                account_url: None,
-            },
+    fn requested_env_from_finds_space_separated_value() {
+        assert_eq!(
+            requested_env_from(argv(&["--dry-run", "--env", "dev", "list"])),
+            Some("dev".to_owned())
         );
-        let env = resolve_with("dev", &file, no_vars).expect("dev resolves");
-        assert_eq!(env.domains_api_url, "https://domains.dev.example.invalid");
-        // api_url is unaffected by the domains override.
-        assert_eq!(env.api_url, "https://dev.example.invalid");
     }
 
     #[test]
-    fn domains_url_env_var_overrides_config() {
-        let mut file = EnvironmentsFile::default();
-        file.environments.insert(
-            "dev".to_owned(),
-            EnvEntry {
-                api_url: "https://dev.example.invalid".to_owned(),
-                client_id: None,
-                auth_url: None,
-                token_url: None,
-                domains_api_url: Some("https://from-file.example.invalid".to_owned()),
-                account_url: None,
-            },
+    fn requested_env_from_finds_equals_separated_value() {
+        assert_eq!(
+            requested_env_from(argv(&["--env=dev", "list"])),
+            Some("dev".to_owned())
         );
-        let var = |k: &str| match k {
-            "DEV_DOMAINS_API_URL" => Some("https://from-env.example.invalid".to_owned()),
-            _ => None,
-        };
-        let env = resolve_with("dev", &file, var).expect("dev resolves");
-        assert_eq!(env.domains_api_url, "https://from-env.example.invalid");
     }
 
     #[test]
-    fn missing_config_file_is_not_an_error() {
-        // load_file resolves a real path; just assert it does not panic and that
-        // a default (empty) file resolves built-ins correctly via the public API.
-        assert!(is_known("prod"));
+    fn requested_env_from_is_none_without_the_flag() {
+        assert_eq!(requested_env_from(argv(&["env", "list"])), None);
     }
 
     #[test]
-    fn account_url_defaults_to_bare_domain_for_prod() {
-        let file = EnvironmentsFile::default();
-        let env = resolve_with("prod", &file, no_vars).expect("prod resolves");
-        assert_eq!(env.account_url, "https://account.godaddy.com");
-    }
-
-    #[test]
-    fn account_url_defaults_to_prefixed_domain_for_non_prod() {
-        let file = EnvironmentsFile::default();
-        let env = resolve_with("ote", &file, no_vars).expect("ote resolves");
-        assert_eq!(env.account_url, "https://account.ote-godaddy.com");
-    }
-
-    #[test]
-    fn account_url_env_var_overrides_default() {
-        let file = EnvironmentsFile::default();
-        let var =
-            |k: &str| (k == "PROD_ACCOUNT_URL").then(|| "https://account.override.test".to_owned());
-        let env = resolve_with("prod", &file, var).expect("prod resolves");
-        assert_eq!(env.account_url, "https://account.override.test");
-    }
-
-    #[test]
-    fn account_url_local_config_overrides_default() {
-        let mut file = EnvironmentsFile::default();
-        let mut e = entry("https://dev.example.invalid");
-        e.account_url = Some("https://account.dev.example.invalid".to_owned());
-        file.environments.insert("dev".to_owned(), e);
-        let env = resolve_with("dev", &file, no_vars).expect("dev resolves");
-        assert_eq!(env.account_url, "https://account.dev.example.invalid");
+    fn requested_env_from_trailing_env_flag_with_no_value_is_none() {
+        assert_eq!(requested_env_from(argv(&["--env"])), None);
     }
 }

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -204,10 +204,37 @@ fn build_environments() -> Environments {
     // validates via `is_known`, which resolves against this very instance and
     // would deadlock re-entering `instance()`'s `OnceLock`
     // mid-initialization.
-    let default = crate::env::read_gdenv_raw().unwrap_or_else(|| DEFAULT_ENV.to_owned());
-    let mut envs = Environments::new(default.clone())
-        .with_app_id(APP_ID)
-        .with_config_file(true);
+    let default_raw = crate::env::read_gdenv_raw().unwrap_or_else(|| DEFAULT_ENV.to_owned());
+    resolve_default_environments(&default_raw)
+}
+
+/// Builds the full `Environments` instance for candidate default
+/// `default_raw`, falling back to [`DEFAULT_ENV`] if it can't actually
+/// resolve. A corrupted/hand-edited `.gdenv`, or one naming a since-removed
+/// custom env, must not become the CLI's real startup default — every other
+/// command relying on the default active environment (via
+/// `ctx.middleware.env`) would then fail with "unknown environment" instead
+/// of falling back, unlike `env::get_env`'s own `is_known` guard. Validated
+/// against `probe` directly (a plain method call on this local instance),
+/// not `instance()`/`resolve()`, so this can't re-enter the singleton's own
+/// initialization. Split out from [`build_environments`] for testability
+/// without touching the real `.gdenv` file or the process-wide singleton.
+fn resolve_default_environments(default_raw: &str) -> Environments {
+    let probe = register(Environments::new(default_raw.to_owned()), default_raw);
+    if probe.resolve(default_raw).is_ok() {
+        probe
+    } else {
+        register(Environments::new(DEFAULT_ENV), default_raw)
+    }
+}
+
+/// Registers the compiled `ote`/`prod` defaults plus any env-var-only
+/// placeholder (see the module doc) onto `envs`. `default_candidate` is the
+/// `.gdenv` value under consideration as the active default — pre-registered
+/// like any other candidate so [`build_environments`] can validate it even
+/// when it's only defined via `<PREFIX>_API_URL`.
+fn register(envs: Environments, default_candidate: &str) -> Environments {
+    let mut envs = envs.with_app_id(APP_ID).with_config_file(true);
     for b in BUILTINS {
         envs = envs.with_environment(
             b.name,
@@ -227,7 +254,10 @@ fn build_environments() -> Environments {
     // gives that layer something to fill in; it's never registered for a
     // name already known via a compiled/file entry, so a real value is
     // never clobbered.
-    for candidate in [default].into_iter().chain(requested_env_from_argv()) {
+    for candidate in [default_candidate.to_owned()]
+        .into_iter()
+        .chain(requested_env_from_argv())
+    {
         if envs.list().contains(&candidate) {
             continue;
         }
@@ -575,6 +605,22 @@ mod tests {
     fn env_prefix_uppercases_and_replaces_hyphen() {
         assert_eq!(env_prefix("ote"), "OTE");
         assert_eq!(env_prefix("prod-us"), "PROD_US");
+    }
+
+    #[test]
+    fn resolve_default_environments_falls_back_to_default_env_for_an_unresolvable_gdenv_value() {
+        // A corrupted/stale `.gdenv` value that resolves to nothing (no
+        // compiled/file entry, no matching `<PREFIX>_API_URL`) must not
+        // become the CLI's real startup default.
+        let envs = resolve_default_environments("totally-bogus-env-name");
+        assert_eq!(envs.default_env(), DEFAULT_ENV);
+        assert!(envs.resolve(DEFAULT_ENV).is_ok());
+    }
+
+    #[test]
+    fn resolve_default_environments_keeps_a_resolvable_gdenv_value() {
+        let envs = resolve_default_environments("prod");
+        assert_eq!(envs.default_env(), "prod");
     }
 
     fn argv(args: &[&str]) -> impl Iterator<Item = String> {

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -254,16 +254,13 @@ fn adapt(name: &str, env: Environment) -> cli_engine::Result<ResolvedEnv> {
             ))
         })?;
     let oauth = env.oauth.unwrap_or_default();
-    let auth_url = if oauth.auth_url.is_empty() {
-        derive_auth_url(&api_url)
-    } else {
-        oauth.auth_url
-    };
-    let token_url = if oauth.token_url.is_empty() {
-        derive_token_url(&api_url)
-    } else {
-        oauth.token_url
-    };
+    // `clean_url`, not a bare emptiness check — a blank-but-non-empty or
+    // schemeless override (from a local config entry or an `<ENV>_OAUTH_*`
+    // env var) must fall back to the derived endpoint too, matching the
+    // validation already applied to `api_url`/`domains_api_url`/`account_url`
+    // above.
+    let auth_url = clean_url(&oauth.auth_url).unwrap_or_else(|| derive_auth_url(&api_url));
+    let token_url = clean_url(&oauth.token_url).unwrap_or_else(|| derive_token_url(&api_url));
     let domains_api_url = env
         .extra
         .get("domains_api_url")
@@ -405,6 +402,30 @@ mod tests {
         let resolved = adapt("dev", env).expect("adapts");
         assert_eq!(resolved.auth_url, "https://auth.example.test/authorize");
         assert_eq!(resolved.token_url, "https://auth.example.test/token");
+    }
+
+    #[test]
+    fn adapt_falls_back_to_derived_oauth_urls_when_override_is_blank_or_malformed() {
+        // A blank-but-non-empty or schemeless override (e.g. from
+        // `<ENV>_OAUTH_AUTH_URL=" "`) must not be used as-is — it should be
+        // treated the same as unset, matching the validation already applied
+        // to api_url/domains_api_url/account_url.
+        let env = test_environment(
+            EnvironmentDef::new()
+                .with_client_id("cid")
+                .with_auth_url("   ")
+                .with_token_url("not-a-url")
+                .with_field("api_url", "https://api.example.test"),
+        );
+        let resolved = adapt("dev", env).expect("adapts");
+        assert_eq!(
+            resolved.auth_url,
+            "https://api.example.test/v2/oauth2/authorize"
+        );
+        assert_eq!(
+            resolved.token_url,
+            "https://api.example.test/v2/oauth2/token"
+        );
     }
 
     #[test]

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -201,7 +201,13 @@ fn requested_env_from(mut args: impl Iterator<Item = String>) -> Option<String> 
         let value = if let Some(v) = arg.strip_prefix("--env=") {
             Some(v.to_owned())
         } else if arg == "--env" {
-            args.next()
+            // A space-separated value that itself looks like another flag
+            // (starts with `-`) is not a value at all — clap rejects this
+            // outright ("a value is required for '--env <ENV>' but none was
+            // supplied"), so this scan must not treat it as one either. An
+            // explicit `--env=-foo` is unambiguous and still accepted, same
+            // as clap's own disambiguation rule.
+            args.next().filter(|v| !v.starts_with('-'))
         } else {
             None
         };
@@ -710,6 +716,24 @@ mod tests {
         assert_eq!(
             requested_env_from(argv(&["--env", "dev", "--env="])),
             Some("dev".to_owned())
+        );
+    }
+
+    #[test]
+    fn requested_env_from_space_separated_value_starting_with_dash_is_not_a_value() {
+        // clap rejects `--env --dry-run` outright ("a value is required for
+        // '--env <ENV>' but none was supplied") rather than treating
+        // `--dry-run` as the value; this scan must agree.
+        assert_eq!(requested_env_from(argv(&["--env", "--dry-run"])), None);
+    }
+
+    #[test]
+    fn requested_env_from_equals_form_accepts_a_value_starting_with_dash() {
+        // `--env=-foo` is unambiguous (unlike the space-separated form) and
+        // still accepted, matching clap's own disambiguation rule.
+        assert_eq!(
+            requested_env_from(argv(&["--env=-foo"])),
+            Some("-foo".to_owned())
         );
     }
 }

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -227,7 +227,7 @@ fn build_environments() -> Environments {
     // would deadlock re-entering `instance()`'s `OnceLock`
     // mid-initialization.
     let default_raw = crate::env::read_gdenv_raw().unwrap_or_else(|| DEFAULT_ENV.to_owned());
-    resolve_default_environments(&default_raw)
+    resolve_default_environments(&default_raw, requested_env_from_argv())
 }
 
 /// Builds the full `Environments` instance for candidate default
@@ -239,23 +239,43 @@ fn build_environments() -> Environments {
 /// of falling back, unlike `env::get_env`'s own `is_known` guard. Validated
 /// against `probe` directly (a plain method call on this local instance),
 /// not `instance()`/`resolve()`, so this can't re-enter the singleton's own
-/// initialization. Split out from [`build_environments`] for testability
-/// without touching the real `.gdenv` file or the process-wide singleton.
-fn resolve_default_environments(default_raw: &str) -> Environments {
-    let probe = register(Environments::new(default_raw.to_owned()), default_raw);
+/// initialization. `requested_from_argv` is injected (rather than this
+/// function calling [`requested_env_from_argv`] itself) so it stays
+/// deterministic for unit tests, regardless of what argv the test binary
+/// itself happens to have been invoked with — [`build_environments`] is the
+/// only real caller, and passes the real scan result.
+fn resolve_default_environments(
+    default_raw: &str,
+    requested_from_argv: Option<String>,
+) -> Environments {
+    let probe = register(
+        Environments::new(default_raw.to_owned()),
+        default_raw,
+        requested_from_argv.clone(),
+    );
     if probe.resolve(default_raw).is_ok() {
         probe
     } else {
-        register(Environments::new(DEFAULT_ENV), default_raw)
+        register(
+            Environments::new(DEFAULT_ENV),
+            default_raw,
+            requested_from_argv,
+        )
     }
 }
 
 /// Registers the compiled `ote`/`prod` defaults plus any env-var-only
 /// placeholder (see the module doc) onto `envs`. `default_candidate` is the
-/// `.gdenv` value under consideration as the active default — pre-registered
-/// like any other candidate so [`build_environments`] can validate it even
-/// when it's only defined via `<PREFIX>_API_URL`.
-fn register(envs: Environments, default_candidate: &str) -> Environments {
+/// `.gdenv` value under consideration as the active default, and
+/// `requested_from_argv` the (already-scanned) `--env` value from the
+/// command line, if any — both pre-registered like any other candidate so
+/// [`resolve_default_environments`] can validate them even when only
+/// defined via `<PREFIX>_API_URL`.
+fn register(
+    envs: Environments,
+    default_candidate: &str,
+    requested_from_argv: Option<String>,
+) -> Environments {
     let mut envs = envs.with_app_id(APP_ID).with_config_file(true);
     for b in BUILTINS {
         envs = envs.with_environment(
@@ -278,7 +298,7 @@ fn register(envs: Environments, default_candidate: &str) -> Environments {
     // never clobbered.
     for candidate in [default_candidate.to_owned()]
         .into_iter()
-        .chain(requested_env_from_argv())
+        .chain(requested_from_argv)
     {
         if envs.list().contains(&candidate) {
             continue;
@@ -643,15 +663,27 @@ mod tests {
         // A corrupted/stale `.gdenv` value that resolves to nothing (no
         // compiled/file entry, no matching `<PREFIX>_API_URL`) must not
         // become the CLI's real startup default.
-        let envs = resolve_default_environments("totally-bogus-env-name");
+        let envs = resolve_default_environments("totally-bogus-env-name", None);
         assert_eq!(envs.default_env(), DEFAULT_ENV);
         assert!(envs.resolve(DEFAULT_ENV).is_ok());
     }
 
     #[test]
     fn resolve_default_environments_keeps_a_resolvable_gdenv_value() {
-        let envs = resolve_default_environments("prod");
+        let envs = resolve_default_environments("prod", None);
         assert_eq!(envs.default_env(), "prod");
+    }
+
+    #[test]
+    fn resolve_default_environments_registers_an_injected_argv_env_var_only_candidate() {
+        // `requested_from_argv` is an injected value here, not a real argv
+        // scan — this stays deterministic regardless of what the test
+        // binary itself happens to have been invoked with.
+        let envs = resolve_default_environments("prod", Some("from-argv".to_owned()));
+        assert!(
+            !envs.list().contains(&"from-argv".to_owned()),
+            "no FROM_ARGV_API_URL env var is set, so no placeholder should be registered"
+        );
     }
 
     fn argv(args: &[&str]) -> impl Iterator<Item = String> {

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -262,7 +262,16 @@ fn register(envs: Environments, default_candidate: &str) -> Environments {
             continue;
         }
         let prefix = env_prefix(&candidate);
-        if std::env::var(format!("{prefix}_API_URL")).is_ok() {
+        // `clean_url`, not a bare `.is_ok()` — a set-but-blank
+        // `<PREFIX>_API_URL` (e.g. `""`) would otherwise make cli-engine's
+        // own `--env <name>` validation accept the name, only for `adapt` to
+        // reject it moments later with a confusing "no usable api_url"
+        // error instead of a clean "unknown environment" one.
+        let has_usable_api_url = std::env::var(format!("{prefix}_API_URL"))
+            .ok()
+            .and_then(|v| clean_url(&v))
+            .is_some();
+        if has_usable_api_url {
             envs =
                 envs.with_environment(candidate, EnvironmentDef::new().with_field("api_url", ""));
         }

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -184,16 +184,32 @@ fn requested_env_from_argv() -> Option<String> {
 
 /// Pure scan over an arg iterator — unit-testable without touching the real
 /// process argv. See [`requested_env_from_argv`] for why this exists.
+///
+/// Scans the *entire* argv and keeps the *last* non-empty `--env`/`--env=`
+/// value, rather than stopping at the first match. A global `--env` and a
+/// command-local one sharing the same arg id (e.g. `gddy --env bar pat add
+/// --env foo ...`) can both appear in one invocation; whichever clap
+/// resolves as the effective value (empirically, the last one) is the one
+/// this scan must agree with, or a real env-var-only environment can be
+/// rejected as unknown even though it's the value actually in effect. An
+/// empty value (`--env=` with nothing after the `=`, or `--env` immediately
+/// followed by another flag with nothing captured) is ignored rather than
+/// becoming a literal empty-string candidate.
 fn requested_env_from(mut args: impl Iterator<Item = String>) -> Option<String> {
+    let mut result = None;
     while let Some(arg) = args.next() {
-        if let Some(value) = arg.strip_prefix("--env=") {
-            return Some(value.to_owned());
-        }
-        if arg == "--env" {
-            return args.next();
+        let value = if let Some(v) = arg.strip_prefix("--env=") {
+            Some(v.to_owned())
+        } else if arg == "--env" {
+            args.next()
+        } else {
+            None
+        };
+        if let Some(v) = value.filter(|v| !v.is_empty()) {
+            result = Some(v);
         }
     }
-    None
+    result
 }
 
 /// Builds the compiled-in `ote`/`prod` `Environments`, shared by
@@ -663,5 +679,37 @@ mod tests {
     #[test]
     fn requested_env_from_trailing_env_flag_with_no_value_is_none() {
         assert_eq!(requested_env_from(argv(&["--env"])), None);
+    }
+
+    #[test]
+    fn requested_env_from_keeps_the_last_of_multiple_occurrences() {
+        // A global `--env` and a command-local one sharing the same arg id
+        // can both appear (e.g. `gddy --env bar pat add --env foo ...`);
+        // clap resolves the *last* one as effective, so this scan must too.
+        assert_eq!(
+            requested_env_from(argv(&[
+                "--env",
+                "bar",
+                "pat",
+                "add",
+                "--env",
+                "foo",
+                "test-token"
+            ])),
+            Some("foo".to_owned())
+        );
+    }
+
+    #[test]
+    fn requested_env_from_ignores_an_empty_equals_value() {
+        assert_eq!(requested_env_from(argv(&["--env="])), None);
+    }
+
+    #[test]
+    fn requested_env_from_empty_occurrence_does_not_clobber_an_earlier_real_value() {
+        assert_eq!(
+            requested_env_from(argv(&["--env", "dev", "--env="])),
+            Some("dev".to_owned())
+        );
     }
 }

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -170,7 +170,16 @@ fn clean_url(raw: &str) -> Option<String> {
 /// (see [`build_environments`]) before cli-engine ever sees it, which means
 /// finding that name before clap has parsed anything.
 fn requested_env_from_argv() -> Option<String> {
-    requested_env_from(std::env::args().skip(1))
+    // `args_os()` + a lossy conversion, not `args()` — this runs during the
+    // environment singleton's own initialization, before clap ever gets a
+    // chance to handle a malformed argument; `args()` panics outright on a
+    // non-UTF-8 arg (possible on Windows/odd shells), which would crash the
+    // whole CLI for a command that doesn't even use `--env`.
+    requested_env_from(
+        std::env::args_os()
+            .skip(1)
+            .map(|arg| arg.to_string_lossy().into_owned()),
+    )
 }
 
 /// Pure scan over an arg iterator — unit-testable without touching the real

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -22,10 +22,8 @@ mod webhook;
 
 use std::{process::ExitCode, sync::Arc};
 
-use clap::Arg;
 use cli_engine::{BuildInfo, Cli, CliConfig, Module};
 
-use crate::env::get_env;
 use crate::next_action::next_action;
 
 /// The full set of `gddy` command modules, shared between `main`'s
@@ -82,32 +80,8 @@ async fn main() -> ExitCode {
             .with_default_auth_provider("godaddy")
             .with_auth_provider(auth_provider)
             .with_auth_extra_commands([scopes_cmd::auth_scopes_command()])
-            .with_register_flags(Arc::new(|cmd| {
-                cmd.arg(
-                    Arg::new("env")
-                        .long("env")
-                        .global(true)
-                        .value_name("ENV")
-                        .default_value(
-                            get_env().unwrap_or_else(|| environments::DEFAULT_ENV.to_owned()),
-                        )
-                        .help("Target environment: prod or ote"),
-                )
-            }))
-            .with_apply_flags(Arc::new(|matches, mw| {
-                if let Some(env) = matches.get_one::<String>("env") {
-                    // Validate only an explicitly-provided `--env`. The default
-                    // value comes from `.gdenv`/DEFAULT_ENV (already filtered), so
-                    // validating it unconditionally would let a malformed local
-                    // config fail *every* command — even ones not using `--env`.
-                    if matches.value_source("env") == Some(clap::parser::ValueSource::CommandLine) {
-                        environments::resolve(env)
-                            .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                    }
-                    mw.env = env.clone();
-                }
-                Ok(())
-            }))
+            .with_min_stage(cli_engine::Stage::Ga)
+            .with_environments(Arc::clone(environments::instance()))
             .with_root_next_actions(Arc::new(|| {
                 vec![
                     next_action("auth status", "Check authentication status"),
@@ -125,4 +99,61 @@ async fn main() -> ExitCode {
     );
 
     cli.execute().await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cli_engine::{Cli, CliConfig, Stage, environments::EnvironmentDef};
+
+    /// Regression test for a real bug found while wiring feature-flagging up
+    /// properly: with no `min_stage` override anywhere, cli-engine's own
+    /// default (`Stage::Ga`) silently hid `hosting`/`webhook`/`application`/
+    /// `actions` entirely (`gddy hosting` reported "unknown command"), even
+    /// though the root `--help` text advertises `hosting`/`application` as
+    /// available. Guards that the *global* default stays `Ga` per product
+    /// decision — i.e. these stay hidden absent an environment override.
+    #[tokio::test]
+    async fn beta_and_experimental_modules_stay_hidden_at_the_default_min_stage() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Ga)
+                .with_modules(super::all_modules()),
+        );
+        let output = cli.run(["gddy", "hosting", "--help"]).await;
+        assert_ne!(
+            output.exit_code, 0,
+            "hosting should stay hidden at the Ga default: {}",
+            output.rendered
+        );
+    }
+
+    /// The other half of the guard: an environment whose resolved
+    /// `min_stage` is lower than the global default reveals those same
+    /// modules. This is exactly the mechanism `environments.toml`'s
+    /// `min_stage`/`feature_overrides` keys (or `<ENV>_MIN_STAGE`/
+    /// `<ENV>_FEATURE_<KEY>` env vars) are meant to drive — see
+    /// `crate::environments`'s module doc.
+    #[tokio::test]
+    async fn an_environment_min_stage_override_reveals_beta_and_experimental_modules() {
+        let environments = Arc::new(
+            cli_engine::environments::Environments::new("dev").with_environment(
+                "dev",
+                EnvironmentDef::new().with_min_stage(Stage::Experimental),
+            ),
+        );
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Ga)
+                .with_environments(environments)
+                .with_modules(super::all_modules()),
+        );
+        let output = cli.run(["gddy", "hosting", "--help"]).await;
+        assert_eq!(
+            output.exit_code, 0,
+            "hosting should be revealed under an Experimental-min_stage environment: {}",
+            output.rendered
+        );
+    }
 }

--- a/rust/src/pat/mod.rs
+++ b/rust/src/pat/mod.rs
@@ -349,7 +349,7 @@ fn add_command() -> RuntimeCommandSpec {
             // Validate the environment up front so a typo does not stash a PAT
             // for a non-existent env. Runs unconditionally, including under
             // `--dry-run`, so `--dry-run` can be used to pre-validate a PAT.
-            environments::resolve(&env).map_err(|e| CliCoreError::message(e.to_string()))?;
+            environments::resolve(&env)?;
 
             let name = string_arg(&ctx.args, "name");
             let token = resolve_token_arg(&ctx.args).await?;
@@ -449,7 +449,7 @@ fn remove_command() -> RuntimeCommandSpec {
             let env = string_arg(&ctx.args, "env");
             // Validate the environment up front so a typo produces a clear error
             // instead of silently reporting "not found".
-            environments::resolve(&env).map_err(|e| CliCoreError::message(e.to_string()))?;
+            environments::resolve(&env)?;
 
             if ctx.dry_run() {
                 let status = if has_pat(&env)? {

--- a/rust/src/payment_methods/mod.rs
+++ b/rust/src/payment_methods/mod.rs
@@ -1,17 +1,13 @@
 //! `gddy payment-methods` — payment method management.
 
 use cli_engine::{
-    CliCoreError, CommandResult, CommandSpec, GroupSpec, Module, NextActionParam,
-    RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+    CommandResult, CommandSpec, GroupSpec, Module, NextActionParam, RuntimeCommandSpec,
+    RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
 use crate::environments;
 use crate::next_action::next_action;
-
-fn map_env_err(e: environments::EnvError) -> CliCoreError {
-    CliCoreError::message(e.to_string())
-}
 
 pub fn module() -> Module {
     Module::new("Payment Methods", |_ctx| {
@@ -42,7 +38,7 @@ fn add_command() -> RuntimeCommandSpec {
         .with_tier(Tier::Mutate)
         .no_auth(true),
         |ctx| async move {
-            let env = environments::resolve(&ctx.middleware.env).map_err(map_env_err)?;
+            let env = environments::resolve(&ctx.middleware.env)?;
             let url = format!("{}/payment-methods/add-payment?plid=1", env.account_url);
             let opened = open::that(&url).is_ok();
             Ok(CommandResult::new(json!({


### PR DESCRIPTION
## Summary
- Replaces gddy's hand-rolled `rust/src/environments/mod.rs` resolution logic with cli-engine 0.4.8's shared `Environments`/`EnvironmentDef` type (bumped from 0.4.7), while keeping the module's own path/API surface stable so downstream call sites needed no import changes.
- Builds each `PkceAuthProvider` per call from gddy's own resolved (and gddy-specific-derived) endpoints, wired via `.with_environments` for the `<ENV>_OAUTH_*` override layer. The provider is always named the fixed `"godaddy"` (not the target env), not gddy's former per-env-named providers — this changes cli-engine's credential storage key from `(app_id, env, env)` to `(app_id, "godaddy", env)`. **Existing stored OAuth tokens are orphaned; users need to `gddy auth login` again after this lands.** PATs are unaffected.
- Fixes a live bug found along the way: `hosting`/`webhook`/`application`/`actions_catalog` were completely hidden in every build (`gddy hosting` → "unknown command") because nothing ever set `min_stage` below cli-engine's `Stage::Ga` default, despite being advertised in the CLI's own root `--help` text. `main.rs` now sets this explicitly, and confirmed end-to-end that an environment's resolved `min_stage`/`feature_overrides` (via a local `environments.toml` entry or `<ENV>_MIN_STAGE`/`<ENV>_FEATURE_<KEY>` env vars) can reveal them per-environment — this was already automatic once `CliConfig::with_environments` was wired, no new engine-side plumbing needed. This only takes effect for the environment active when the process *starts* (persist via `gddy env set <name>`, not a same-invocation `--env`).
- Preserves gddy-specific behavior cli-engine's `Environments` has no notion of: `domains_api_url`/`account_url` defaulting, `auth_url`/`token_url` derivation from `api_url`, URL validation (a blank/malformed override — including on the OAuth URLs — is rejected rather than silently used), and defining a brand-new environment purely via `<PREFIX>_API_URL` with no compiled/file entry (gddy's own pre-existing feature; cli-engine's own env-var layer can't discover a name on its own). The env-var-only-environment mechanism also validates a corrupted/stale `.gdenv` default (falls back to `prod` rather than becoming an unresolvable startup default) and correctly disambiguates the `--env` value from raw argv (last occurrence wins when both a global and command-local `--env` are present, a following flag is never mistaken for a value, and it scans safely even if an argument isn't valid UTF-8).

Related engine-side gaps found during this work were spun out into DEVEX-947 and DEVEX-948 rather than blocking this PR.

Jira: DEVEX-929

## Test plan
- [x] `cargo build`, `cargo test` (353 passing), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean
- [x] Manually verified `env list/get/set/info`, `--env` validation and the env-var-only-environment fallback (including multiple `--env` occurrences and a blank/malformed override), against the real built binary
- [x] Manually verified a local `environments.toml`'s nested `[environments.<name>]` shape still parses with zero edits
- [x] Manually verified `min_stage`/`feature_overrides` in `environments.toml` reveal gated modules end-to-end, using (and restoring) the real local config file
- [x] Manually verified (`RUST_LOG=gddy=debug`) that the real `dev`/`test` environments — which only set `client_id` — resolve to the correctly-derived `auth_url`/`token_url` for the actual OAuth flow, not just for logging
- [x] Regression tests added throughout the review loop for each of the above (argv parsing edge cases, `.gdenv` fallback, OAuth URL validation, stage-gated module visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)