### PR TITLE
feat(platform): namespace Developer Platform commands (DEVX-621)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,24 @@ Use `gddy --help` or `gddy tree` to get a comprehensive list of available comman
 - `domain` — list your domains, check availability, get suggestions, and register new ones
 - `dns` — view and edit a domain's DNS records
 
+### Developer Platform
+
+- `platform app` — create, configure, release, and deploy GoDaddy Platform apps
+- `platform actions` — discover the action contracts an app can declare
+- `platform webhook` — inspect webhook event types for app subscriptions
+
+The Developer Platform command tree is currently an Experimental preview. Enable
+Experimental commands in your environment, then begin with `gddy platform app init`.
+
+### Migrating platform commands
+
+The Rust CLI uses one unambiguous `platform` namespace for Developer Platform
+work. Update scripts and prompts as follows:
+
+| Before | After |
+| --- | --- |
+| `gddy application init` | `gddy platform app init` |
+| `gddy actions list` | `gddy platform actions list` |
+| `gddy webhook events` | `gddy platform webhook events` |
+
 We're actively working to expand the CLI to cover additional GoDaddy products.

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -1,6 +1,6 @@
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, Module, NextActionParam, RuntimeCommandSpec,
-    RuntimeGroupSpec, Stage, Tier,
+    CommandResult, CommandSpec, GroupSpec, NextActionParam, RuntimeCommandSpec, RuntimeGroupSpec,
+    Tier,
 };
 use serde_json::json;
 
@@ -60,24 +60,24 @@ fn load_action_schema(name: &str) -> Option<serde_json::Value> {
     serde_json::from_str(json_str).ok()
 }
 
-pub fn module() -> Module {
-    Module::new("GPA", |_ctx| {
-        RuntimeGroupSpec::new(
-            GroupSpec::new("actions", "Discover available GoDaddy action contracts")
-                .with_long(
-                    "Browse the catalog of GoDaddy actions your application can declare.\n\
+/// The action-catalog command group, composed below `gddy platform`.
+pub fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(
+        GroupSpec::new("actions", "Discover available GoDaddy action contracts")
+            .with_long(
+                "Browse the catalog of GoDaddy actions your application can declare.\n\
                      An action contract defines the name, and the input/output schema, \
                      of a capability your app exposes to the GoDaddy platform.\n\
-                     Use `gddy actions list` to see all available actions, and \
-                     `gddy actions describe` to inspect a specific action's schema.",
-                ),
-        )
+                     Use `gddy platform actions list` to see all available actions, and \
+                     `gddy platform actions describe` to inspect a specific action's schema.",
+            ),
+    )
         .with_command(RuntimeCommandSpec::new(
             CommandSpec::new("list", "List all available action contracts")
                 .with_long(
                     "Prints the name and short description of every action your \
                      application can declare.\n\
-                     Run `gddy actions describe <ACTION>` to see the full \
+                     Run `gddy platform actions describe <ACTION>` to see the full \
                      input/output schema for a specific action.",
                 )
                 .with_system("actions")
@@ -89,7 +89,10 @@ pub fn module() -> Module {
                     .map(|(name, description)| json!({ "name": name, "description": description }))
                     .collect();
                 Ok(CommandResult::new(json!({ "actions": actions })).with_next_actions(vec![
-                    next_action("actions describe <action>", "See an action's full schema")
+                    next_action(
+                        "platform actions describe <action>",
+                        "See an action's full schema",
+                    )
                         .with_param("action", NextActionParam::required()),
                 ]))
             },
@@ -99,7 +102,7 @@ pub fn module() -> Module {
                 .with_long(
                     "Prints the full JSON schema for the named action contract, \
                      including its expected input fields and the shape of its output.\n\
-                     Run `gddy actions list` for the list of valid action names.",
+                     Run `gddy platform actions list` for the list of valid action names.",
                 )
                 .with_system("actions")
                 .with_tier(Tier::Read)
@@ -122,12 +125,10 @@ pub fn module() -> Module {
                     .to_owned();
                 let schema = load_action_schema(&name).ok_or_else(|| {
                     cli_engine::CliCoreError::message(format!(
-                        "action {name:?} not found; run `gddy actions list` to see available actions"
+                        "action {name:?} not found; run `gddy platform actions list` to see available actions"
                     ))
                 })?;
                 Ok(CommandResult::new(schema))
             },
         ))
-    })
-    .with_feature_flag("actions", Stage::Experimental)
 }

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -136,7 +136,7 @@ async fn fail_deploy(
 }
 
 /// Builds the terminal `{"type":"result",...}` event for a successful
-/// `application deploy` run.
+/// `platform app deploy` run.
 fn deploy_result_event(
     name: &str,
     application_id: &str,
@@ -182,12 +182,12 @@ fn add_config_next_actions(app_name: &str) -> Vec<NextAction> {
     };
     vec![
         next_action(
-            "application validate <name>",
+            "platform app validate <name>",
             "Validate remote application configuration",
         )
         .with_param("name", name_param),
         next_action(
-            "application release --application-id <application-id> --version <version>",
+            "platform app release --application-id <application-id> --version <version>",
             "Create a new release",
         )
         .with_param("application-id", NextActionParam::required())
@@ -199,31 +199,32 @@ fn add_config_next_actions(app_name: &str) -> Vec<NextAction> {
 fn deploy_next_actions(name: &str) -> Vec<NextAction> {
     vec![
         next_action(
-            "application enable <name> --store-id <store-id>",
+            "platform app enable <name> --store-id <store-id>",
             "Enable the application on a store",
         )
         .with_param("name", required_value(name))
         .with_param("store-id", NextActionParam::required()),
         next_action(
-            "application info --name <name>",
+            "platform app info --name <name>",
             "Inspect deployment status",
         )
         .with_param("name", required_value(name)),
-        next_action("application deploy --name <name>", "Rerun deployment")
+        next_action("platform app deploy --name <name>", "Rerun deployment")
             .with_param("name", required_value(name)),
     ]
 }
 
 pub fn application_group() -> RuntimeGroupSpec {
     RuntimeGroupSpec::new(
-        GroupSpec::new("application", "Manage GoDaddy applications")
+        GroupSpec::new("app", "Manage GoDaddy Platform apps")
             .with_long(
                 "Manage GoDaddy developer-platform applications. A GoDaddy application is a \
                 developer-platform app described by a godaddy.toml manifest in your working \
-                directory. Use `application init` to create one, `application validate <name>` \
-                to check remote application state, and `application deploy` to publish it.",
+                directory. Use `gddy platform app init` to create one, `gddy platform app \
+                validate <name>` to check remote application state, and `gddy platform app \
+                deploy` to publish it.",
             )
-            .with_alias("app"),
+            .with_alias("application"),
     )
     .with_command(list_command())
     .with_command(info_command())
@@ -243,7 +244,7 @@ fn list_command() -> RuntimeCommandSpec {
         CommandSpec::new("list", "List all applications")
             .with_long(
                 "List all GoDaddy developer-platform applications visible to the current \
-                account. Use `application info --name <name>` to fetch full details for a \
+                account. Use `gddy platform app info --name <name>` to fetch full details for a \
                 single application.",
             )
             .with_system("applications")
@@ -255,12 +256,12 @@ fn list_command() -> RuntimeCommandSpec {
             let data = client.list_applications().await.map_err(client_err)?;
             Ok(CommandResult::new(data).with_next_actions(vec![
                 next_action(
-                    "application info --name <name>",
+                    "platform app info --name <name>",
                     "Get details for a specific application",
                 )
                 .with_param("name", NextActionParam::required()),
                 next_action(
-                    "application init --name <name> --description <description> --url <url> --proxy-url <proxy-url> --scopes <scopes>",
+                    "platform app init --name <name> --description <description> --url <url> --proxy-url <proxy-url> --scopes <scopes>",
                     "Initialize a new application",
                 ),
             ]))
@@ -273,7 +274,8 @@ fn info_command() -> RuntimeCommandSpec {
         CommandSpec::new("info", "Get application details")
             .with_long(
                 "Fetch full details for a single GoDaddy developer-platform application by \
-                name, including status, URLs, and authorization scopes. Use `application list` \
+                name, including status, URLs, and authorization scopes. Use `gddy platform app \
+                list` \
                 to find available names.",
             )
             .with_system("applications")
@@ -300,12 +302,12 @@ fn info_command() -> RuntimeCommandSpec {
             let app_id = app["id"].as_str().unwrap_or("").to_owned();
             Ok(CommandResult::new(app.clone()).with_next_actions(vec![
                 next_action(
-                    "application validate <name>",
+                    "platform app validate <name>",
                     "Validate application configuration",
                 )
                 .with_param("name", required_value(&name)),
                 next_action(
-                    "application update --id <id> [--label <label>] [--description <description>] [--status <status>]",
+                    "platform app update --id <id> [--label <label>] [--description <description>] [--status <status>]",
                     "Update application configuration",
                 )
                 .with_param("id", required_value(&app_id))
@@ -317,13 +319,13 @@ fn info_command() -> RuntimeCommandSpec {
                     },
                 ),
                 next_action(
-                    "application release --application-id <application-id> --version <version>",
+                    "platform app release --application-id <application-id> --version <version>",
                     "Create a release",
                 )
                 .with_param("application-id", required_value(&app_id))
                 .with_param("version", NextActionParam::required()),
                 next_action(
-                    "application deploy --name <name>",
+                    "platform app deploy --name <name>",
                     "Deploy this application",
                 )
                 .with_param("name", required_value(&name)),
@@ -339,8 +341,8 @@ fn init_command() -> RuntimeCommandSpec {
                 "Register a new GoDaddy developer-platform application and write a \
                 godaddy.toml manifest to the current directory. The manifest captures the \
                 application name, URL, authorization scopes, and any actions or extensions \
-                added later. Run `application validate <name>` to confirm the remote \
-                application is healthy, then `application release` to create a versioned \
+                added later. Run `gddy platform app validate <name>` to confirm the remote \
+                application is healthy, then `gddy platform app release` to create a versioned \
                 release.",
             )
             .with_system("applications")
@@ -545,20 +547,20 @@ fn init_command() -> RuntimeCommandSpec {
             });
             Ok(CommandResult::new(result).with_next_actions(vec![
                 next_action(
-                    "application add action --name <name> --url <url>",
+                    "platform app add action --name <name> --url <url>",
                     "Add first action",
                 ),
                 next_action(
-                    "application add subscription --name <name> --events <events> --url <url>",
+                    "platform app add subscription --name <name> --events <events> --url <url>",
                     "Add webhook subscription",
                 ),
                 next_action(
-                    "application validate <name>",
+                    "platform app validate <name>",
                     "Validate the remote application state",
                 )
                 .with_param("name", required_value(&name)),
                 next_action(
-                    "application release --application-id <application-id> --version <version>",
+                    "platform app release --application-id <application-id> --version <version>",
                     "Create the first release",
                 )
                 .with_param("application-id", required_value(&app_id))
@@ -626,7 +628,7 @@ fn validate_command() -> RuntimeCommandSpec {
             if valid {
                 next_actions.push(
                     next_action(
-                        "application release --application-id <application-id> --version <version>",
+                        "platform app release --application-id <application-id> --version <version>",
                         "Create a release after validation",
                     )
                     .with_param("application-id", required_value(&app_id))
@@ -635,7 +637,7 @@ fn validate_command() -> RuntimeCommandSpec {
             }
             next_actions.push(
                 next_action(
-                    "application info --name <name>",
+                    "platform app info --name <name>",
                     "Inspect application details",
                 )
                 .with_param("name", required_value(&name)),
@@ -657,7 +659,7 @@ fn update_command() -> RuntimeCommandSpec {
             .with_long(
                 "Update the label, description, or status of a GoDaddy developer-platform \
                 application by its ID. At least one of --label, --description, or --status \
-                must be provided. Use `application info --name <name>` to retrieve the \
+                must be provided. Use `gddy platform app info --name <name>` to retrieve the \
                 application ID.",
             )
             .with_system("applications")
@@ -718,12 +720,12 @@ fn update_command() -> RuntimeCommandSpec {
             Ok(
                 CommandResult::new(data["updateApplication"].clone()).with_next_actions(vec![
                     next_action(
-                        "application info --name <name>",
+                        "platform app info --name <name>",
                         "Inspect updated application",
                     )
                     .with_param("name", required_value(&name)),
                     next_action(
-                        "application deploy --name <name>",
+                        "platform app deploy --name <name>",
                         "Deploy updated application",
                     )
                     .with_param("name", required_value(&name)),
@@ -738,7 +740,7 @@ fn enable_command() -> RuntimeCommandSpec {
         CommandSpec::new("enable", "Enable an application on a store")
             .with_long(
                 "Make a GoDaddy developer-platform application available on a specific \
-                store. Use `application disable` to reverse this. Both the application name \
+                store. Use `gddy platform app disable` to reverse this. Both the application name \
                 and a store ID are required.",
             )
             .with_system("applications")
@@ -769,13 +771,13 @@ fn enable_command() -> RuntimeCommandSpec {
             Ok(
                 CommandResult::new(data["enableStoreApplication"].clone()).with_next_actions(vec![
                     next_action(
-                        "application disable <name> --store-id <store-id>",
+                        "platform app disable <name> --store-id <store-id>",
                         "Disable the application on the same store",
                     )
                     .with_param("name", required_value(&name))
                     .with_param("store-id", required_value(&store_id)),
                     next_action(
-                        "application info --name <name>",
+                        "platform app info --name <name>",
                         "Inspect application status",
                     )
                     .with_param("name", required_value(&name)),
@@ -790,7 +792,7 @@ fn disable_command() -> RuntimeCommandSpec {
         CommandSpec::new("disable", "Disable an application on a store")
             .with_long(
                 "Remove a GoDaddy developer-platform application from a specific store, \
-                making it unavailable there. Use `application enable` to re-enable it. \
+                making it unavailable there. Use `gddy platform app enable` to re-enable it. \
                 Both the application name and a store ID are required.",
             )
             .with_system("applications")
@@ -822,13 +824,13 @@ fn disable_command() -> RuntimeCommandSpec {
                 CommandResult::new(data["disableStoreApplication"].clone()).with_next_actions(
                     vec![
                         next_action(
-                            "application enable <name> --store-id <store-id>",
+                            "platform app enable <name> --store-id <store-id>",
                             "Re-enable the application on the same store",
                         )
                         .with_param("name", required_value(&name))
                         .with_param("store-id", required_value(&store_id)),
                         next_action(
-                            "application info --name <name>",
+                            "platform app info --name <name>",
                             "Inspect application status",
                         )
                         .with_param("name", required_value(&name)),
@@ -845,7 +847,7 @@ fn archive_command() -> RuntimeCommandSpec {
             .with_long(
                 "Archive a GoDaddy developer-platform application by name. Archiving is \
                 irreversible via this CLI; the application will no longer be active. \
-                Use `application list` to confirm the application name before archiving.",
+                Use `gddy platform app list` to confirm the application name before archiving.",
             )
             .with_system("applications")
             .with_tier(Tier::Destructive)
@@ -874,11 +876,11 @@ fn archive_command() -> RuntimeCommandSpec {
             Ok(
                 CommandResult::new(data["archiveApplication"].clone()).with_next_actions(vec![
                     next_action(
-                        "application info --name <name>",
+                        "platform app info --name <name>",
                         "Inspect archived application",
                     )
                     .with_param("name", required_value(&name)),
-                    next_action("application list", "List all applications"),
+                    next_action("platform app list", "List all platform apps"),
                 ]),
             )
         },
@@ -940,7 +942,7 @@ fn release_command() -> RuntimeCommandSpec {
             .with_long(
                 "Tag a new versioned release for a GoDaddy developer-platform application. \
                 The version must follow semver (e.g. 1.2.3). A release is required before \
-                running `application deploy`. Use `application info --name <name>` to \
+                running `gddy platform app deploy`. Use `gddy platform app info --name <name>` to \
                 retrieve the application ID.",
             )
             .with_system("applications")
@@ -982,7 +984,7 @@ fn release_command() -> RuntimeCommandSpec {
 
             // Include actions, webhook subscriptions, and UI extensions from
             // godaddy.toml so configured behavior is captured in the release.
-            // Without this, everything added via `application add` was silently
+            // Without this, everything added via `platform app add` was silently
             // dropped. A missing config is non-fatal (empty arrays); a config
             // with too many targets per extension is a hard error.
             let (actions, subscriptions, ui_extensions) = match crate::config::read_config(
@@ -1023,12 +1025,12 @@ fn release_command() -> RuntimeCommandSpec {
             Ok(
                 CommandResult::new(data["createRelease"].clone()).with_next_actions(vec![
                     next_action(
-                        "application deploy --name <name>",
+                        "platform app deploy --name <name>",
                         "Deploy the released application",
                     )
                     .with_param("name", name_param.clone()),
                     next_action(
-                        "application info --name <name>",
+                        "platform app info --name <name>",
                         "Inspect application and latest release",
                     )
                     .with_param("name", name_param),
@@ -1046,7 +1048,7 @@ fn deploy_command() -> RuntimeCommandSpec {
                 with esbuild, run the security scanner (rules SEC101–SEC115) on each bundle, \
                 then upload the artifacts to the latest release of the named application. \
                 Progress is streamed as JSON events. A release must exist before deploying; \
-                create one with `application release`.",
+                create one with `gddy platform app release`.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -1125,7 +1127,7 @@ fn deploy_command() -> RuntimeCommandSpec {
                 .map(str::to_owned);
             let Some(release_id) = release_id else {
                 let err = cli_engine::CliCoreError::message(format!(
-                    "application '{name}' has no releases — create one first with: gddy application release --application-id {application_id} --version 0.0.1"
+                    "application '{name}' has no releases — create one first with: gddy platform app release --application-id {application_id} --version 0.0.1"
                 ));
                 return Err(fail_deploy(&sender, err).await);
             };
@@ -1464,7 +1466,7 @@ pub fn add_group() -> RuntimeGroupSpec {
             "Append actions, webhook subscriptions, or UI extensions to the \
                 godaddy.toml manifest in the current directory. These commands do not \
                 require authentication and do not contact the API; run \
-                `application deploy` to publish the updated manifest.",
+                `gddy platform app deploy` to publish the updated manifest.",
         ),
     )
     .with_command(RuntimeCommandSpec::new_with_context(
@@ -1474,7 +1476,7 @@ pub fn add_group() -> RuntimeGroupSpec {
                     directory. An action is an HTTP endpoint that the platform calls on \
                     behalf of the application; it is identified by a name and a public \
                     HTTPS URL. The manifest is updated in place; run \
-                    `application validate <name>` to confirm remote application state.",
+                    `gddy platform app validate <name>` to confirm remote application state.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -1514,7 +1516,7 @@ pub fn add_group() -> RuntimeGroupSpec {
                 "Append a webhook subscription entry to the godaddy.toml manifest in \
                     the current directory. A subscription routes platform events to an HTTPS \
                     endpoint. Provide one or more event types with --events; run \
-                    `gddy webhook events` to discover the full list of valid event types.",
+                    `gddy platform webhook events` to discover the full list of valid event types.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -1540,7 +1542,7 @@ pub fn add_group() -> RuntimeGroupSpec {
                     .required(true)
                     .help(
                         "One or more event types to subscribe to \
-                            (run `gddy webhook events` to list valid values)",
+                            (run `gddy platform webhook events` to list valid values)",
                     ),
             ),
         |ctx| async move {
@@ -1585,7 +1587,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 directory. Extensions are JavaScript bundles that the platform renders \
                 inside store surfaces. Three types are supported: embed (inline widget), \
                 checkout (checkout-flow widget), and blocks (content blocks). Run \
-                `application deploy` to bundle and upload the registered extensions.",
+                `gddy platform app deploy` to bundle and upload the registered extensions.",
         ),
     )
     .with_command(RuntimeCommandSpec::new_with_context(
@@ -1594,7 +1596,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 "Register an embed UI extension in godaddy.toml. An embed extension is a \
                 JavaScript bundle rendered as an inline widget inside a store surface. \
                 Provide a unique name, a platform handle, and the path to the source \
-                entry-point file. Run `application deploy` to bundle and upload.",
+                entry-point file. Run `gddy platform app deploy` to bundle and upload.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -1664,7 +1666,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 "Register a checkout UI extension in godaddy.toml. A checkout extension is \
                 a JavaScript bundle rendered during the store checkout flow. Provide a \
                 unique name, a platform handle, and the path to the source entry-point \
-                file. Run `application deploy` to bundle and upload.",
+                file. Run `gddy platform app deploy` to bundle and upload.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -1734,7 +1736,7 @@ pub fn add_extension_group() -> RuntimeGroupSpec {
                 "Register a blocks UI extension in godaddy.toml. A blocks extension is a \
                 JavaScript bundle that provides content blocks within a store. Only one \
                 blocks extension is supported per application; running this command again \
-                will overwrite the existing entry. Run `application deploy` to bundle and \
+                will overwrite the existing entry. Run `gddy platform app deploy` to bundle and \
                 upload.",
             )
             .with_system("applications")
@@ -1930,23 +1932,23 @@ mod tests {
             .expect("multiple update fields should be allowed together");
     }
 
-    /// API commands must stay fail-closed: `application list` calls the backend,
+    /// API commands must stay fail-closed: `platform app list` calls the backend,
     /// so it must require authentication. Built with **no auth provider
     /// registered**, the engine's default `AuthRequirement::Required` must reject
     /// it before the handler runs (no network call). This guards against someone
     /// mistakenly marking an API command `no_auth(true)`, which would let it run
     /// unauthenticated.
     #[tokio::test]
-    async fn application_list_requires_auth() {
+    async fn platform_app_list_requires_auth() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
                 .with_min_stage(Stage::Experimental)
                 .with_default_auth_provider("godaddy")
-                .with_module(super::super::module()),
+                .with_module(crate::platform::module()),
         );
 
         let output = cli
-            .run(["gddy", "application", "list", "--output", "json"])
+            .run(["gddy", "platform", "app", "list", "--output", "json"])
             .await;
 
         // The engine maps auth-resolution failures to exit code 2; together with
@@ -1955,7 +1957,7 @@ mod tests {
         const AUTH_FAILURE_EXIT: i32 = 2;
         assert_eq!(
             output.exit_code, AUTH_FAILURE_EXIT,
-            "application list must fail closed at auth resolution, got: {}",
+            "platform app list must fail closed at auth resolution, got: {}",
             output.rendered
         );
         let json: serde_json::Value =
@@ -2147,7 +2149,7 @@ mod tests {
             event["next_actions"][0]["command"]
                 .as_str()
                 .unwrap_or("")
-                .contains("application enable"),
+                .contains("platform app enable"),
             "first next action should enable on a store: {event}"
         );
     }

--- a/rust/src/application/mod.rs
+++ b/rust/src/application/mod.rs
@@ -2,9 +2,9 @@ pub mod client;
 mod commands;
 pub mod public_url;
 
-use cli_engine::{Module, Stage};
+use cli_engine::RuntimeGroupSpec;
 
-pub fn module() -> Module {
-    Module::new("GPA", |_ctx| commands::application_group())
-        .with_feature_flag("application", Stage::Experimental)
+/// The app command group, composed below `gddy platform`.
+pub fn group() -> RuntimeGroupSpec {
+    commands::application_group()
 }

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! gddy's global default (set on `CliConfig` in `main.rs`) keeps
 //! `min_stage` at `Stage::Ga`, hiding any module/command flagged below GA
-//! (e.g. `hosting` = Beta; `webhook`/`application`/`actions` = Experimental).
+//! (e.g. `hosting` = Beta; `platform` = Experimental).
 //! An `environments.toml` entry can permanently opt a specific environment
 //! into those pre-release commands via the *same* recognized keys cli-engine
 //! parses on every `EnvironmentDef` — no gddy-specific plumbing needed:

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -14,6 +14,7 @@ mod next_action;
 mod output_schema;
 mod pat;
 mod payment_methods;
+mod platform;
 mod quote_cache;
 mod scopes;
 mod scopes_cmd;
@@ -32,17 +33,15 @@ use crate::next_action::next_action;
 /// [`cli_engine::build_module_group`]), so both draw from exactly one list.
 pub(crate) fn all_modules() -> Vec<Module> {
     vec![
-        actions_catalog::module(),
         api_explorer::module(),
-        application::module(),
         dns::module(),
         domain::module(),
         env::module(),
         hosting::module(),
         pat::module(),
         payment_methods::module(),
+        platform::module(),
         update::module(),
-        webhook::module(),
     ]
 }
 
@@ -64,7 +63,7 @@ async fn main() -> ExitCode {
                  • domain   — list your domains, check availability, get suggestions, and register new ones\n  \
                  • dns      — view and edit a domain's DNS records\n  \
                  • api      — explore and call GoDaddy REST API endpoints directly\n  \
-                 • application — build, configure, and deploy platform applications\n  \
+                 • platform — build and manage GoDaddy Platform integrations\n  \
                  • hosting  — manage Node.js PaaS applications (create, upload, deploy)\n  \
                  • payment-methods — manage the payment methods used for purchases\n\
                  \n\
@@ -86,7 +85,7 @@ async fn main() -> ExitCode {
                 vec![
                     next_action("auth status", "Check authentication status"),
                     next_action("env get", "Get the current active environment"),
-                    next_action("application list", "List all applications"),
+                    next_action("platform app list", "List all platform apps"),
                     next_action("tree", "Display the full command tree"),
                 ]
             }))
@@ -109,11 +108,9 @@ mod tests {
 
     /// Regression test for a real bug found while wiring feature-flagging up
     /// properly: with no `min_stage` override anywhere, cli-engine's own
-    /// default (`Stage::Ga`) silently hid `hosting`/`webhook`/`application`/
-    /// `actions` entirely (`gddy hosting` reported "unknown command"), even
-    /// though the root `--help` text advertises `hosting`/`application` as
-    /// available. Guards that the *global* default stays `Ga` per product
-    /// decision — i.e. these stay hidden absent an environment override.
+    /// default (`Stage::Ga`) hides `hosting` and the Developer Platform
+    /// namespace entirely. Guards that the *global* default stays `Ga` per
+    /// product decision — i.e. these stay hidden absent an environment override.
     #[tokio::test]
     async fn beta_and_experimental_modules_stay_hidden_at_the_default_min_stage() {
         let cli = Cli::new(
@@ -125,6 +122,21 @@ mod tests {
         assert_ne!(
             output.exit_code, 0,
             "hosting should stay hidden at the Ga default: {}",
+            output.rendered
+        );
+    }
+
+    #[tokio::test]
+    async fn platform_namespace_is_hidden_at_the_default_min_stage() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Ga)
+                .with_modules(super::all_modules()),
+        );
+        let output = cli.run(["gddy", "platform", "--help"]).await;
+        assert_ne!(
+            output.exit_code, 0,
+            "platform should stay hidden at the Ga default: {}",
             output.rendered
         );
     }
@@ -155,5 +167,62 @@ mod tests {
             "hosting should be revealed under an Experimental-min_stage environment: {}",
             output.rendered
         );
+    }
+
+    #[tokio::test]
+    async fn platform_namespace_exposes_the_gpa_command_tree() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Experimental)
+                .with_modules(super::all_modules()),
+        );
+
+        let tree = cli.run(["gddy", "tree", "--output", "json"]).await;
+        assert_eq!(tree.exit_code, 0, "{}", tree.rendered);
+        for path in [
+            "platform",
+            "platform app",
+            "platform actions",
+            "platform webhook",
+        ] {
+            assert!(
+                tree.rendered.contains(path),
+                "tree should publish {path:?}: {}",
+                tree.rendered
+            );
+        }
+
+        for (command, child) in [
+            (["gddy", "platform", "app", "--help"].as_slice(), "init"),
+            (
+                ["gddy", "platform", "actions", "--help"].as_slice(),
+                "describe",
+            ),
+            (
+                ["gddy", "platform", "webhook", "--help"].as_slice(),
+                "events",
+            ),
+            (
+                ["gddy", "platform", "application", "--help"].as_slice(),
+                "init",
+            ),
+        ] {
+            let output = cli.run(command).await;
+            assert_eq!(output.exit_code, 0, "{}", output.rendered);
+            assert!(
+                output.rendered.contains(child),
+                "help should list {child:?}: {}",
+                output.rendered
+            );
+        }
+
+        for legacy_root in ["application", "actions", "webhook"] {
+            let output = cli.run(["gddy", legacy_root, "--help"]).await;
+            assert_ne!(
+                output.exit_code, 0,
+                "legacy root {legacy_root:?} should not be registered: {}",
+                output.rendered
+            );
+        }
     }
 }

--- a/rust/src/platform/mod.rs
+++ b/rust/src/platform/mod.rs
@@ -1,0 +1,24 @@
+//! GoDaddy Developer Platform command namespace.
+//!
+//! This is intentionally a composition-only module: the application, action
+//! catalog, and webhook implementations retain their existing handlers and
+//! clients, while `platform` provides their unambiguous common CLI path.
+
+use cli_engine::{GroupSpec, Module, RuntimeGroupSpec, Stage};
+
+pub fn module() -> Module {
+    Module::new("Platform", |_ctx| {
+        RuntimeGroupSpec::new(
+            GroupSpec::new("platform", "Build and manage GoDaddy Platform integrations")
+                .with_long(
+                    "Build integrations for the GoDaddy Developer Platform. Manage your app, \
+                     browse action contracts, and inspect webhook event types from one \
+                     namespace. Use `gddy platform app init` to create an app.",
+                )
+                .with_feature_flag("platform", Stage::Experimental),
+        )
+        .with_group(crate::application::group())
+        .with_group(crate::actions_catalog::group())
+        .with_group(crate::webhook::group())
+    })
+}

--- a/rust/src/scopes.rs
+++ b/rust/src/scopes.rs
@@ -37,7 +37,7 @@
 //! This registry covers the scopes the CLI requests for *itself* (login defaults
 //! plus per-command step-up). It intentionally does NOT cover scopes that are
 //! user data rather than the CLI's own grants — e.g. the `authorizationScopes`
-//! assigned to a third-party app created via `gddy application create`, or the
+//! assigned to a third-party app created via `gddy platform app init`, or the
 //! ad-hoc scopes `gddy api call --scope …` derives from the API catalog at
 //! runtime.
 
@@ -84,7 +84,7 @@ declare_scopes! {
     APP_REGISTRY_READ => "apps.app-registry:read",
     /// Create/update/archive the caller's registered applications. NOT requested
     /// at login by default (it's a rare operation for most customers); the
-    /// app-registry mutation commands (`application init/update/enable/disable/
+    /// app-registry mutation commands (`platform app init/update/enable/disable/
     /// archive/release/deploy`) declare it via `with_scopes` so cli-engine
     /// requests it on demand (OAuth step-up).
     APP_REGISTRY_WRITE => "apps.app-registry:write",

--- a/rust/src/webhook/mod.rs
+++ b/rust/src/webhook/mod.rs
@@ -1,66 +1,63 @@
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, Module, RuntimeCommandSpec, RuntimeGroupSpec, Stage,
-    Tier,
+    CommandResult, CommandSpec, GroupSpec, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
 };
 
 use crate::application::client::api_url_for_env;
 
-pub fn module() -> Module {
-    Module::new("GPA", |_ctx| {
-        RuntimeGroupSpec::new(
-            GroupSpec::new("webhook", "Manage webhook event types").with_long(
-                "Inspect the webhook event types your application can subscribe to.\n\
-                     Use `gddy application add subscription` to attach a webhook \
+/// The webhook command group, composed below `gddy platform`.
+pub fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(
+        GroupSpec::new("webhook", "Manage webhook event types").with_long(
+            "Inspect the webhook event types your application can subscribe to.\n\
+                     Use `gddy platform app add subscription` to attach a webhook \
                      subscription to an application.",
-            ),
-        )
-        .with_command(RuntimeCommandSpec::new_with_context(
-            CommandSpec::new("events", "List available webhook event types")
-                .with_long(
-                    "Returns the full list of event types that can be used when \
+        ),
+    )
+    .with_command(RuntimeCommandSpec::new_with_context(
+        CommandSpec::new("events", "List available webhook event types")
+            .with_long(
+                "Returns the full list of event types that can be used when \
                          creating a webhook subscription.\n\
                          Pass an event type from this list to \
-                         `gddy application add subscription`.",
-                )
-                .with_system("webhooks")
-                .with_tier(Tier::Read),
-            |ctx| async move {
-                let token = ctx.credential().await?.token;
-                let base_url = api_url_for_env(&ctx.middleware.env);
-                let url = format!("{base_url}/v1/apis/webhook-event-types");
-                let client = crate::application::client::make_http_client();
-                let request = client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .header("x-request-id", uuid::Uuid::new_v4().to_string())
-                    .build()
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                cli_engine::transport::debug_log_reqwest_request(&request);
-                let resp = client
-                    .execute(request)
-                    .await
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                         `gddy platform app add subscription`.",
+            )
+            .with_system("webhooks")
+            .with_tier(Tier::Read),
+        |ctx| async move {
+            let token = ctx.credential().await?.token;
+            let base_url = api_url_for_env(&ctx.middleware.env);
+            let url = format!("{base_url}/v1/apis/webhook-event-types");
+            let client = crate::application::client::make_http_client();
+            let request = client
+                .get(&url)
+                .bearer_auth(&token)
+                .header("x-request-id", uuid::Uuid::new_v4().to_string())
+                .build()
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            cli_engine::transport::debug_log_reqwest_request(&request);
+            let resp = client
+                .execute(request)
+                .await
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
 
-                let status = resp.status();
-                let headers = resp.headers().clone();
-                let bytes = resp
-                    .bytes()
-                    .await
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                cli_engine::transport::debug_log_reqwest_response(status, &headers, &bytes);
+            let status = resp.status();
+            let headers = resp.headers().clone();
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            cli_engine::transport::debug_log_reqwest_response(status, &headers, &bytes);
 
-                if !status.is_success() {
-                    let body = String::from_utf8_lossy(&bytes).into_owned();
-                    return Err(cli_engine::CliCoreError::message(format!(
-                        "webhook events request failed ({}): {body}",
-                        status.as_u16()
-                    )));
-                }
-                let data: serde_json::Value = serde_json::from_slice(&bytes)
-                    .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
-                Ok(CommandResult::new(data))
-            },
-        ))
-    })
-    .with_feature_flag("webhook", Stage::Experimental)
+            if !status.is_success() {
+                let body = String::from_utf8_lossy(&bytes).into_owned();
+                return Err(cli_engine::CliCoreError::message(format!(
+                    "webhook events request failed ({}): {body}",
+                    status.as_u16()
+                )));
+            }
+            let data: serde_json::Value = serde_json::from_slice(&bytes)
+                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+            Ok(CommandResult::new(data))
+        },
+    ))
 }


### PR DESCRIPTION
## Summary
- replace the root-level application, actions, and webhook command families with one Experimental `gddy platform` namespace
- make `gddy platform app` canonical, retaining `gddy platform application` as a nested alias only
- update help, next actions, scope references, feature-flag documentation, and README migration guidance
- add command-tree, help, alias, legacy-root rejection, and fail-closed-auth regression coverage

## Migration
- `gddy application …` → `gddy platform app …`
- `gddy actions …` → `gddy platform actions …`
- `gddy webhook …` → `gddy platform webhook …`

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test` (362 passed)
- manual Experimental-mode tree/help checks using `PROD_MIN_STAGE=experimental`

Refs: DEVX-621