### PR TITLE
fix: Node.js Hosting CLI deployments --limit flag typing issue

### DIFF
--- a/rust/src/hosting/nodejs/mod.rs
+++ b/rust/src/hosting/nodejs/mod.rs
@@ -63,9 +63,9 @@ fn optional_u32(ctx: &CommandContext, key: &str) -> Option<u32> {
         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
 }
 
-/// Local override of the engine's global `--limit` is typed `i64` to match it.
-/// Only forward API-valid values (1..=50); missing/`<=0` omit the query param
-/// so the server applies its default (20).
+/// Turns `--limit` into the deployments query param. Missing or non-positive
+/// values are omitted so the global flag's default of 0 is never sent. The API
+/// accepts 1-50 and defaults to 20 when the param is absent.
 fn optional_api_limit(ctx: &CommandContext) -> Option<u32> {
     api_limit_from_value(ctx.args.get("limit"))
 }
@@ -427,14 +427,9 @@ fn deployment_list_command() -> RuntimeCommandSpec {
                     .help("Application ID"),
             )
             .with_arg(
-                // Local override of the engine's global `--limit`, typed
-                // `i64` to match it: clap's `global(true)` propagates a
-                // parsed value up into every ancestor `ArgMatches` under the
-                // shared `"limit"` id, and cli-engine's global-flag parsing
-                // always reads the root value back out as `i64` — a
-                // differently-typed local override (e.g. `u32`) panics there
-                // with a downcast mismatch. `allow_negative_numbers` lets a
-                // negative value reach the range check below.
+                // Must be i64 because this shares an id with the global `--limit`,
+                // which the engine always reads as i64. Using u32 here panics on
+                // downcast.
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_name("N")
@@ -1110,8 +1105,7 @@ mod tests {
     };
     use serde_json::json;
 
-    /// Builds a standalone `clap::Command` from the real `--limit` arg
-    /// definition so range validation exercises the shipped arg, not a copy.
+    /// Builds a clap command from the real `--limit` arg rather than a hand-rolled copy.
     fn deployment_list_clap_command() -> clap::Command {
         clap::Command::new("list").args(deployment_list_command().spec.args)
     }
@@ -1141,8 +1135,7 @@ mod tests {
 
     #[test]
     fn api_limit_from_value_omits_missing_and_non_positive() {
-        // Safety net: global `--limit` defaults to 0; never forward that
-        // (or negatives) as the hosting deployments query param.
+        // The global `--limit` defaults to 0, which must not be forwarded to the API.
         assert_eq!(api_limit_from_value(None), None);
         assert_eq!(api_limit_from_value(Some(&json!(0))), None);
         assert_eq!(api_limit_from_value(Some(&json!(-1))), None);

--- a/rust/src/hosting/nodejs/mod.rs
+++ b/rust/src/hosting/nodejs/mod.rs
@@ -63,6 +63,19 @@ fn optional_u32(ctx: &CommandContext, key: &str) -> Option<u32> {
         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
 }
 
+/// Local override of the engine's global `--limit` is typed `i64` to match it.
+/// Only forward API-valid values (1..=50); missing/`<=0` omit the query param
+/// so the server applies its default (20).
+fn optional_api_limit(ctx: &CommandContext) -> Option<u32> {
+    api_limit_from_value(ctx.args.get("limit"))
+}
+
+fn api_limit_from_value(v: Option<&Value>) -> Option<u32> {
+    v.and_then(|v| v.as_i64())
+        .filter(|&n| n >= 1)
+        .and_then(|n| u32::try_from(n).ok())
+}
+
 /// Whether a zip-upload or git-import job status is terminal (no further polling).
 fn is_source_job_terminal(status: &str) -> bool {
     matches!(status, "complete" | "failed")
@@ -414,15 +427,24 @@ fn deployment_list_command() -> RuntimeCommandSpec {
                     .help("Application ID"),
             )
             .with_arg(
+                // Local override of the engine's global `--limit`, typed
+                // `i64` to match it: clap's `global(true)` propagates a
+                // parsed value up into every ancestor `ArgMatches` under the
+                // shared `"limit"` id, and cli-engine's global-flag parsing
+                // always reads the root value back out as `i64` — a
+                // differently-typed local override (e.g. `u32`) panics there
+                // with a downcast mismatch. `allow_negative_numbers` lets a
+                // negative value reach the range check below.
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_name("N")
-                    .value_parser(clap::value_parser!(u32).range(1..=50))
+                    .allow_negative_numbers(true)
+                    .value_parser(clap::value_parser!(i64).range(1..=50))
                     .help("Maximum deployments to return (1-50)"),
             ),
         |ctx| async move {
             let app_id = required_str(&ctx, "app-id", "--app-id")?;
-            let limit = optional_u32(&ctx, "limit");
+            let limit = optional_api_limit(&ctx);
             let client = make_client(&ctx, &[APPS_READ]).await?;
             let data = client
                 .list_deployments(&app_id, limit)
@@ -1082,8 +1104,51 @@ fn logs_command() -> RuntimeCommandSpec {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_app_creation_job_terminal, is_source_job_terminal, promote_job_fields};
+    use super::{
+        api_limit_from_value, deployment_list_command, is_app_creation_job_terminal,
+        is_source_job_terminal, promote_job_fields,
+    };
     use serde_json::json;
+
+    /// Builds a standalone `clap::Command` from the real `--limit` arg
+    /// definition so range validation exercises the shipped arg, not a copy.
+    fn deployment_list_clap_command() -> clap::Command {
+        clap::Command::new("list").args(deployment_list_command().spec.args)
+    }
+
+    #[test]
+    fn limit_rejects_out_of_range_and_negative_values() {
+        for bad in ["0", "51", "-1"] {
+            let err = deployment_list_clap_command()
+                .try_get_matches_from(["list", "--app-id", "app-1", "--limit", bad])
+                .expect_err("out-of-range --limit should be rejected");
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "--limit {bad} should fail range validation, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn limit_accepts_the_full_valid_range() {
+        for good in ["1", "50"] {
+            deployment_list_clap_command()
+                .try_get_matches_from(["list", "--app-id", "app-1", "--limit", good])
+                .expect("value within the valid --limit range should be accepted");
+        }
+    }
+
+    #[test]
+    fn api_limit_from_value_omits_missing_and_non_positive() {
+        // Safety net: global `--limit` defaults to 0; never forward that
+        // (or negatives) as the hosting deployments query param.
+        assert_eq!(api_limit_from_value(None), None);
+        assert_eq!(api_limit_from_value(Some(&json!(0))), None);
+        assert_eq!(api_limit_from_value(Some(&json!(-1))), None);
+        assert_eq!(api_limit_from_value(Some(&json!(1))), Some(1));
+        assert_eq!(api_limit_from_value(Some(&json!(50))), Some(50));
+    }
 
     #[test]
     fn source_job_terminal_status_detection() {


### PR DESCRIPTION
## Summary

Local `deployments --limit` flag was typed as u32, but cli-engine’s global `--limit` is i64. They used the same arg id but were different types, so clap was panicking on downcast. The fix is to parse it as an i64 like `domain suggest`.

## Testing Output

```bash
GDDY_MIN_STAGE=beta ./target/debug/gddy hosting nodejs deployment list --app-id <redacted> --limit 50

deployments: {"createdAt":"2026-07-07T10:20:29Z","gitHash":"<redacted>","id":"<redacted>","status":"deployed","updatedAt":"2026-07-07T10:20:37Z"}
hasMore: no
totalCount: 1

Next steps:
  gddy hosting nodejs deployment publish --app-id <redacted>
      Publish the latest source
```

