### PR TITLE
fix(ci): repoint workflow triggers from rust-port to main

### DIFF
--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -10,18 +10,13 @@ name: API catalog drift
 # Requires a token with read access to the gdcorp-platform spec repos, provisioned
 # as the `CATALOG_SPEC_TOKEN` secret. The default GITHUB_TOKEN only reaches this
 # repo. A missing token is a configuration error and fails the job.
-#
-# Scheduled workflows only run from a repository's default branch. While
-# `rust-port` is not the default, run this check on every push to `rust-port`;
-# the weekly schedule activates when `rust-port` becomes the default branch.
-# `workflow_dispatch` also allows an on-demand check of any branch.
 
 on:
   schedule:
-    - cron: "17 6 * * 1" # Mondays ~06:17 UTC after rust-port becomes default
+    - cron: "17 6 * * 1" # Mondays ~06:17 UTC
   push:
     branches:
-      - rust-port
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,10 +2,10 @@ name: CICD
 on:
   push:
     branches:
-      - rust-port
+      - main
   pull_request:
     branches:
-      - rust-port
+      - main
 
 jobs:
   cicd:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,12 @@ name: Release
 # Cuts real semver GitHub Releases for the `gddy` binary via release-please,
 # then builds and attaches multi-platform archives to the release it creates.
 #
-# Targets `rust-port` directly (not `main`) — see release-please-config.json
-# and .release-please-manifest.json for context on why. When `rust-port`
-# eventually merges into `main`, repoint the `push` trigger and the action's
-# `target-branch` input below; nothing else needs to change.
+# Targets `main` — see release-please-config.json and
+# .release-please-manifest.json for the release-please state this depends on.
 
 on:
   push:
-    branches: [rust-port]
+    branches: [main]
   workflow_dispatch:
     inputs:
       publish_only:
@@ -40,7 +38,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          target-branch: rust-port
+          target-branch: main
 
   build:
     name: Build ${{ matrix.target }}

--- a/.github/workflows/rust-port-alpha.yaml
+++ b/.github/workflows/rust-port-alpha.yaml
@@ -1,7 +1,7 @@
-name: rust-port alpha
+name: main alpha
 
-# Publishes a `gddy` alpha binary on every push to the rust-port feature branch
-# so people can try the Rust port alongside the legacy `godaddy` CLI. The Rust
+# Publishes a `gddy` alpha binary on every push to `main`, so people can try
+# the latest build ahead of the next tagged release-please release. The
 # binary is named `gddy` (see rust/Cargo.toml). Output is a single rolling
 # prerelease on the fixed `alpha` tag, overwritten on each push.
 #
@@ -10,7 +10,7 @@ name: rust-port alpha
 
 on:
   push:
-    branches: [rust-port]
+    branches: [main]
   workflow_dispatch:
 
 # Least privilege by default; only the publish job needs `contents: write` to
@@ -24,7 +24,7 @@ permissions:
 # recreates the release/tag, so a cancellation mid-window could leave `alpha`
 # missing. Queuing instead lets each publish finish atomically; the last one wins.
 concurrency:
-  group: rust-port-alpha
+  group: main-alpha
   cancel-in-progress: false
 
 jobs:
@@ -174,8 +174,8 @@ jobs:
           gh release delete alpha --yes --cleanup-tag || true
 
           {
-            printf '**Experimental alpha of the GoDaddy CLI Rust port.** Built from `%s` on %s.\n\n' "$SHORT_SHA" "$BUILT_ON"
-            printf 'Installs as `gddy` so you can try it alongside the legacy `godaddy` CLI. It tracks the tip of the `rust-port` branch and is overwritten on every push — expect breakage.\n\n'
+            printf '**Experimental alpha build of the GoDaddy CLI (`gddy`).** Built from `%s` on %s.\n\n' "$SHORT_SHA" "$BUILT_ON"
+            printf 'Tracks the tip of `main` and is overwritten on every push — expect breakage. For a stable release, use the [latest tagged release](https://github.com/%s/releases/latest) instead.\n\n' "$REPO"
             printf 'Install / update (public repo — no auth needed):\n\n'
             printf 'macOS / Linux (and Git Bash / MSYS2 / Cygwin on Windows):\n\n'
             printf '```\n'
@@ -190,7 +190,7 @@ jobs:
           gh release create alpha \
             --prerelease \
             --target "$GITHUB_SHA" \
-            --title "rust-port alpha (${SHORT_SHA})" \
+            --title "main alpha (${SHORT_SHA})" \
             --notes-file alpha-notes.md \
             dist/gddy-x86_64-unknown-linux-gnu.tar.gz \
             dist/gddy-aarch64-unknown-linux-gnu.tar.gz \


### PR DESCRIPTION
## Summary
- `release.yml`, `cicd.yml`, `catalog-drift.yml`, and the alpha-build workflow (`rust-port-alpha.yaml`) still triggered on the `rust-port` branch, which no longer exists after the gddy/main branch swap (DEVEX-924) — most notably, `release.yml`'s push trigger and `target-branch` meant release-please never ran on merges to `main`.
- Retargets all of the above to `main` (DEVEX-934, DEVEX-936).
- Retargets and rewords the rolling alpha-build workflow instead of deleting it (DEVEX-933), dropping stale "experimental Rust port / legacy godaddy CLI" framing now that `gddy` is the primary CLI.
- Collapses the README's duplicate "Beta (Rust port preview)" install section into the primary `## Installation` section, removing the same stale framing.

## Test plan
- [ ] Confirm `cicd.yml` and `catalog-drift.yml` runs fire on this PR (they trigger on `pull_request`/`push` against `main`, so they should show up as checks here)
- [ ] After merge, confirm `release.yml`'s `release-please` job actually runs on the merge commit to `main`
- [ ] Confirm the alpha-build workflow runs and publishes correctly on a subsequent push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)