### PR TITLE
fix: restore Claude Code plugin marketplace for gddy skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "godaddy",
+  "owner": {
+    "name": "GoDaddy",
+    "email": "oss@godaddy.com"
+  },
+  "description": "Skills for using GoDaddy's command-line tools with an AI coding agent.",
+  "plugins": [
+    {
+      "name": "gddy",
+      "source": "./plugins/gddy",
+      "description": "Skill for using GoDaddy's gddy CLI — domain search, registration, and DNS management.",
+      "author": {
+        "name": "GoDaddy"
+      }
+    }
+  ]
+}

--- a/plugins/gddy/.claude-plugin/plugin.json
+++ b/plugins/gddy/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "gddy",
+  "description": "Skill for using GoDaddy's gddy CLI — domain search, registration, and DNS management.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GoDaddy"
+  }
+}

--- a/plugins/gddy/skills/gddy
+++ b/plugins/gddy/skills/gddy
@@ -1,0 +1,1 @@
+../../../.agents/skills/gddy


### PR DESCRIPTION
## Summary
- Restores `.claude-plugin/marketplace.json` and `plugins/gddy/.claude-plugin/plugin.json`, plus the `plugins/gddy/skills/gddy` symlink into `.agents/skills/gddy`.
- These were dropped in `4dd988a` on the old TypeScript-CLI branch on the assumption they already existed on `rust-port` — they never did, so when `rust-port` was renamed to `main` during the branch swap, the marketplace files were lost entirely.
- `.agents/skills/gddy/README.md` still documents `claude plugin marketplace add godaddy/cli` / `claude plugin install gddy@godaddy`, which requires these files to be present at the repo root.

## Test plan
- [x] Restored file contents match the original addition in `a2eb44a` (`Add Claude Code plugin marketplace and agent skill for the gddy CLI (#104)`)
- [x] Symlink `plugins/gddy/skills/gddy` resolves to `.agents/skills/gddy/SKILL.md`
- [ ] `claude plugin marketplace add godaddy/cli` / `claude plugin install gddy@godaddy` works end-to-end once merged to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)