### PR TITLE
fix(cli): render platform actions list as a table with pagination

### DIFF
--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -1,10 +1,16 @@
 use cli_engine::{
-    CommandResult, CommandSpec, GroupSpec, NextActionParam, RuntimeCommandSpec, RuntimeGroupSpec,
-    Tier,
+    CommandResult, CommandSpec, GroupSpec, NextActionParam, PaginationConfig, RuntimeCommandSpec,
+    RuntimeGroupSpec, Tier,
 };
 use serde_json::json;
 
 use crate::next_action::next_action;
+use crate::output_schema::output_schema;
+
+output_schema!(ActionSummary {
+    "name": "string";
+    "description": "string";
+});
 
 /// Static catalog of available GoDaddy action names.
 /// Loaded from the manifest at compile time.
@@ -89,13 +95,19 @@ pub fn group() -> RuntimeGroupSpec {
                 )
                 .with_system("actions")
                 .with_tier(Tier::Read)
-                .no_auth(true),
+                .no_auth(true)
+                .with_default_fields("name,description")
+                .with_output_schema::<ActionSummary>()
+                .with_pagination(PaginationConfig {
+                    default_limit: 50,
+                    max_limit: 200,
+                }),
             |_cred, _args| async move {
                 let actions: Vec<_> = ACTIONS
                     .iter()
                     .map(|(name, description)| json!({ "name": name, "description": description }))
                     .collect();
-                Ok(CommandResult::new(json!({ "actions": actions })).with_next_actions(vec![
+                Ok(CommandResult::new(json!(actions)).with_next_actions(vec![
                     next_action(
                         "platform actions describe <action>",
                         "See an action's full schema",

--- a/rust/src/actions_catalog/mod.rs
+++ b/rust/src/actions_catalog/mod.rs
@@ -89,7 +89,9 @@ pub fn group() -> RuntimeGroupSpec {
             CommandSpec::new("list", "List all available action contracts")
                 .with_long(
                     "Prints the name and short description of every action your \
-                     application can declare.\n\
+                     application can declare. Shows up to 50 actions by default; \
+                     use --limit/--offset to page through the rest once the \
+                     catalog grows past that.\n\
                      Run `gddy platform actions describe <ACTION>` to see the full \
                      input/output schema for a specific action.",
                 )


### PR DESCRIPTION
## Summary
- `gddy platform actions list` dumped a single unreadable line of JSON-ish text in human mode instead of a table.
- Returns a plain array from the handler (matching `domain list`/`dns list`/`api search`) so human output can render `name`/`description` as columns, and registers an output schema for `--schema`/help.
- Opts into cli-engine's pagination (`--limit`/`--offset`, default 50, max 200) so the catalog can grow past its current 7 entries without dumping everything unpaginated.

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` / `cargo test` all pass
- [x] `gddy platform actions list --human` renders a table
- [x] `gddy platform actions list --human --limit 3` / `--offset 3` page correctly, with a generated "next page" hint
- [x] `gddy platform actions list --json` still returns valid JSON (shape changed from `{"actions": [...]}` to a plain array under `data`, consistent with other list commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)