### PR TITLE
fix(auth): report per-environment status and refresh-token availability

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -577,9 +577,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85af64e54dff0f0320cf8a81b83c16f49e3307d1608532b7085b31c665228853"
+checksum = "5cffbb94a18a5e0a604fd7ad837ab5b99b02f84ae3d1ccb6336387cc23c46a7b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.6" }
+cli-engine = { features = ["pkce-auth"], version = "0.7" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -213,19 +213,25 @@ impl AuthProvider for GoDaddyAuthProvider {
     }
 
     async fn list_environments(&self) -> Result<Vec<String>> {
-        // Enumerate stored credentials across built-ins + locally-configured
-        // envs (env-var-only envs are excluded from `listable`, matching the
-        // `env list` contract). `listable` falls back to built-ins on a
-        // malformed local config, so this never fails wholesale.
+        // List every environment that could plausibly have a cached
+        // credential — built-ins + locally-configured envs (env-var-only
+        // envs are excluded from `listable`, matching the `env list`
+        // contract) plus anything with a registered PAT. `listable` falls
+        // back to built-ins on a malformed local config, so this never fails
+        // wholesale.
         //
-        // `PkceAuthProvider::list_environments` only reflects its own
-        // in-memory token cache (keyring/file storage can't be enumerated by
-        // prefix), so a freshly-built provider always returns an empty list
-        // here — this loop is a no-op in practice today, same as before this
-        // module built one provider per call. Kept for whenever cli-engine
-        // gains real storage enumeration.
+        // `PkceAuthProvider::list_environments` can't help here: keyring and
+        // file-fallback storage aren't enumerable by prefix, so it only
+        // reflects its own in-memory token cache — and since `provider_for`
+        // builds a fresh provider per call, that cache is always empty. So
+        // rather than ask providers to enumerate, list every *known*
+        // environment name and let `Dispatcher::all_statuses` call `status`
+        // on each; `status` does read real persisted storage, so a
+        // "not logged in" result there is trustworthy in a way an empty
+        // enumeration result is not.
         let listable = environments::listable()?;
-        let mut envs = std::collections::BTreeSet::new();
+        let mut envs: std::collections::BTreeSet<String> =
+            listable.into_iter().map(|resolved| resolved.name).collect();
         match pat::registry_envs().await {
             Ok(pats) => envs.extend(pats),
             Err(err) => {
@@ -234,10 +240,6 @@ impl AuthProvider for GoDaddyAuthProvider {
                     "failed to load PAT registry while listing environments; continuing"
                 );
             }
-        }
-        for resolved in listable {
-            let provider = build_provider(&resolved);
-            envs.extend(provider.list_environments().await.unwrap_or_default());
         }
         Ok(envs.into_iter().collect())
     }


### PR DESCRIPTION
## Summary
- `gddy auth status` with no `--env` returned an empty array — it enumerated environments via each `PkceAuthProvider`'s in-memory token cache, which is always empty since a fresh provider is built per call. Now lists every known environment (built-ins + locally configured + PAT registry) and lets the dispatcher check status against real persisted storage.
- Bumps `cli-engine` to 0.7, picking up `Credential::refreshable` (godaddy/cli-engine#79) so `auth status` output can distinguish a credential that definitely needs `auth login` from one that will attempt a silent renewal first.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (494 passed)
- [x] `cargo fmt --check`
- [x] Manually verified `gddy auth status` reports per-environment status with an accurate `refreshable` column