### PR TITLE
fix(cli): drop experimental platform suggestion, fix stale --search doc

### DIFF
--- a/.agents/skills/gddy/README.md
+++ b/.agents/skills/gddy/README.md
@@ -1,6 +1,6 @@
 # gddy skill
 
-Teaches an AI coding agent how to drive `gddy`, GoDaddy's beta CLI for domain search, registration, and DNS management. It covers install/auth, the two-step quote-then-purchase flow for buying a domain, DNS record semantics (`add` vs `set` vs `delete`), and how to use the CLI's own self-documentation (`--help`, `--search`, `tree`, `guide`) to stay current as `gddy` evolves.
+Teaches an AI coding agent how to drive `gddy`, GoDaddy's beta CLI for domain search, registration, and DNS management. It covers install/auth, the two-step quote-then-purchase flow for buying a domain, DNS record semantics (`add` vs `set` vs `delete`), and how to use the CLI's own self-documentation (`--help`, `search`, `tree`, `guide`) to stay current as `gddy` evolves.
 
 See [SKILL.md](./SKILL.md) for the full instructions given to the agent.
 

--- a/.agents/skills/gddy/SKILL.md
+++ b/.agents/skills/gddy/SKILL.md
@@ -31,7 +31,7 @@ Verify that installation works by running `gddy --version`.
 The `gddy` CLI is self-documenting. Use the following to get more information about its capabilities:
 
 - The `--help` flag will give you detailed documentation on any command.
-- `gddy --search <keywords>` will help you find a command.
+- `gddy search <keywords>` will help you find a command.
 - The `gddy tree` command will give you a full listing of all commands.
 - The `gddy guide` command lets you view detailed documentation that explains concepts and outlines complex workflows.
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -87,7 +87,6 @@ async fn main() -> ExitCode {
                 vec![
                     next_action("auth status", "Check authentication status"),
                     next_action("env get", "Get the current active environment"),
-                    next_action("platform app list", "List all platform apps"),
                     next_action("tree", "Display the full command tree"),
                 ]
             }))


### PR DESCRIPTION
## Summary
- Remove `platform app list` from the root `next_actions` list — `platform` is gated behind `Stage::Experimental` and hidden at the default `Ga` min-stage, but this suggestion surfaced unconditionally for everyone.
- Fix the `gddy` skill docs (`SKILL.md`, `README.md`), which still referenced the removed `--search` global flag instead of the `search <query...>` subcommand introduced in cli-engine 0.5.0.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo fmt --check`