### PR TITLE
feat(errors): map failures to stable codes and top-level fix [DEVEX-945]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ GoDaddy CLI is a Rust binary (edition 2024) built using:
 - Register commands via `Module::new(...)` and wire them in `main.rs`.
 - Use `clap::Arg` for arguments; retrieve via `ctx.args.get("key")`.
 - Return `Ok(CommandResult::new(json!({...})))` for success.
-- Return `Err(cli_engine::CliCoreError::message("..."))` for user-facing errors.
+- Prefer `crate::error::GddyError::{not_found,validation,auth,config,security,network,…}` (and `GddyError::from` for module client errors) so agents get stable `error.code` + top-level `fix`. Use `Err(cli_engine::CliCoreError::message("..."))` only for one-off cases that do not yet have a shared mapping.
 - Streaming commands use `RuntimeCommandSpec::new_streaming` and emit events via `StreamSender`.
 
 ## Key Concepts

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -566,9 +566,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a27dd2b1e961082ee9e3045980f862710ea71c523c114d202e05c2bfbd4608"
+checksum = "96cdf323aa65420ed820e48242da8bc783b966a615ee192f32c9496be1a385d8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1632,7 +1632,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2587,7 +2587,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2624,7 +2624,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.4.8" }
+cli-engine = { features = ["pkce-auth"], version = "0.4.10" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -721,7 +721,7 @@ fn call_command() -> RuntimeCommandSpec {
 
             let request = req
                 .build()
-                .map_err(|e| crate::error::GddyError::unexpected(e.to_string()))?;
+                .map_err(|e| crate::error::GddyError::validation(e.to_string()))?;
             cli_engine::transport::debug_log_reqwest_request(&request);
             let resp = client
                 .execute(request)

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -385,7 +385,11 @@ fn endpoint_list_command() -> RuntimeCommandSpec {
                 .iter()
                 .find(|d| d.name == domain_filter)
                 .ok_or_else(|| {
-                    cli_engine::CliCoreError::message(format!("domain '{domain_filter}' not found"))
+                    crate::error::GddyError::not_found(format!(
+                        "domain '{domain_filter}' not found"
+                    ))
+                    .with_fix("Run: gddy api domain list")
+                    .into_cli_error()
                 })?;
             let endpoints: Vec<Value> = domain
                 .endpoints
@@ -440,9 +444,13 @@ fn describe_command() -> RuntimeCommandSpec {
                 .unwrap_or("");
             let catalog = catalog();
             let (domain, ep) = find_endpoint(catalog, query).ok_or_else(|| {
-                cli_engine::CliCoreError::message(format!(
-                    "no endpoint found matching '{query}' — try `api search {query}`"
+                crate::error::GddyError::not_found(format!(
+                    "no endpoint found matching '{query}' — try `gddy api search {query}`"
                 ))
+                .with_fix(format!(
+                    "Run: gddy api search {query} or gddy api endpoint list"
+                ))
+                .into_cli_error()
             })?;
             Ok(CommandResult::new(json!({
                 "domain": domain.name,
@@ -617,7 +625,8 @@ fn call_command() -> RuntimeCommandSpec {
             // "POST " with trailing whitespace) would return a successful
             // dry-run preview even though a real run would reject it here.
             let parsed_method: reqwest::Method = method.parse().map_err(|_| {
-                cli_engine::CliCoreError::message(format!("invalid HTTP method: {method}"))
+                crate::error::GddyError::validation(format!("invalid HTTP method: {method}"))
+                    .into_cli_error()
             })?;
 
             // `--dry-run` is statically tagged `Tier::Mutate` since the method
@@ -653,16 +662,21 @@ fn call_command() -> RuntimeCommandSpec {
 
             if let Some(file_path) = ctx.args.get("file").and_then(|v| v.as_str()) {
                 let content = std::fs::read_to_string(file_path).map_err(|e| {
-                    cli_engine::CliCoreError::message(format!(
+                    crate::error::GddyError::validation(format!(
                         "failed to read file '{file_path}': {e}"
                     ))
+                    .into_cli_error()
                 })?;
                 request_body = Some(serde_json::from_str(&content).map_err(|e| {
-                    cli_engine::CliCoreError::message(format!("invalid JSON in '{file_path}': {e}"))
+                    crate::error::GddyError::validation(format!(
+                        "invalid JSON in '{file_path}': {e}"
+                    ))
+                    .into_cli_error()
                 })?);
             } else if let Some(body_str) = ctx.args.get("body").and_then(|v| v.as_str()) {
                 request_body = Some(serde_json::from_str(body_str).map_err(|e| {
-                    cli_engine::CliCoreError::message(format!("invalid JSON body: {e}"))
+                    crate::error::GddyError::validation(format!("invalid JSON body: {e}"))
+                        .into_cli_error()
                 })?);
             }
 
@@ -671,9 +685,10 @@ fn call_command() -> RuntimeCommandSpec {
                 let body = request_body.get_or_insert_with(|| json!({}));
                 for s in &fields {
                     let eq = s.find('=').ok_or_else(|| {
-                        cli_engine::CliCoreError::message(format!(
+                        crate::error::GddyError::validation(format!(
                             "invalid field format '{s}': expected key=value"
                         ))
+                        .into_cli_error()
                     })?;
                     let key = s[..eq].to_owned();
                     let val = s[eq + 1..].to_owned();
@@ -692,9 +707,10 @@ fn call_command() -> RuntimeCommandSpec {
             // Apply user-supplied `--header KEY:VALUE` values (repeatable).
             for h in string_list(&ctx.args, "header") {
                 let (key, val) = split_header(&h).ok_or_else(|| {
-                    cli_engine::CliCoreError::message(format!(
+                    crate::error::GddyError::validation(format!(
                         "invalid header '{h}': expected KEY:VALUE"
                     ))
+                    .into_cli_error()
                 })?;
                 req = req.header(key, val);
             }
@@ -705,12 +721,12 @@ fn call_command() -> RuntimeCommandSpec {
 
             let request = req
                 .build()
-                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                .map_err(|e| crate::error::GddyError::unexpected(e.to_string()))?;
             cli_engine::transport::debug_log_reqwest_request(&request);
             let resp = client
                 .execute(request)
                 .await
-                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
 
             let status_code = resp.status();
             let status_text = status_code.canonical_reason().unwrap_or("").to_owned();
@@ -723,7 +739,7 @@ fn call_command() -> RuntimeCommandSpec {
             let body_bytes = resp
                 .bytes()
                 .await
-                .map_err(|e| cli_engine::CliCoreError::message(e.to_string()))?;
+                .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
             cli_engine::transport::debug_log_reqwest_response(
                 status_code,
                 &response_headers_raw,
@@ -749,11 +765,15 @@ fn call_command() -> RuntimeCommandSpec {
             // path and surface those errors instead of reporting a false success.
             let is_graphql = endpoint.contains("graphql") || endpoint.contains("subgraph");
             if is_graphql && let Some(errors) = graphql_errors(&body) {
-                return Err(cli_engine::CliCoreError::message(format!(
-                    "GraphQL request returned {} error(s):\n{}",
-                    errors.len(),
-                    serde_json::to_string_pretty(&json!(errors)).unwrap_or_default(),
-                )));
+                return Err(crate::error::GddyError::from_graphql(
+                    format!(
+                        "GraphQL request returned {} error(s):\n{}",
+                        errors.len(),
+                        serde_json::to_string_pretty(&json!(errors)).unwrap_or_default(),
+                    ),
+                    "api",
+                )
+                .into());
             }
 
             // Scope step-up already ran up front (the token was requested with
@@ -767,11 +787,13 @@ fn call_command() -> RuntimeCommandSpec {
                     .map(|s| format!("--scope {s}"))
                     .collect::<Vec<_>>()
                     .join(" ");
-                return Err(cli_engine::CliCoreError::message(format!(
+                return Err(crate::error::GddyError::auth(format!(
                     "403 Forbidden — the authorized token is missing required scope(s): {}. \
                      Re-run `gddy auth login {login_hint}` and try again.",
                     required.join(", "),
-                )));
+                ))
+                .with_fix(format!("Run: gddy auth login {login_hint}"))
+                .into());
             }
 
             // Any other non-2xx is a failure, not a success envelope. Include the
@@ -783,9 +805,12 @@ fn call_command() -> RuntimeCommandSpec {
                     .chars()
                     .take(4000)
                     .collect();
-                return Err(cli_engine::CliCoreError::message(format!(
-                    "{status} {status_text}\n{detail}"
-                )));
+                return Err(crate::error::GddyError::from_http(
+                    status,
+                    format!("{status_text}\n{detail}"),
+                    "api",
+                )
+                .into_cli_error());
             }
 
             // Identify the call and its outcome in the result envelope.

--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -31,6 +31,28 @@ pub enum ClientError {
     InvalidHeader(String),
 }
 
+impl From<ClientError> for crate::error::GddyError {
+    fn from(value: ClientError) -> Self {
+        match value {
+            ClientError::Http { status, body } => Self::from_http(status, body, "applications"),
+            ClientError::Network(e) => {
+                Self::network(format!("network error: {e}")).with_system("applications")
+            }
+            ClientError::GraphQL(msg) => {
+                Self::from_graphql(format!("GraphQL errors: {msg}"), "applications")
+            }
+            ClientError::TooLarge { size, max } => Self::validation(format!(
+                "file size {size} bytes exceeds maximum allowed ({max} bytes)"
+            ))
+            .with_system("applications"),
+            ClientError::InvalidHeader(name) => {
+                Self::validation(format!("invalid upload header {name}"))
+                    .with_system("applications")
+            }
+        }
+    }
+}
+
 /// Result of a successful artifact upload.
 #[derive(Debug, Clone)]
 pub struct UploadResult {

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -104,12 +104,12 @@ async fn make_client(ctx: &cli_engine::CommandContext) -> cli_engine::Result<App
 }
 
 fn client_err(e: crate::application::client::ClientError) -> cli_engine::CliCoreError {
-    cli_engine::CliCoreError::message(e.to_string())
+    crate::error::GddyError::from(e).into_cli_error()
 }
 
 /// Builds the terminal `{"type":"error",...}` event for a streaming command,
-/// reusing `cli_engine::build_error_envelope` so the `code`/`message` match
-/// what a non-streaming command would have rendered for the same error.
+/// reusing `cli_engine::build_error_envelope` so the `code`/`message`/`fix`
+/// match what a non-streaming command would have rendered for the same error.
 fn deploy_error_event(err: &cli_engine::CliCoreError) -> Value {
     let envelope = cli_engine::build_error_envelope(err, "applications");
     // `build_error_envelope` always populates `.error` with a non-empty code;
@@ -118,12 +118,16 @@ fn deploy_error_event(err: &cli_engine::CliCoreError) -> Value {
         .error
         .map(|e| (e.code, e.message))
         .unwrap_or_else(|| ("ERROR".to_owned(), err.to_string()));
-    json!({
+    let mut event = json!({
         "type": "error",
         "ok": false,
         "error": { "code": code, "message": message },
         "next_actions": [],
-    })
+    });
+    if let Some(fix) = envelope.fix.filter(|f| !f.is_empty()) {
+        event["fix"] = json!(fix);
+    }
+    event
 }
 
 /// Emit the terminal error event on a streaming command, then return the
@@ -296,9 +300,10 @@ fn info_command() -> RuntimeCommandSpec {
             let data = client.get_application(&name).await.map_err(client_err)?;
             let app = &data["application"];
             if app.is_null() {
-                return Err(cli_engine::CliCoreError::message(format!(
+                return Err(crate::error::GddyError::not_found(format!(
                     "application '{name}' not found"
-                )));
+                ))
+                .into_cli_error());
             }
             let app_id = app["id"].as_str().unwrap_or("").to_owned();
             Ok(CommandResult::new(app.clone()).with_next_actions(vec![
@@ -416,7 +421,8 @@ fn init_command() -> RuntimeCommandSpec {
             let existing = match ctx.args.get("config").and_then(|v| v.as_str()) {
                 Some(path) => Some(
                     crate::config::read_config(std::path::Path::new(path)).map_err(|e| {
-                        cli_engine::CliCoreError::message(format!("invalid config: {e}"))
+                        crate::error::GddyError::config(format!("invalid config: {e}"))
+                            .into_cli_error()
                     })?,
                 ),
                 None => None,
@@ -639,9 +645,10 @@ fn validate_command() -> RuntimeCommandSpec {
             let data = client.get_application(&name).await.map_err(client_err)?;
             let app = &data["application"];
             if app.is_null() {
-                return Err(cli_engine::CliCoreError::message(format!(
+                return Err(crate::error::GddyError::not_found(format!(
                     "application '{name}' not found"
-                )));
+                ))
+                .into_cli_error());
             }
 
             let app_id = app["id"].as_str().unwrap_or("").to_owned();
@@ -891,7 +898,8 @@ fn archive_command() -> RuntimeCommandSpec {
             let app_id = app_data["application"]["id"]
                 .as_str()
                 .ok_or_else(|| {
-                    cli_engine::CliCoreError::message(format!("application '{name}' not found"))
+                    crate::error::GddyError::not_found(format!("application '{name}' not found"))
+                        .into_cli_error()
                 })?
                 .to_owned();
             let data = client
@@ -1110,7 +1118,8 @@ fn deploy_command() -> RuntimeCommandSpec {
             let config = tap_deploy_err(
                 &sender,
                 crate::config::read_config(&config_path).map_err(|e| {
-                    cli_engine::CliCoreError::message(format!("config read failed: {e}"))
+                    crate::error::GddyError::config(format!("config read failed: {e}"))
+                        .into_cli_error()
                 }),
             )
             .await?;
@@ -1133,7 +1142,8 @@ fn deploy_command() -> RuntimeCommandSpec {
             let app = &app_data["application"];
             if app.is_null() {
                 let err =
-                    cli_engine::CliCoreError::message(format!("application '{name}' not found"));
+                    crate::error::GddyError::not_found(format!("application '{name}' not found"))
+                        .into_cli_error();
                 return Err(fail_deploy(&sender, err).await);
             }
             let application_id = app["id"].as_str().unwrap_or("").to_owned();
@@ -1402,10 +1412,11 @@ async fn deploy_extension(
                 }
             })
             .collect();
-        return Err(cli_engine::CliCoreError::message(format!(
+        return Err(crate::error::GddyError::security(format!(
             "security scan blocked deployment of '{ext_name}':\n{}",
             blocked_msgs.join("\n")
-        )));
+        ))
+        .into());
     }
 
     sender
@@ -2111,6 +2122,22 @@ mod tests {
         assert_eq!(event["next_actions"], serde_json::json!([]));
     }
 
+    #[test]
+    fn deploy_error_event_includes_fix_from_gddy_error() {
+        let err =
+            crate::error::GddyError::not_found("application 'foo' not found").into_cli_error();
+        let event = super::deploy_error_event(&err);
+
+        assert_eq!(event["error"]["code"], crate::error::codes::NOT_FOUND);
+        assert_eq!(event["error"]["message"], "application 'foo' not found");
+        assert!(
+            event["fix"]
+                .as_str()
+                .is_some_and(|f| f.contains("platform app list")),
+            "expected fix on streaming error event: {event}"
+        );
+    }
+
     #[derive(Debug)]
     struct CodedTestError;
 
@@ -2134,6 +2161,10 @@ mod tests {
         fn error_request_id(&self) -> Option<std::borrow::Cow<'static, str>> {
             None
         }
+
+        fn error_fix(&self) -> Option<std::borrow::Cow<'static, str>> {
+            Some("Check release status and retry.".into())
+        }
     }
 
     /// Proves `deploy_error_event` actually passes through a real error code
@@ -2147,6 +2178,7 @@ mod tests {
 
         assert_eq!(event["error"]["code"], "RELEASE_REJECTED");
         assert_eq!(event["error"]["message"], "upstream rejected the release");
+        assert_eq!(event["fix"], "Check release status and retry.");
     }
 
     #[test]

--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -1,6 +1,6 @@
 //! `dns add` — append new DNS records to a domain without touching existing ones.
 
-use cli_engine::{CliCoreError, CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
+use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
 use serde_json::{Value, json};
 
 use crate::domain::{make_client, string_list};
@@ -107,7 +107,8 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let name = arg_str(&ctx, "name").unwrap_or_default();
             let data = string_list(&ctx, "data");
             let opts = RecordOptions::from_ctx(&ctx);
-            validate_caa_fields(&record_type, &opts).map_err(CliCoreError::message)?;
+            validate_caa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
             let records = v3_records(&name, &record_type, &data, &opts);
 
             let debug = !ctx.middleware.debug.is_empty();
@@ -154,7 +155,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                         &name,
                     )])
                 })
-                .map_err(CliCoreError::message)
+                .map_err(super::mutate_failed)
         },
     )
 }

--- a/rust/src/dns/delete.rs
+++ b/rust/src/dns/delete.rs
@@ -1,6 +1,6 @@
 //! `dns delete` — remove all records matching a type+name from a domain.
 
-use cli_engine::{CliCoreError, CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
+use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
 use serde_json::{Value, json};
 
 use crate::domain::{api_error, make_client};
@@ -213,7 +213,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                         &name,
                     )])
                 })
-                .map_err(CliCoreError::message)
+                .map_err(super::mutate_failed)
         },
     )
 }

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -18,7 +18,7 @@
 //! [`Tier::Destructive`] — they overwrite or remove existing records — so
 //! `--dry-run` short-circuits them with a preview.
 
-use cli_engine::{GroupSpec, Module, RuntimeGroupSpec};
+use cli_engine::{CliCoreError, GroupSpec, Module, RuntimeGroupSpec};
 
 mod add;
 mod conflicts;
@@ -26,6 +26,16 @@ mod delete;
 mod list;
 mod records;
 mod set;
+
+/// Partial add/set/delete failure: outcomes may mix validation, API, and
+/// transport errors, so this is classified as unexpected with a DNS-specific fix.
+pub(super) fn mutate_failed(message: impl Into<String>) -> CliCoreError {
+    crate::error::GddyError::unexpected(message)
+        .with_fix(
+            "Re-run with only the failed value(s), or use gddy dns list to inspect the current records.",
+        )
+        .into_cli_error()
+}
 
 pub fn module() -> Module {
     Module::new("DNS", |_ctx| {

--- a/rust/src/dns/set.rs
+++ b/rust/src/dns/set.rs
@@ -1,6 +1,6 @@
 //! `dns set` — replace every record for a type+name pair (destructive).
 
-use cli_engine::{CliCoreError, CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
+use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
 use serde_json::{Value, json};
 
 use crate::domain::{api_error, format_api_error, make_client, string_list};
@@ -451,7 +451,8 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let data = string_list(&ctx, "data");
             let opts = RecordOptions::from_ctx(&ctx);
             let replace_conflicting = arg_bool(&ctx, "replace-conflicting-types");
-            validate_caa_fields(&record_type, &opts).map_err(CliCoreError::message)?;
+            validate_caa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
 
             let debug = !ctx.middleware.debug.is_empty();
             let client = make_client(&ctx).await?;
@@ -471,12 +472,19 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // if any lacks one, rather than silently dropping it (which would
             // leave it behind and make `set` add records instead of replacing).
             if existing.iter().any(|r| r.record_id.is_none()) {
-                return Err(CliCoreError::message(format!(
+                let message = format!(
                     "some existing {record_type} records for {name} were returned without a \
                      recordId, so `set` can't safely replace the full set. Re-run `gddy dns \
                      list {domain} --type {record_type} --name {name}` and adjust in the \
                      control panel if this persists."
-                )));
+                );
+                let fix = format!(
+                    "Re-run `gddy dns list {domain} --type {record_type} --name {name}` and \
+                     adjust in the control panel if this persists."
+                );
+                return Err(crate::error::GddyError::unexpected(message)
+                    .with_fix(fix)
+                    .into_cli_error());
             }
             let existing_ids: Vec<String> = existing
                 .iter()
@@ -564,7 +572,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                         &name,
                     )])
                 })
-                .map_err(CliCoreError::message)
+                .map_err(super::mutate_failed)
         },
     )
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,0 +1,363 @@
+//! Shared GoDaddy CLI error codes and recovery hints for agent envelopes.
+//!
+//! Prefer these constructors over bare [`cli_engine::CliCoreError::message`] so
+//! JSON envelopes (and streaming deploy error events) get stable `error.code`
+//! values and a top-level `fix` recovery hint.
+
+use std::borrow::Cow;
+use std::fmt;
+
+use cli_engine::{CliCoreError, DetailedError};
+
+/// Stable agent-facing error codes.
+pub(crate) mod codes {
+    pub(crate) const NOT_FOUND: &str = "NOT_FOUND";
+    pub(crate) const VALIDATION_ERROR: &str = "VALIDATION_ERROR";
+    pub(crate) const NETWORK_ERROR: &str = "NETWORK_ERROR";
+    pub(crate) const AUTH_REQUIRED: &str = "AUTH_REQUIRED";
+    pub(crate) const CONFIG_ERROR: &str = "CONFIG_ERROR";
+    pub(crate) const SECURITY_BLOCKED: &str = "SECURITY_BLOCKED";
+    pub(crate) const UNEXPECTED_ERROR: &str = "UNEXPECTED_ERROR";
+}
+
+mod fixes {
+    pub(super) const NOT_FOUND: &str =
+        "Use discovery commands such as: gddy platform app list or gddy platform actions list.";
+    pub(super) const VALIDATION: &str = "Review command arguments and try again with valid values.";
+    pub(super) const AUTH: &str = "Run: gddy auth login";
+    pub(super) const FORBIDDEN: &str = "You may lack permission for this resource. Confirm scopes with: gddy auth scopes, or re-authenticate with: gddy auth login";
+    pub(super) const CONFIG: &str = "Check your config with: gddy env info";
+    pub(super) const SECURITY: &str =
+        "Resolve security findings and rerun: gddy platform app deploy --name <name>";
+    pub(super) const UNEXPECTED: &str =
+        "Run: gddy tree for command discovery and retry with corrected input.";
+    pub(super) const UNEXPECTED_RESPONSE: &str =
+        "The API returned an unexpected response body. Retry, or report this if it persists.";
+    pub(super) const NETWORK_CONNECTIVITY: &str =
+        "Verify environment connectivity with: gddy env get and retry.";
+    pub(super) const NETWORK_CLIENT: &str = "Check request path/query/body. Inspect error.details.response for API validation feedback.";
+    pub(super) const NETWORK_SERVER: &str =
+        "The API is currently failing server-side. Retry, or check service health/incidents.";
+    pub(super) const NETWORK_GRAPHQL: &str = "Check GraphQL query, variables, and operationName. Inspect error.details.response.errors for resolver/validation details.";
+    pub(super) const NOT_FOUND_HOSTING: &str = "Use: gddy hosting nodejs app list";
+    /// Live `api call` 404: the requested URL/resource was not found (not a catalog miss).
+    pub(super) const NOT_FOUND_API: &str =
+        "Check the request path and parameters. Inspect the response body for details.";
+}
+
+fn not_found_fix_for(system: &str) -> &'static str {
+    match system {
+        "hosting" => fixes::NOT_FOUND_HOSTING,
+        "api" => fixes::NOT_FOUND_API,
+        // applications / unknown → platform discovery (default NOT_FOUND fix)
+        _ => fixes::NOT_FOUND,
+    }
+}
+
+/// Structured CLI error that maps to a coded envelope via [`DetailedError`].
+#[derive(Debug, Clone)]
+pub(crate) struct GddyError {
+    message: String,
+    code: &'static str,
+    fix: Option<String>,
+    system: Option<String>,
+}
+
+impl GddyError {
+    #[must_use]
+    pub(crate) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code,
+            fix: None,
+            system: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn with_fix(mut self, fix: impl Into<String>) -> Self {
+        let fix = fix.into();
+        self.fix = (!fix.is_empty()).then_some(fix);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_system(mut self, system: impl Into<String>) -> Self {
+        let system = system.into();
+        self.system = (!system.is_empty()).then_some(system);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn not_found(message: impl Into<String>) -> Self {
+        Self::new(codes::NOT_FOUND, message).with_fix(fixes::NOT_FOUND)
+    }
+
+    #[must_use]
+    pub(crate) fn validation(message: impl Into<String>) -> Self {
+        Self::new(codes::VALIDATION_ERROR, message).with_fix(fixes::VALIDATION)
+    }
+
+    #[must_use]
+    pub(crate) fn auth(message: impl Into<String>) -> Self {
+        Self::new(codes::AUTH_REQUIRED, message).with_fix(fixes::AUTH)
+    }
+
+    #[must_use]
+    pub(crate) fn config(message: impl Into<String>) -> Self {
+        Self::new(codes::CONFIG_ERROR, message).with_fix(fixes::CONFIG)
+    }
+
+    #[must_use]
+    pub(crate) fn security(message: impl Into<String>) -> Self {
+        Self::new(codes::SECURITY_BLOCKED, message).with_fix(fixes::SECURITY)
+    }
+
+    #[must_use]
+    pub(crate) fn unexpected(message: impl Into<String>) -> Self {
+        Self::new(codes::UNEXPECTED_ERROR, message).with_fix(fixes::UNEXPECTED)
+    }
+
+    #[must_use]
+    pub(crate) fn network(message: impl Into<String>) -> Self {
+        Self::new(codes::NETWORK_ERROR, message).with_fix(fixes::NETWORK_CONNECTIVITY)
+    }
+
+    /// Map an HTTP status (+ body) to a coded error with a status-aware fix.
+    ///
+    /// - `401` → auth (missing/expired credentials)
+    /// - `403` → network/client (authenticated but not allowed)
+    /// - `404` → not found (system-specific discovery fix)
+    /// - `2xx` → unexpected (callers sometimes wrap malformed success bodies as Http)
+    /// - other `4xx` / `5xx` → network with client/server fixes
+    #[must_use]
+    pub(crate) fn from_http(status: u16, body: impl AsRef<str>, system: impl Into<String>) -> Self {
+        let body = body.as_ref();
+        let message = if body.is_empty() {
+            format!("HTTP error {status}")
+        } else {
+            format!("HTTP error {status}: {body}")
+        };
+        let system = system.into();
+        match status {
+            401 => Self::auth(message).with_system(system),
+            403 => Self::new(codes::NETWORK_ERROR, message)
+                .with_fix(fixes::FORBIDDEN)
+                .with_system(system),
+            404 => Self::new(codes::NOT_FOUND, message)
+                .with_fix(not_found_fix_for(&system))
+                .with_system(system),
+            200..=299 => Self::new(codes::UNEXPECTED_ERROR, message)
+                .with_fix(fixes::UNEXPECTED_RESPONSE)
+                .with_system(system),
+            400..=499 => Self::new(codes::NETWORK_ERROR, message)
+                .with_fix(fixes::NETWORK_CLIENT)
+                .with_system(system),
+            500..=599 => Self::new(codes::NETWORK_ERROR, message)
+                .with_fix(fixes::NETWORK_SERVER)
+                .with_system(system),
+            _ => Self::network(message).with_system(system),
+        }
+    }
+
+    /// Map GraphQL transport/resolver failures.
+    #[must_use]
+    pub(crate) fn from_graphql(message: impl Into<String>, system: impl Into<String>) -> Self {
+        Self::new(codes::NETWORK_ERROR, message)
+            .with_fix(fixes::NETWORK_GRAPHQL)
+            .with_system(system)
+    }
+
+    /// Convert into a [`CliCoreError`] that carries `code` + top-level `fix`.
+    ///
+    /// Prefer this over [`.into()`](Into::into) at `Err(...)` call sites —
+    /// [`CliCoreError`] has several `From` impls and type inference often fails.
+    #[must_use]
+    pub(crate) fn into_cli_error(self) -> CliCoreError {
+        CliCoreError::with_detailed_error(self)
+    }
+}
+
+impl fmt::Display for GddyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GddyError {}
+
+impl DetailedError for GddyError {
+    fn error_code(&self) -> Cow<'static, str> {
+        Cow::Borrowed(self.code)
+    }
+
+    fn error_system(&self) -> Option<Cow<'static, str>> {
+        self.system.clone().map(Cow::Owned)
+    }
+
+    fn error_request_id(&self) -> Option<Cow<'static, str>> {
+        None
+    }
+
+    fn error_fix(&self) -> Option<Cow<'static, str>> {
+        self.fix.clone().map(Cow::Owned)
+    }
+}
+
+impl From<GddyError> for CliCoreError {
+    fn from(value: GddyError) -> Self {
+        value.into_cli_error()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_sets_code_and_fix() {
+        let err = GddyError::not_found("application 'foo' not found");
+        assert_eq!(err.error_code(), codes::NOT_FOUND);
+        assert!(
+            err.error_fix()
+                .is_some_and(|f| f.contains("platform app list")),
+            "expected discovery fix, got {:?}",
+            err.error_fix()
+        );
+
+        let envelope = cli_engine::build_error_envelope(&err.into_cli_error(), "applications");
+        assert_eq!(
+            envelope.error.as_ref().map(|e| e.code.as_str()),
+            Some(codes::NOT_FOUND)
+        );
+        assert_eq!(
+            envelope.error.as_ref().map(|e| e.message.as_str()),
+            Some("application 'foo' not found")
+        );
+        assert!(
+            envelope
+                .fix
+                .as_deref()
+                .is_some_and(|f| f.contains("platform app list")),
+            "envelope.fix missing: {envelope:?}"
+        );
+    }
+
+    #[test]
+    fn from_http_maps_auth_and_not_found() {
+        let auth = GddyError::from_http(401, "unauthorized", "applications");
+        assert_eq!(auth.error_code(), codes::AUTH_REQUIRED);
+
+        let forbidden = GddyError::from_http(403, "denied", "applications");
+        assert_eq!(forbidden.error_code(), codes::NETWORK_ERROR);
+        assert!(
+            forbidden
+                .error_fix()
+                .is_some_and(|f| f.contains("auth scopes")),
+            "{:?}",
+            forbidden.error_fix()
+        );
+
+        let malformed = GddyError::from_http(
+            200,
+            "invalid JSON response: eof (body: not-json)",
+            "applications",
+        );
+        assert_eq!(malformed.error_code(), codes::UNEXPECTED_ERROR);
+        assert!(
+            malformed
+                .error_fix()
+                .is_some_and(|f| f.contains("unexpected response")),
+            "{:?}",
+            malformed.error_fix()
+        );
+
+        let missing = GddyError::from_http(404, "gone", "applications");
+        assert_eq!(missing.error_code(), codes::NOT_FOUND);
+        assert!(
+            missing
+                .error_fix()
+                .is_some_and(|f| f.contains("platform app list")),
+            "{:?}",
+            missing.error_fix()
+        );
+
+        let hosting_missing = GddyError::from_http(404, "gone", "hosting");
+        assert!(
+            hosting_missing
+                .error_fix()
+                .is_some_and(|f| f.contains("hosting nodejs app list")),
+            "{:?}",
+            hosting_missing.error_fix()
+        );
+
+        let api_missing = GddyError::from_http(404, "gone", "api");
+        assert!(
+            api_missing
+                .error_fix()
+                .is_some_and(|f| f.contains("request path")),
+            "{:?}",
+            api_missing.error_fix()
+        );
+
+        let client = GddyError::from_http(422, "bad", "applications");
+        assert_eq!(client.error_code(), codes::NETWORK_ERROR);
+        assert!(
+            client
+                .error_fix()
+                .is_some_and(|f| f.contains("path/query/body")),
+            "{:?}",
+            client.error_fix()
+        );
+
+        let server = GddyError::from_http(503, "down", "applications");
+        assert!(
+            server
+                .error_fix()
+                .is_some_and(|f| f.contains("server-side")),
+            "{:?}",
+            server.error_fix()
+        );
+    }
+
+    #[test]
+    fn security_blocked_code() {
+        let err = GddyError::security("security scan blocked deployment of 'x'");
+        let envelope = cli_engine::build_error_envelope(&err.into_cli_error(), "applications");
+        assert_eq!(
+            envelope.error.as_ref().map(|e| e.code.as_str()),
+            Some(codes::SECURITY_BLOCKED)
+        );
+        assert!(
+            envelope
+                .fix
+                .as_deref()
+                .is_some_and(|f| f.contains("platform app deploy")),
+            "{:?}",
+            envelope.fix
+        );
+    }
+
+    #[test]
+    fn auth_with_fix_can_include_scopes() {
+        let err =
+            GddyError::auth("missing scopes").with_fix("Run: gddy auth login --scope foo:bar");
+        assert_eq!(err.error_code(), codes::AUTH_REQUIRED);
+        assert_eq!(
+            err.error_fix().as_deref(),
+            Some("Run: gddy auth login --scope foo:bar")
+        );
+    }
+
+    #[test]
+    fn unexpected_with_custom_fix_overrides_default() {
+        let err = GddyError::unexpected("records without recordId")
+            .with_fix("Re-run `gddy dns list example.com --type A --name www`");
+        assert_eq!(err.error_code(), codes::UNEXPECTED_ERROR);
+        assert!(
+            err.error_fix().is_some_and(|f| f.contains("dns list")),
+            "{:?}",
+            err.error_fix()
+        );
+    }
+}

--- a/rust/src/hosting/nodejs/client.rs
+++ b/rust/src/hosting/nodejs/client.rs
@@ -20,6 +20,20 @@ pub enum ClientError {
     },
 }
 
+impl From<ClientError> for crate::error::GddyError {
+    fn from(value: ClientError) -> Self {
+        match value {
+            ClientError::Http { status, body } => Self::from_http(status, body, "hosting"),
+            ClientError::Network(e) => {
+                Self::network(format!("network error: {e}")).with_system("hosting")
+            }
+            ClientError::Io { path, source } => {
+                Self::validation(format!("failed to read {path}: {source}")).with_system("hosting")
+            }
+        }
+    }
+}
+
 pub struct HostingClient {
     client: Client,
     base_url: String,

--- a/rust/src/hosting/nodejs/mod.rs
+++ b/rust/src/hosting/nodejs/mod.rs
@@ -39,11 +39,13 @@ async fn make_client(ctx: &CommandContext, scopes: &[&str]) -> Result<HostingCli
 }
 
 fn client_err(e: client::ClientError) -> CliCoreError {
-    CliCoreError::message(e.to_string())
+    crate::error::GddyError::from(e).into_cli_error()
 }
 
 fn required_str(ctx: &CommandContext, key: &str, label: &str) -> Result<String> {
-    optional_str(ctx, key).ok_or_else(|| CliCoreError::message(format!("{label} is required")))
+    optional_str(ctx, key).ok_or_else(|| {
+        crate::error::GddyError::validation(format!("{label} is required")).into_cli_error()
+    })
 }
 
 fn optional_str(ctx: &CommandContext, key: &str) -> Option<String> {
@@ -278,9 +280,10 @@ fn app_update_command() -> RuntimeCommandSpec {
             let name = optional_str(&ctx, "name");
             let root_path = optional_str(&ctx, "root-path");
             if name.is_none() && root_path.is_none() {
-                return Err(CliCoreError::message(
+                return Err(crate::error::GddyError::validation(
                     "at least one of --name or --root-path is required",
-                ));
+                )
+                .into_cli_error());
             }
             let mut body = serde_json::Map::new();
             if let Some(name) = name {
@@ -539,7 +542,10 @@ fn source_upload_command() -> RuntimeCommandSpec {
             let file = required_str(&ctx, "file", "--file")?;
             let path = std::path::Path::new(&file);
             if !path.is_file() {
-                return Err(CliCoreError::message(format!("zip file not found: {file}")));
+                return Err(crate::error::GddyError::validation(format!(
+                    "zip file not found: {file}"
+                ))
+                .into_cli_error());
             }
             let client = make_client(&ctx, &[CODE_WRITE]).await?;
             let data = client
@@ -987,10 +993,16 @@ fn secrets_update_command() -> RuntimeCommandSpec {
             let app_id = required_str(&ctx, "app-id", "--app-id")?;
             let file = required_str(&ctx, "file", "--file")?;
             let content = std::fs::read_to_string(&file).map_err(|e| {
-                CliCoreError::message(format!("failed to read secrets file '{file}': {e}"))
+                crate::error::GddyError::validation(format!(
+                    "failed to read secrets file '{file}': {e}"
+                ))
+                .into_cli_error()
             })?;
             let body: Value = serde_json::from_str(&content).map_err(|e| {
-                CliCoreError::message(format!("invalid JSON in secrets file '{file}': {e}"))
+                crate::error::GddyError::validation(format!(
+                    "invalid JSON in secrets file '{file}': {e}"
+                ))
+                .into_cli_error()
             })?;
             let client = make_client(&ctx, &[SECRETS_WRITE]).await?;
             let data = client

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -8,6 +8,7 @@ mod dns;
 mod domain;
 mod env;
 mod environments;
+mod error;
 mod extension;
 mod hosting;
 mod next_action;


### PR DESCRIPTION
## Summary
- Bump `cli-engine` to `0.4.10` and add shared `GddyError` (`error.code` + top-level `fix`) so agent envelopes match the old TS recovery shape.
- Wire `application`/`hosting` client errors and high-value command paths (`api, dns, platform app, hosting`) through coded constructors; streaming deploy terminal error events now include `fix`.
- HTTP mapping is status-aware (401 auth, 403 permission, 404 by system, malformed 2xx body, other 4xx/5xx network); DNS partial write summaries use `UNEXPECTED_ERROR` with a `dns list` recovery hint.

## Test plan
- [x] `cargo build` / `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test`
- [x] Unit: `error::*` envelope/`from_http` cases; `deploy_error_event_includes_fix_from_gddy_error` (streaming `fix` without a live deploy)
- [x] Offline CLI JSON envelopes:
  - `api describe` unknown op → `NOT_FOUND` + search/endpoint-list `fix`
  - `api endpoint list --domain …` missing catalog domain → `NOT_FOUND` + `api domain list` `fix`
  - `api call --dry-run` bad `--header` / `-f` / `-d` / missing `-F` file → `VALIDATION_ERROR` + review-args `fix`
  - `hosting nodejs app update` missing `--name`/`--root-path` → `VALIDATION_ERROR`
  - `hosting nodejs source upload` missing zip path → `VALIDATION_ERROR`