### PR TITLE
fix(api-catalog): resync drift, normalize domains base URL, sort + env-aware routing

### DIFF
--- a/rust/domains-client/openapi/domains.oas3.json
+++ b/rust/domains-client/openapi/domains.oas3.json
@@ -13,7 +13,7 @@
   },
   "servers": [
     {
-      "url": "https://api.ote-godaddy.com",
+      "url": "https://api.godaddy.com",
       "description": "Domains API host"
     }
   ],

--- a/rust/domains-client/scripts/regenerate-spec.sh
+++ b/rust/domains-client/scripts/regenerate-spec.sh
@@ -34,9 +34,10 @@ trimmed_v1="$openapi_dir/.swagger_domains.trimmed.v1.json"
 v1_oas3="$openapi_dir/.domains.v1.oas3.json"
 oas3="$openapi_dir/domains.oas3.json"
 
-# The document host. base_url is overridden at runtime by the CLI per environment,
-# so this is cosmetic; keep it on the public OTE host.
-host="https://api.ote-godaddy.com"
+# The document host. base_url is overridden at runtime by the CLI per environment
+# (environments::resolve_domains), so this is cosmetic — keep it prod-canonical,
+# consistent with every other embedded catalog domain's baseUrl.
+host="https://api.godaddy.com"
 
 echo "==> Downloading upstream Swagger 2.0 spec"
 curl -fsSL "https://developer.godaddy.com/swagger/swagger_domains.json" -o "$v2"

--- a/rust/schemas/api/domains.json
+++ b/rust/schemas/api/domains.json
@@ -10,7 +10,7 @@
             }
           ],
           "description": "The type of legal agreement. Identifies which agreement text the customer must accept.\n",
-          "example": "DNRA"
+          "example": "API_DPA"
         },
         "title": {
           "description": "Human-readable title of the agreement, suitable for display to the customer.\n",
@@ -28,7 +28,15 @@
       "type": "object"
     },
     "AgreementType": {
-      "description": "The type of legal agreement that must be accepted prior to executing a domain operation. Additional agreement types may be returned for specific TLDs or product combinations. DNRA — Domain Name Registration Agreement. DNTA — Domain Name Transfer Agreement. DNPA — Domain Name Privacy Agreement. HTTPS_NOTICE — HTTPS notice acknowledgment for eligible TLDs. AURA — AU Domain Agreement for .au TLD registrations and transfers. CIRA — Canadian Internet Registration Authority Agreement for .ca TLD registrations and transfers.\n",
+      "description": "The type of legal agreement that must be accepted prior to executing a domain operation. Additional agreement types may be returned for specific TLDs or product combinations. API_DPA - API Domain Purchase Agreement. DNTA — Domain Name Transfer Agreement. DNPA — Domain Name Privacy Agreement. HTTPS_NOTICE — HTTPS notice acknowledgment for eligible TLDs. AURA — AU Domain Agreement for .au TLD registrations and transfers. CIRA — Canadian Internet Registration Authority Agreement for .ca TLD registrations and transfers.\n",
+      "enum": [
+        "API_DPA",
+        "AURA",
+        "CIRA",
+        "DNPA",
+        "DNTA",
+        "HTTPS_NOTICE"
+      ],
       "title": "Agreement Type",
       "type": "string"
     },
@@ -121,7 +129,7 @@
       "type": "object"
     },
     "Consent": {
-      "description": "Customer consent record for a domain operation, capturing which legal agreements were accepted, when, and by whom. This object is self-reported by the caller and treated as supplementary attestation. The server verifies agreedBy.principal against the authenticated identity (auth token + X-Shopper-Id resolution) and rejects with consent_principal_mismatch on disagreement. The persisted consent record is the union of this claimed block and the verified auth context.\n",
+      "description": "Customer consent record for a domain operation, capturing which legal agreements were accepted, when, and by whom. On execute, the caller supplies agreementTypes and agreedAt. The server derives agreedBy from the authenticated request context (OAuth identity, X-Shopper-Id, client IP, and transmission channel).\n",
       "properties": {
         "agreedAt": {
           "allOf": [
@@ -132,12 +140,18 @@
           "description": "The timestamp at which the principal expressed consent. Should reflect when the customer clicked accept or confirmed the operation, not when the API call was made.\n"
         },
         "agreedBy": {
-          "$ref": "#/$defs/ConsentActor"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ConsentActor"
+            }
+          ],
+          "description": "Who gave consent and how it was transmitted. Server-derived from the execute request's auth context.\n",
+          "readOnly": true
         },
         "agreementTypes": {
           "description": "The agreement types the customer accepted. Must match the agreementType values returned in the corresponding quote's requiredAgreements array.\n",
           "example": [
-            "DNRA"
+            "API_DPA"
           ],
           "items": {
             "$ref": "#/$defs/AgreementType"
@@ -148,28 +162,27 @@
       },
       "required": [
         "agreementTypes",
-        "agreedAt",
-        "agreedBy"
+        "agreedAt"
       ],
       "title": "Consent",
       "type": "object"
     },
     "ConsentActor": {
-      "description": "Identifies who gave consent and who transmitted it. One uniform schema for all actor types. Self-reported by the caller and treated as supplementary attestation; the server verifies principal against the resolved auth identity (OAuth token + X-Shopper-Id) and rejects with consent_principal_mismatch on disagreement. The persisted consent record is the union of this block and the verified auth context.\nprincipal identifies the account holder whose consent is being recorded. actor identifies the automated or intermediary party that transmitted the consent when different from the principal. For DIRECT, actor is omitted.\n",
+      "description": "Identifies who gave consent and how it was transmitted. One uniform schema for all actor types. Populated by the server from the execute request's authenticated context — not supplied by the caller.\n",
       "properties": {
         "actor": {
-          "description": "The automated agent or system that transmitted the consent. Omitted for DIRECT. For AGENT, identifies the specific agent instance. For RESELLER, may identify the reseller when distinct from the OAuth token subject.\n",
+          "description": "The party that transmitted the consent when distinct from the principal. Omitted for DIRECT.\n",
           "example": "agent:claude/atlas-1",
           "type": "string"
         },
         "ip": {
-          "description": "The IP address of the principal at the time consent was expressed, if known. Optional — an absent IP with a verified principal is preferred over a fabricated one.\n",
+          "description": "Client IP address captured from the execute request at the time consent was recorded. Omitted when unavailable.\n",
           "example": "203.0.113.7",
           "type": "string"
         },
         "principal": {
-          "description": "The shopper or account ID whose consent is being recorded. Must match the shopper resolved from the OAuth token and X-Shopper-Id header; mismatch returns consent_principal_mismatch.\n",
-          "example": "shopper_123",
+          "description": "The resolved customer identifier whose consent is recorded, derived from the auth context on the execute request.\n",
+          "example": "550e8400-e29b-41d4-a716-446655440000",
           "type": "string"
         },
         "type": {
@@ -178,7 +191,7 @@
               "$ref": "#/$defs/ConsentActorType"
             }
           ],
-          "description": "Who transmitted consent relative to the principal.\n",
+          "description": "How consent was transmitted relative to the principal. Server-assigned from the request's auth and channel context.\n",
           "example": "DIRECT"
         }
       },
@@ -191,7 +204,12 @@
       "x-sensitivity": "confidential"
     },
     "ConsentActorType": {
-      "description": "Who transmitted consent on behalf of the principal. DIRECT — the principal acted directly; actor is omitted. AGENT — an AI or automation acted on behalf of the principal. RESELLER — a reseller acted on behalf of a shopper.\n",
+      "description": "How consent was transmitted relative to the principal. DIRECT — the principal transmitted consent directly; actor is omitted. AGENT — consent was transmitted by an AI or automation on the principal's behalf. RESELLER — consent was transmitted by a reseller on the principal's behalf.\n",
+      "enum": [
+        "AGENT",
+        "DIRECT",
+        "RESELLER"
+      ],
       "title": "Consent Actor Type",
       "type": "string"
     },
@@ -651,16 +669,25 @@
     },
     "DomainOperationStatus": {
       "description": "The execution state of an asynchronous domain operation. CONFIRMED — operation has been accepted and is queued for execution. EXECUTING — operation is actively being processed by the registry or downstream systems. COMPLETED — operation finished successfully; result data is available. FAILED — operation terminated with an unrecoverable error; error detail is attached.\n",
+      "enum": [
+        "COMPLETED",
+        "CONFIRMED",
+        "EXECUTING",
+        "FAILED"
+      ],
       "title": "Domain Operation Status",
       "type": "string"
     },
     "DomainOperationType": {
       "description": "The type of asynchronous domain operation. Used to distinguish which workflow is being polled on the /operations/{operationId} endpoint. REGISTER — new domain registration.\n",
+      "enum": [
+        "REGISTER"
+      ],
       "title": "Domain Operation Type",
       "type": "string"
     },
     "DomainStatus": {
-      "description": "The lifecycle status of a registered domain. Reflects the domain's current operational state within the registry and GoDaddy's management layer. ACTIVE — domain is registered and is active. CANCELLED — domain has been cancelled by the user or system, and is not reclaimable. DELETED_REDEEMABLE — domain is in ICANN redemption grace period; recovery fees apply. EXPIRED — registration period has ended; domain is pending deletion or redemption. FAILED - domain registration or transfer error. HELD_REGISTRAR - domain is held at the registrar and cannot be transferred or modified - this is usually the result of a dispute. LOCKED_REGISTRAR — domain is locked at the registrar - this is usually the result of spam, abuse, etc. OWNERSHIP_CHANGED - domain has been moved to another account. PARKED - domain has been parked. PENDING_REGISTRATION - domain is pending setup at the registry. PENDING_TRANSFER — an outbound transfer to another registrar is in progress. REPOSSESSED - domain has been confiscated - this is usually the result of a chargeback, fraud, abuse, etc. SUSPENDED — domain has been administratively suspended by the registry or registrar. TRANSFERRED - domain has been transferred to another registrar.\n",
+      "description": "The lifecycle status of a registered domain. Reflects the domain's current operational state within the registry and GoDaddy's management layer. ACTIVE — domain is registered and is active. CANCELLED — domain has been cancelled by the user or system, and is not be reclaimable. DELETED_REDEEMABLE — domain is in ICANN redemption grace period; recovery fees apply. EXPIRED — registration period has ended; domain is pending deletion or redemption. FAILED - domain registration or transfer error. HELD_REGISTRAR - domain is held at the registrar and cannot be transferred or modified - this is usually the result of a dispute. LOCKED_REGISTRAR — domain is locked at the registrar - this is usually the result of a spam, abuse, etc. OWNERSHIP_CHANGED - domain has been moved to another account. PARKED - domain has been parked. PENDING_REGISTRATION - domain is pending setup at the registry. PENDING_TRANSFER — an outbound transfer to another registrar is in progress. REPOSSESSED - domain has been confiscated - this is usually the result of a chargeback, fraud, abuse, etc. SUSPENDED — domain has been administratively suspended by the registry or registrar. TRANSFERRED - domain has been transferred to another registrar.\n",
       "enum": [
         "ACTIVE",
         "CANCELLED",
@@ -758,7 +785,7 @@
               "$ref": "#/$defs/Consent"
             }
           ],
-          "description": "The customer's consent record for the legal agreements returned in the quote. Must reference the same agreementTypes as the quote.\n"
+          "description": "The customer's consent for the legal agreements returned in the quote. On execute, supply agreementTypes and agreedAt; agreedBy is server-derived and returned on the persisted record.\n"
         },
         "createdAt": {
           "allOf": [
@@ -801,6 +828,11 @@
           "example": "9f1c2e7a-4b3d-4e8f-a1c2-3d4e5f6a7b8c",
           "readOnly": true
         },
+        "orderId": {
+          "description": "The orderId of the order that created this registration. Present only when the registration is completed. Not present for failed or pending registrations.\n",
+          "readOnly": true,
+          "type": "string"
+        },
         "period": {
           "default": 1,
           "description": "Registration period in years. Must match the period in the quote.",
@@ -808,6 +840,15 @@
           "maximum": 10,
           "minimum": 1,
           "type": "integer"
+        },
+        "price": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/simple-money"
+            }
+          ],
+          "description": "The locked registration price for the quoted period. Held for the duration of the quoteToken's TTL. Represents the total amount that will be charged on execute.\n",
+          "readOnly": true
         },
         "profile": {
           "allOf": [
@@ -1721,7 +1762,7 @@
       "type": "string"
     }
   },
-  "baseUrl": "https://api.ote-godaddy.com",
+  "baseUrl": "https://api.godaddy.com",
   "description": "The GoDaddy Domain Lifecycle Management API provides comprehensive capabilities\nfor discovering, registering, managing, renewing, transferring, and reselling\ndomain names. This is major version 3, designed for agent-first interactions\nwhile remaining fully usable by direct API clients and resellers.\n\n## Namespace\n\nAll paths are under `/v3/domains/`. The namespace is `domains` (the business capability);\nthe core entity collection is `/domain-names`.\n\n## Key Conventions\n\n**Quote/execute for commercial operations.** Every commercial mutation (register,\nrenew, transfer) requires a `quoteToken` minted by the corresponding quote\ncollection endpoint. Execution without a prior quote is structurally impossible.\nThe token locks the price, resolved settings, and required legal agreements for a\n10-minute TTL. Quote calls are free, read-only, and safe to call speculatively.\n\n**Async commercial operations.** `POST /registrations`, `POST /renewals`, and\n`POST /transfers` each return `202 Accepted` with the concrete entity body\n(`Registration`, `Renewal`, or `Transfer`) and a `Location` header. Poll\n`links[rel=self]` on the returned entity until status is `COMPLETED` or `FAILED`.\nEach concrete resource is also reachable via `GET /operations/{operationId}`;\nthe `operationId` is included in the entity for clients that prefer the abstract\nview. Non-commercial mutations return a `DomainOperation` body.\n\n**Entity-oriented resource model.** Domains are the core entity of this API\n(exposed as `/domain-names` in the path to distinguish the resource collection\nfrom the `domains` namespace prefix). Register, renew, and transfer are\ncommercial actions executed by `POST` to their corresponding top-level\nresource collections (`/registrations`, `/renewals`, `/transfers`); each\naccepts a prior quote and returns an async entity to poll until completion.\nFor commercial execute calls, the target domain is\nexpressed in the request body, not the path. Sub-resources (`contacts`,\n`nameservers`, `privacy`, `auto-renew`, `transfer-lock`, `records`) only exist\nin the context of a specific domain-name instance. The `/check-availability`\ncontroller accepts GET (single domain) or POST (1–50 domains) and carries no\npersistent identity.\n\n**Flat, two-level maximum.** No resource path goes deeper than\n`/{collection}/{id}/{sub-resource}` or `/{collection}/{id}/{sub-collection}/{id}`.\n\n**Reseller on-behalf-of.** Resellers pass `X-Shopper-Id`; all operations are\nthen scoped to that shopper. Absent the header, the authenticated entity's own\naccount is used.\n\n## Launch Scope (v3.0)\nStandard TLDs only. TLDs with eligibility requirements (.us, .ca, .eu) return\n`UNSUPPORTED_TLD` until Phase 2.\n",
   "endpoints": [
     {
@@ -2933,5 +2974,5 @@
   ],
   "name": "domains",
   "title": "Domain Lifecycle Management API",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/rust/schemas/api/fulfillments.json
+++ b/rust/schemas/api/fulfillments.json
@@ -641,6 +641,51 @@
       "minLength": 20,
       "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
       "type": "string"
+    },
+    "link-description": {
+      "$id": "https://godaddy.com/schema/common/link-description.v1",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A request-related [HATEOAS link](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-hyperschema-02).",
+      "properties": {
+        "href": {
+          "description": "The complete target URL, or link, to use in combination with the method to make the related call, as defined by [RFC 6570 - URI Template](https://tools.ietf.org/html/rfc6570), with the addition of the `$`, `(`, and `)` characters for pre-processing. The `href` is the key HATEOAS component that links a completed call with a subsequent call.",
+          "format": "uri",
+          "type": "string"
+        },
+        "method": {
+          "description": "The method to use to request the link target. For example, for HTTP, this might be `GET` or `DELETE`.",
+          "type": "string"
+        },
+        "rel": {
+          "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which is an identifier for a link that unambiguously describes the semantics of the link. For values, see [Link Relationship Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).",
+          "type": "string"
+        },
+        "submissionMediaType": {
+          "default": "application/json",
+          "description": "The media type with which to submit data with the request.",
+          "type": "string"
+        },
+        "submissionSchema": {
+          "description": "The schema that describes the request data."
+        },
+        "targetMediaType": {
+          "description": "The [RFC 2046-defined media type](https://www.ietf.org/rfc/rfc2046.txt) that describes the link target.",
+          "type": "string"
+        },
+        "targetSchema": {
+          "description": "The schema that describes the link target."
+        },
+        "title": {
+          "description": "The link title.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rel",
+        "href"
+      ],
+      "title": "Link Description",
+      "type": "object"
     }
   },
   "baseUrl": "https://fulfillment.api.commerce.godaddy.com/v1/commerce",
@@ -780,6 +825,169 @@
       },
       "scopes": [],
       "summary": "Retrieve and filter fulfillments"
+    },
+    {
+      "description": "Retrieve fulfillments for a store, either by order ID(s) or by status. At least one of `orderId` or `status` must be provided. When `orderId` is present it takes precedence and `status` is ignored.",
+      "method": "GET",
+      "operationId": "listFulfillments",
+      "parameters": [
+        {
+          "description": "Store ID",
+          "in": "path",
+          "name": "storeId",
+          "required": true,
+          "schema": {
+            "$ref": "#/$defs/FulfillmentPlan"
+          }
+        },
+        {
+          "description": "Order ID or comma-separated list of order IDs (maximum 100) to fetch fulfillments for. Takes precedence over `status` when present.",
+          "in": "query",
+          "name": "orderId",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Filter fulfillments by status. Required when `orderId` is not provided; results are paginated.",
+          "in": "query",
+          "name": "status",
+          "required": false,
+          "schema": {
+            "$ref": "#/$defs/FulfillmentStatus"
+          }
+        },
+        {
+          "description": "Maximum number of results per page. Only applies when querying by `status`. Values above the maximum are capped at 100.",
+          "in": "query",
+          "name": "pageSize",
+          "required": false,
+          "schema": {
+            "default": 50,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Deprecated — use `pageSize` instead. Alias for `pageSize`. Only applies when querying by `status`.",
+          "in": "query",
+          "name": "limit",
+          "required": false,
+          "schema": {
+            "default": 50,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Opaque pagination cursor from `links[rel=next]` of a previous status-query response.",
+          "in": "query",
+          "name": "pageToken",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Deprecated — use `pageToken` instead. Alias for `pageToken`.",
+          "in": "query",
+          "name": "nextToken",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "path": "/stores/{storeId}/fulfillments",
+      "responses": {
+        "200": {
+          "description": "Successfully retrieved fulfillments",
+          "schema": {
+            "properties": {
+              "fulfillments": {
+                "deprecated": true,
+                "description": "Deprecated — use `items` instead. Same data as `items`; will be removed in a future major version.",
+                "items": {
+                  "$ref": "#/$defs/Fulfillment"
+                },
+                "type": "array"
+              },
+              "items": {
+                "description": "List of fulfillments matching the query.",
+                "items": {
+                  "$ref": "#/$defs/Fulfillment"
+                },
+                "type": "array"
+              },
+              "links": {
+                "description": "HATEOAS pagination links. Present only when querying by `status`. `rel=self` (current page); `rel=next` (next page, when more results exist). Omitted for `orderId` queries.",
+                "items": {
+                  "$ref": "#/$defs/link-description"
+                },
+                "readOnly": true,
+                "type": "array"
+              },
+              "nextToken": {
+                "deprecated": true,
+                "description": "Deprecated — use `links[rel=next].href` instead. Opaque pagination cursor. Present only when querying by `status` and more pages remain; omitted (not null) once the results are exhausted.",
+                "type": "string"
+              },
+              "status": {
+                "deprecated": true,
+                "description": "Deprecated — HTTP status code conveys success/failure. Always `success` on 200 responses. Will be removed in a future major version.",
+                "example": "success",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "fulfillments"
+            ],
+            "type": "object"
+          }
+        },
+        "400": {
+          "description": "Malformed or invalid request parameters",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        },
+        "401": {
+          "description": "Authentication info not sent or is invalid",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        },
+        "403": {
+          "description": "Authenticated user is not allowed access",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        },
+        "404": {
+          "description": "Resource not found",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        },
+        "422": {
+          "description": "Application-specific request error",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        },
+        "default": {
+          "description": "Unexpected error",
+          "schema": {
+            "$ref": "#/$defs/Error"
+          }
+        }
+      },
+      "scopes": [],
+      "summary": "List fulfillments for a store"
     },
     {
       "description": "Create a new fulfillment",
@@ -999,5 +1207,5 @@
   ],
   "name": "fulfillments",
   "title": "Fulfillment Service",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/rust/schemas/api/manifest.json
+++ b/rust/schemas/api/manifest.json
@@ -1,115 +1,115 @@
 {
-  "generated": "2026-07-15T11:40:00.622620+00:00",
+  "generated": "2026-07-30T20:05:32.981342381+00:00",
   "domains": {
-    "subscriptions": {
-      "file": "subscriptions.json",
-      "title": "Commerce Subscription API",
-      "endpointCount": 8
-    },
-    "payments": {
-      "file": "payments.json",
-      "title": "Payments API",
-      "endpointCount": 43
-    },
     "transactions": {
       "file": "transactions.json",
       "title": "Transactions API",
       "endpointCount": 17
-    },
-    "orders": {
-      "file": "orders.json",
-      "title": "Order Service",
-      "endpointCount": 15
-    },
-    "recommendations": {
-      "file": "recommendations.json",
-      "title": "GoDaddy Recommendation API",
-      "endpointCount": 1
-    },
-    "price-adjustments": {
-      "file": "price-adjustments.json",
-      "title": "GoDaddy Price Adjustment API",
-      "endpointCount": 10
-    },
-    "catalog-products": {
-      "file": "catalog-products.json",
-      "title": "Catalog GraphQL API",
-      "endpointCount": 1
-    },
-    "onboarding": {
-      "file": "onboarding.json",
-      "title": "Commerce Onboarding API",
-      "endpointCount": 5
-    },
-    "taxes": {
-      "file": "taxes.json",
-      "title": "Tax GraphQL API",
-      "endpointCount": 1
-    },
-    "businesses": {
-      "file": "businesses.json",
-      "title": "Commerce Business API",
-      "endpointCount": 8
-    },
-    "channels": {
-      "file": "channels.json",
-      "title": "Channels API",
-      "endpointCount": 8
-    },
-    "shipping": {
-      "file": "shipping.json",
-      "title": "Shipping Service",
-      "endpointCount": 7
-    },
-    "fulfillments": {
-      "file": "fulfillments.json",
-      "title": "Fulfillment Service",
-      "endpointCount": 3
-    },
-    "chargebacks": {
-      "file": "chargebacks.json",
-      "title": "Chargeback Management",
-      "endpointCount": 10
-    },
-    "metafields": {
-      "file": "metafields.json",
-      "title": "Metafields API",
-      "endpointCount": 12
-    },
-    "payment-requests": {
-      "file": "payment-requests.json",
-      "title": "Payment Requests API",
-      "endpointCount": 5
-    },
-    "location-addresses": {
-      "file": "location-addresses.json",
-      "title": "Addresses API",
-      "endpointCount": 2
-    },
-    "stores": {
-      "file": "stores.json",
-      "title": "Commerce Store API",
-      "endpointCount": 8
-    },
-    "bulk-operations": {
-      "file": "bulk-operations.json",
-      "title": "Bulk Operations API",
-      "endpointCount": 27
     },
     "customer-profiles": {
       "file": "customer-profiles.json",
       "title": "Customers API",
       "endpointCount": 9
     },
+    "orders": {
+      "file": "orders.json",
+      "title": "Order Service",
+      "endpointCount": 15
+    },
+    "onboarding": {
+      "file": "onboarding.json",
+      "title": "Commerce Onboarding API",
+      "endpointCount": 5
+    },
+    "fulfillments": {
+      "file": "fulfillments.json",
+      "title": "Fulfillment Service",
+      "endpointCount": 4
+    },
+    "payments": {
+      "file": "payments.json",
+      "title": "Payments API",
+      "endpointCount": 43
+    },
     "hosting-nodejs": {
       "file": "hosting-nodejs.json",
       "title": "Node.js Hosting Public API",
       "endpointCount": 20
     },
+    "payment-requests": {
+      "file": "payment-requests.json",
+      "title": "Payment Requests API",
+      "endpointCount": 5
+    },
+    "recommendations": {
+      "file": "recommendations.json",
+      "title": "GoDaddy Recommendation API",
+      "endpointCount": 1
+    },
+    "catalog-products": {
+      "file": "catalog-products.json",
+      "title": "Catalog GraphQL API",
+      "endpointCount": 1
+    },
+    "shipping": {
+      "file": "shipping.json",
+      "title": "Shipping Service",
+      "endpointCount": 7
+    },
+    "metafields": {
+      "file": "metafields.json",
+      "title": "Metafields API",
+      "endpointCount": 12
+    },
+    "location-addresses": {
+      "file": "location-addresses.json",
+      "title": "Addresses API",
+      "endpointCount": 2
+    },
+    "price-adjustments": {
+      "file": "price-adjustments.json",
+      "title": "GoDaddy Price Adjustment API",
+      "endpointCount": 10
+    },
+    "chargebacks": {
+      "file": "chargebacks.json",
+      "title": "Chargeback Management",
+      "endpointCount": 10
+    },
+    "channels": {
+      "file": "channels.json",
+      "title": "Channels API",
+      "endpointCount": 8
+    },
+    "stores": {
+      "file": "stores.json",
+      "title": "Commerce Store API",
+      "endpointCount": 8
+    },
     "domains": {
       "file": "domains.json",
       "title": "Domain Lifecycle Management API",
       "endpointCount": 14
+    },
+    "bulk-operations": {
+      "file": "bulk-operations.json",
+      "title": "Bulk Operations API",
+      "endpointCount": 27
+    },
+    "businesses": {
+      "file": "businesses.json",
+      "title": "Commerce Business API",
+      "endpointCount": 8
+    },
+    "subscriptions": {
+      "file": "subscriptions.json",
+      "title": "Commerce Subscription API",
+      "endpointCount": 8
+    },
+    "taxes": {
+      "file": "taxes.json",
+      "title": "Tax GraphQL API",
+      "endpointCount": 1
     }
   }
 }

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -159,10 +159,14 @@ const DOMAIN_FILES: &[(&str, &str)] = &[
 
 fn catalog() -> &'static [Domain] {
     CATALOG.get_or_init(|| {
-        DOMAIN_FILES
+        let mut domains: Vec<Domain> = DOMAIN_FILES
             .iter()
             .filter_map(|(_, src)| serde_json::from_str::<Domain>(src).ok())
-            .collect()
+            .collect();
+        // Sorted once here (not per-listing) so every consumer — `api domain
+        // list`, `api search`, `api describe` — sees the same stable order.
+        domains.sort_by(|a, b| a.name.cmp(&b.name));
+        domains
     })
 }
 
@@ -327,17 +331,22 @@ fn domain_list_command() -> RuntimeCommandSpec {
             .no_auth(true)
             .with_default_fields("domain,title,endpoints,baseUrl")
             .with_output_schema::<ApiDomain>(),
-        |_ctx| async move {
+        |ctx| async move {
             let catalog = catalog();
             let domains: Vec<Value> = catalog
                 .iter()
                 .map(|d| {
+                    let base_url = crate::environments::resolve_catalog_base_url(
+                        &d.name,
+                        &d.base_url,
+                        &ctx.middleware.env,
+                    );
                     json!({
                         "domain": d.name,
                         "title": d.title,
                         "description": d.description,
                         "endpoints": d.endpoints.len(),
-                        "baseUrl": d.base_url,
+                        "baseUrl": base_url,
                     })
                 })
                 .collect();
@@ -643,18 +652,28 @@ fn call_command() -> RuntimeCommandSpec {
                 .with_dry_run());
             }
 
-            // Required scopes = explicit --scope flags, plus the matched catalog
-            // endpoint's declared scopes (best-effort: a concrete request path
-            // may not match a templated catalog path, in which case only --scope
-            // contributes). These drive OAuth scope step-up at credential time.
+            // Best-effort match against the embedded catalog: a concrete request
+            // path may not match a templated catalog path, in which case scopes
+            // fall back to just --scope and the base URL falls back to the
+            // generic gateway host.
+            let matched = find_endpoint(catalog(), endpoint);
+
+            // Required scopes = explicit --scope flags, plus the matched
+            // endpoint's declared scopes. These drive OAuth scope step-up at
+            // credential time.
             let flag_scopes = string_list(&ctx.args, "scope");
-            let endpoint_scopes = find_endpoint(catalog(), endpoint)
-                .map(|(_, ep)| ep.scopes.as_slice())
-                .unwrap_or(&[]);
+            let endpoint_scopes = matched.map(|(_, ep)| ep.scopes.as_slice()).unwrap_or(&[]);
             let required = merge_required_scopes(flag_scopes, endpoint_scopes);
 
             let token = ctx.credential_with_scopes(&required).await?.token;
-            let base_url = crate::application::client::api_url_for_env(&ctx.middleware.env);
+            let base_url = match matched {
+                Some((domain, _)) => crate::environments::resolve_catalog_base_url(
+                    &domain.name,
+                    &domain.base_url,
+                    &ctx.middleware.env,
+                ),
+                None => crate::application::client::api_url_for_env(&ctx.middleware.env),
+            };
             let url = format!("{base_url}{endpoint}");
 
             // Build request body: -F file > -d body, then merge -f fields on top
@@ -881,6 +900,40 @@ mod tests {
             merge_required_scopes(v(&["commerce.order:write"]), &endpoint.scopes),
             v(&["commerce.order:write", "commerce.order:read"]),
         );
+    }
+
+    /// `catalog()` sorts once so every listing (`api domain list`, `api
+    /// search`, `api describe`) sees the same stable, alphabetical order.
+    #[test]
+    fn catalog_domains_are_sorted_alphabetically() {
+        let names: Vec<&str> = catalog().iter().map(|d| d.name.as_str()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    /// Mirrors `call_command`'s domain-aware base-URL resolution: a matched
+    /// catalog endpoint resolves through its own domain's host (not the
+    /// generic gateway), with per-environment convention substitution.
+    #[test]
+    fn matched_endpoint_resolves_its_own_domain_base_url() {
+        let (domain, _) = find_endpoint(catalog(), "listFulfillments")
+            .expect("listFulfillments exists in the embedded catalog");
+        assert_eq!(domain.name, "fulfillments");
+        let base_url =
+            crate::environments::resolve_catalog_base_url(&domain.name, &domain.base_url, "ote");
+        assert_eq!(
+            base_url,
+            "https://fulfillment.api.commerce.ote-godaddy.com/v1/commerce"
+        );
+    }
+
+    /// An endpoint the catalog doesn't recognize has no domain to resolve a
+    /// base URL against — `call_command` falls back to the generic gateway
+    /// host in this case.
+    #[test]
+    fn unmatched_endpoint_has_no_domain_to_resolve_against() {
+        assert!(find_endpoint(catalog(), "not-a-real-operation-id").is_none());
     }
 
     #[test]

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -638,6 +638,20 @@ fn call_command() -> RuntimeCommandSpec {
                     .into_cli_error()
             })?;
 
+            // Validate unconditionally, including under `--dry-run` (same
+            // rationale as the method check above). `find_endpoint` below can
+            // match a raw operationId, but the request URL is always built
+            // from this literal `endpoint` string, not the matched catalog
+            // path — accepting a bare operationId here would silently build
+            // an invalid URL (e.g. `https://.../listFulfillments`).
+            if !endpoint.starts_with('/') {
+                return Err(crate::error::GddyError::validation(format!(
+                    "endpoint must be a URL path starting with '/', not {endpoint:?} — \
+                     use `api describe {endpoint}` to find the concrete path"
+                ))
+                .into_cli_error());
+            }
+
             // `--dry-run` is statically tagged `Tier::Mutate` since the method
             // is only known at runtime, but a GET/HEAD is safe to actually run
             // (and more useful previewed as real data than as a generic
@@ -1082,6 +1096,34 @@ mod tests {
         assert_ne!(output.exit_code, 0, "{}", output.rendered);
         assert!(
             output.rendered.contains("invalid HTTP method"),
+            "{}",
+            output.rendered
+        );
+    }
+
+    /// A bare operationId (no leading '/') must be rejected rather than
+    /// silently built into an invalid request URL — `find_endpoint` can match
+    /// it for scope lookup, but the URL is always built from the literal
+    /// `endpoint` string, not the matched catalog path.
+    #[tokio::test]
+    async fn call_rejects_an_endpoint_without_a_leading_slash() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy").with_module(super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "listFulfillments",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            output.rendered.contains("must be a URL path starting with"),
             "{}",
             output.rendered
         );

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -170,12 +170,34 @@ fn catalog() -> &'static [Domain] {
     })
 }
 
+/// True if `concrete`'s path segments structurally match `template`'s: a
+/// `{param}` segment in `template` matches any single non-empty segment in
+/// `concrete` at the same position, every other segment must match
+/// literally (case-insensitive). Matches a real request path with path
+/// params substituted (e.g. `/stores/abc123/orders`) against the catalog's
+/// templated path (`/stores/{storeId}/orders`), which neither exact nor
+/// substring matching can do — a concrete path never literally contains the
+/// `{storeId}` placeholder.
+fn path_matches_template(template: &str, concrete: &str) -> bool {
+    let template_segs: Vec<&str> = template.trim_matches('/').split('/').collect();
+    let concrete_segs: Vec<&str> = concrete.trim_matches('/').split('/').collect();
+    template_segs.len() == concrete_segs.len()
+        && template_segs
+            .iter()
+            .zip(concrete_segs.iter())
+            .all(|(t, c)| {
+                (t.starts_with('{') && t.ends_with('}') && !c.is_empty())
+                    || t.eq_ignore_ascii_case(c)
+            })
+}
+
 fn find_endpoint<'a>(catalog: &'a [Domain], query: &str) -> Option<(&'a Domain, &'a Endpoint)> {
     let q = query.to_lowercase();
     catalog.iter().find_map(|domain| {
         domain.endpoints.iter().find_map(|ep| {
             if ep.operation_id.to_lowercase() == q
                 || ep.path.to_lowercase() == q
+                || path_matches_template(&ep.path, query)
                 || ep.path.to_lowercase().contains(&q)
             {
                 Some((domain, ep))
@@ -940,6 +962,18 @@ mod tests {
             base_url,
             "https://fulfillment.api.commerce.ote-godaddy.com/v1/commerce"
         );
+    }
+
+    /// A real request path with path params substituted (as `api call`
+    /// receives — no user passes a literal `{storeId}`) must still match its
+    /// templated catalog path, or every parameterized endpoint would fall
+    /// back to the wrong (generic gateway) base URL and lose scope lookup.
+    #[test]
+    fn concrete_path_matches_its_templated_catalog_path() {
+        let (domain, endpoint) = find_endpoint(catalog(), "/stores/abc123/fulfillments")
+            .expect("concrete path should match the templated catalog path");
+        assert_eq!(domain.name, "fulfillments");
+        assert_eq!(endpoint.operation_id, "listFulfillments");
     }
 
     /// An endpoint the catalog doesn't recognize has no domain to resolve a

--- a/rust/src/environments/mod.rs
+++ b/rust/src/environments/mod.rs
@@ -118,12 +118,82 @@ pub fn env_prefix(name: &str) -> String {
 }
 
 fn derive_account_url(env_name: &str) -> String {
-    let host = if env_name == "prod" {
-        "account.godaddy.com".to_owned()
+    if env_name == "prod" {
+        return "https://account.godaddy.com".to_owned();
+    }
+    substitute_env_host("https://account.godaddy.com", env_name)
+        .unwrap_or_else(|| "https://account.godaddy.com".to_owned())
+}
+
+/// Applies GoDaddy's internal-environment hostname convention
+/// (`{env}-godaddy.com`) to a canonical `*.godaddy.com` URL, preserving any
+/// subdomain prefix and the original scheme/path. Returns `None` if the
+/// host isn't under `godaddy.com` — nothing to substitute.
+fn substitute_env_host(url: &str, env_name: &str) -> Option<String> {
+    let lower = url.to_ascii_lowercase();
+    let scheme_len = if lower.starts_with("https://") {
+        8
+    } else if lower.starts_with("http://") {
+        7
     } else {
-        format!("account.{env_name}-godaddy.com")
+        return None;
     };
-    format!("https://{host}")
+    let rest = &url[scheme_len..];
+    let host_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let host = &rest[..host_end];
+    let host_lower = host.to_ascii_lowercase();
+    let new_host = if host_lower == "godaddy.com" {
+        format!("{env_name}-godaddy.com")
+    } else {
+        let prefix = host_lower.strip_suffix(".godaddy.com")?;
+        format!("{}.{env_name}-godaddy.com", &host[..prefix.len()])
+    };
+    Some(format!(
+        "{}{}{}",
+        &url[..scheme_len],
+        new_host,
+        &rest[host_end..]
+    ))
+}
+
+/// Resolve the environment-specific base URL for a catalog domain (used by
+/// `api domain list` / `api call`). Checks an explicit override first — a
+/// `<domain>_api_url` key from local config, or a `<PREFIX>_<DOMAIN>_API_URL`
+/// env var read directly here (not through cli-engine's `apply_env_vars`,
+/// which only overrides an extra key already present after the compiled+file
+/// layers merge — see the module doc; gddy's `register()` never pre-seeds
+/// per-domain override keys on the compiled builtins). Checking the env var
+/// directly makes this work uniformly for `prod`/`ote` builtins and custom
+/// dev/test env names alike. Absent an override, falls back to GoDaddy's
+/// `{env}-godaddy.com` hostname convention against `prod_base_url` for any
+/// non-`prod` environment.
+pub fn resolve_catalog_base_url(domain: &str, prod_base_url: &str, env_name: &str) -> String {
+    let override_key = format!("{}_api_url", domain.replace('-', "_"));
+    if let Some(url) = domain_override(&override_key, env_name, |k| std::env::var(k).ok()) {
+        return url;
+    }
+    if env_name == DEFAULT_ENV {
+        return prod_base_url.to_owned();
+    }
+    substitute_env_host(prod_base_url, env_name).unwrap_or_else(|| prod_base_url.to_owned())
+}
+
+/// Pure lookup for [`resolve_catalog_base_url`]'s override, with the env-var
+/// getter injected so tests stay parallel-safe (no real `std::env::set_var`),
+/// matching [`resolve_from_env_var_only`]'s pattern.
+fn domain_override(
+    override_key: &str,
+    env_name: &str,
+    var: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    if let Ok(env) = instance().resolve(env_name)
+        && let Some(v) = env.extra.get(override_key)
+        && let Some(clean) = clean_url(v)
+    {
+        return Some(clean);
+    }
+    let var_name = format!("{}_{}", env_prefix(env_name), override_key.to_uppercase());
+    var(&var_name).and_then(|v| clean_url(&v))
 }
 
 fn derive_auth_url(api_url: &str) -> String {
@@ -617,6 +687,82 @@ mod tests {
         );
         let resolved = adapt("dev", env).expect("adapts");
         assert_eq!(resolved.account_url, "https://account.override.test");
+    }
+
+    #[test]
+    fn substitute_env_host_prefixes_a_bare_domain() {
+        assert_eq!(
+            substitute_env_host("https://godaddy.com", "ote"),
+            Some("https://ote-godaddy.com".to_owned())
+        );
+    }
+
+    #[test]
+    fn substitute_env_host_preserves_subdomain_and_path() {
+        assert_eq!(
+            substitute_env_host(
+                "https://fulfillment.api.commerce.godaddy.com/v1/commerce",
+                "dev"
+            ),
+            Some("https://fulfillment.api.commerce.dev-godaddy.com/v1/commerce".to_owned())
+        );
+    }
+
+    #[test]
+    fn substitute_env_host_returns_none_for_non_godaddy_host() {
+        assert_eq!(substitute_env_host("https://example.com/v1", "ote"), None);
+    }
+
+    #[test]
+    fn domain_override_falls_back_to_env_var_when_no_local_config_entry() {
+        // "fulfillments-catalog-test" is not a compiled builtin and has no
+        // local config entry, so the first (local-config) branch misses and
+        // the injected var getter is consulted directly.
+        let var = |k: &str| {
+            (k == "FULFILLMENTS_CATALOG_TEST_FULFILLMENTS_API_URL")
+                .then(|| "https://fulfillments.example.test".to_owned())
+        };
+        let resolved = domain_override("fulfillments_api_url", "fulfillments-catalog-test", var);
+        assert_eq!(
+            resolved,
+            Some("https://fulfillments.example.test".to_owned())
+        );
+    }
+
+    #[test]
+    fn domain_override_is_none_when_neither_layer_has_it() {
+        let resolved = domain_override("fulfillments_api_url", "fulfillments-catalog-test", |_| {
+            None
+        });
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_catalog_base_url_returns_prod_unchanged() {
+        let url = resolve_catalog_base_url(
+            "fulfillments",
+            "https://fulfillment.api.commerce.godaddy.com/v1/commerce",
+            "prod",
+        );
+        assert_eq!(
+            url,
+            "https://fulfillment.api.commerce.godaddy.com/v1/commerce"
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_base_url_applies_convention_for_non_prod() {
+        // No override exists anywhere for this made-up env/domain pair, so
+        // this exercises the `{env}-godaddy.com` convention fallback.
+        let url = resolve_catalog_base_url(
+            "fulfillments",
+            "https://fulfillment.api.commerce.godaddy.com/v1/commerce",
+            "ote",
+        );
+        assert_eq!(
+            url,
+            "https://fulfillment.api.commerce.ote-godaddy.com/v1/commerce"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Regenerates the embedded API catalog (`domains.json`, `fulfillments.json`) to resync with upstream specs — the local `domains` spec was already at v3.1.0 but never regenerated, and `commerce.fulfillments-specification` merged a new `listFulfillments` endpoint (v1.2.0) that was never picked up. See the failed [catalog-drift run](https://github.com/godaddy/cli/actions/runs/30562742943/job/90939630686).
- Normalizes the vendored `domains` spec's host to production (`api.godaddy.com`) instead of OTE, consistent with every other catalog domain's `baseUrl`.
- Sorts `api domain list` alphabetically instead of following `api-catalog-sources.json` insertion order.
- Generalizes the environment-aware base-URL override that already existed for the real `domain` commands (`environments::resolve_domains`) to every catalog domain via `environments::resolve_catalog_base_url` — checks an explicit per-domain override, otherwise applies GoDaddy's `{env}-godaddy.com` hostname convention. Wired into both `api domain list` (display) and `api call` (actual request routing).
- `api call` now rejects an `endpoint` argument that doesn't start with `/` (e.g. a bare operationId) up front, instead of silently building an invalid request URL.
- `find_endpoint` now also matches a concrete request path with path params substituted (e.g. `/stores/abc123/orders`) against the catalog's templated path (`/stores/{storeId}/orders`) — previously neither exact nor substring matching could do this, so every parameterized endpoint silently fell back to the wrong base URL and lost scope auto-detection. (Caught by Copilot review; the last two items above are its fixes.)

## Test plan

- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo test` (405 passing) / `cargo fmt --check` all pass
- [x] `cargo test -p generate-api-catalog` — structural drift guard passes against the regenerated catalog
- [x] Reproduced the drift locally with a real `GITHUB_TOKEN` and confirmed it matches CI's diff exactly (267 insertions / 18 deletions across `domains.json` + `fulfillments.json`)
- [x] Manually verified `cargo run -- api domain list --env {prod,ote,test}` resolves correct per-domain, per-environment hosts (e.g. `fulfillments` → `fulfillment.api.commerce.test-godaddy.com` under `test`) and alphabetical ordering
- [x] `api call`'s routing covered by unit tests mirroring the `find_endpoint` + `resolve_catalog_base_url` composition it uses, including the new concrete-path-vs-template matching (no existing httpmock harness for its real HTTP path to extend)
- [x] Copilot review: 4 comments across 2 rounds, all addressed (2 fixed with new commits + tests, 2 explained — one mirrors upstream vendored spec content, one is a pre-existing `$defs` key-naming quirk in `generate-api-catalog` unrelated to this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)