### PR TITLE
feat(domain): show registration period with its unit in the default table

### DIFF
--- a/rust/src/domain/available.rs
+++ b/rust/src/domain/available.rs
@@ -1,11 +1,15 @@
 //! `gddy domain available` — check whether a domain can be registered (v3).
 
-use cli_engine::{CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, Tier};
+use cli_engine::{
+    CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+};
 use serde_json::json;
 
 use domains_client::types;
 
-use super::common::{api_error, format_money, headline_price, make_client, validate_domain_name};
+use super::common::{
+    api_error, format_money, headline_price, make_client, period_label, validate_domain_name,
+};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_READ;
@@ -22,7 +26,23 @@ output_schema!(DomainAvailableResult {
     "currency": "string", optional;
     "renewalPrice": "string", optional;
     "period": "number", optional;
+    "periodLabel": "string", optional;
 });
+
+/// `period` alone would render in the default table as a bare number, so swap
+/// it for the unit-bearing `periodLabel` there; `period` stays available (via
+/// `--fields all`/explicit selection) for scripting against `--output json`.
+fn view_columns() -> Vec<TableColumn> {
+    vec![
+        TableColumn::new("domain", "Domain"),
+        TableColumn::new("available", "Available"),
+        TableColumn::new("definitive", "Definitive"),
+        TableColumn::new("price", "Price"),
+        TableColumn::new("renewalPrice", "Renewal Price"),
+        TableColumn::new("currency", "Currency"),
+        TableColumn::new("periodLabel", "Period"),
+    ]
+}
 
 #[derive(Debug, Clone, clap::Args)]
 struct AvailableArgs {
@@ -47,8 +67,11 @@ pub(super) fn command() -> RuntimeCommandSpec {
             )
             .with_system("domain")
             .with_tier(Tier::Read)
-            .with_default_fields("domain,available,definitive,price,renewalPrice,currency,period")
+            .with_default_fields(
+                "domain,available,definitive,price,renewalPrice,currency,period,periodLabel",
+            )
             .with_output_schema::<DomainAvailableResult>()
+            .with_view(view_columns())
             .with_scopes(&[DOMAINS_READ]),
         |ctx, args: AvailableArgs| async move {
             let domain = validate_domain_name(&args.domain)?;
@@ -94,6 +117,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 }
                 if let Some(period) = term.period {
                     result["period"] = json!(period.get());
+                    result["periodLabel"] = json!(period_label(period.get()));
                 }
             }
 
@@ -117,7 +141,8 @@ pub(super) fn command() -> RuntimeCommandSpec {
 
 #[cfg(test)]
 mod tests {
-    use super::command;
+    use super::{command, view_columns};
+    use serde_json::json;
 
     #[test]
     fn default_fields_includes_renewal_price() {
@@ -127,5 +152,22 @@ mod tests {
         // `renewalPrice1Year` can't produce a false pass here.
         let fields = command().spec.default_fields.expect("default fields set");
         assert!(fields.split(',').any(|f| f == "renewalPrice"), "{fields}");
+    }
+
+    #[test]
+    fn period_renders_with_its_unit_in_the_default_table() {
+        // The bare `period` number ("1") read as ambiguous; the table must show
+        // `periodLabel` ("1 year") instead, while `period` itself stays numeric
+        // in the payload for scripting against `--output json`.
+        let available = json!({
+            "domain": "example.com",
+            "available": true,
+            "definitive": true,
+            "period": 1,
+            "periodLabel": "1 year",
+        });
+        let envelope = cli_engine::Envelope::success(available, "domain");
+        let rendered = cli_engine::render_human_with_view(&envelope, Some(&view_columns()), "");
+        assert!(rendered.contains("1 year"), "{rendered}");
     }
 }

--- a/rust/src/domain/common.rs
+++ b/rust/src/domain/common.rs
@@ -102,6 +102,18 @@ pub(super) fn term_for_period(
     prices.iter().find(|p| p.period == Some(period))
 }
 
+/// A registration length with its unit spelled out ("1 year", "2 years") — a
+/// bare number reads ambiguously in a table, so `quote`/`available` show this
+/// alongside the numeric `period` field (which stays a plain number for
+/// scripting against `--output json`).
+pub(super) fn period_label(period: u64) -> String {
+    if period == 1 {
+        "1 year".to_owned()
+    } else {
+        format!("{period} years")
+    }
+}
+
 /// Validate that `raw` (trimmed) is syntactically a valid domain name. Rejects
 /// the shapes from DEVEX-885's bug report — embedded whitespace, null bytes, a
 /// "protocol://" prefix, a "/path" suffix — via `url::Host::parse`'s WHATWG
@@ -729,6 +741,13 @@ mod tests {
             false,
         );
         assert!(!msg.contains("some fields are invalid"), "{msg}");
+    }
+
+    #[test]
+    fn period_label_pluralizes_correctly() {
+        assert_eq!(period_label(1), "1 year");
+        assert_eq!(period_label(2), "2 years");
+        assert_eq!(period_label(10), "10 years");
     }
 
     #[test]

--- a/rust/src/domain/quote.rs
+++ b/rust/src/domain/quote.rs
@@ -9,7 +9,8 @@ use serde_json::json;
 use domains_client::types;
 
 use super::common::{
-    api_error, format_money, make_client, validate_domain_name, validate_nameserver_hosts,
+    api_error, format_money, make_client, period_label, validate_domain_name,
+    validate_nameserver_hosts,
 };
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
@@ -25,6 +26,7 @@ output_schema!(DomainQuoteResult {
     "currency": "string", optional;
     "renewalPrice": "string", optional;
     "period": "number", optional;
+    "periodLabel": "string", optional;
     "quoteToken": "string", optional;
     "expiresAt": "string", optional;
     "irreversible": "bool", optional;
@@ -123,6 +125,7 @@ fn quote_to_json(quote: &types::RegistrationQuote, request_domain: &str) -> serd
     }
     if let Some(period) = quote.period {
         out["period"] = json!(period.get());
+        out["periodLabel"] = json!(period_label(period.get()));
     }
     if let Some(token) = quote.quote_token.as_ref() {
         out["quoteToken"] = json!(token.to_string());
@@ -212,7 +215,7 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("price", "Price"),
         TableColumn::new("renewalPrice", "Renewal Price"),
         TableColumn::new("currency", "Currency"),
-        TableColumn::new("period", "Period"),
+        TableColumn::new("periodLabel", "Period"),
         TableColumn::new("quoteToken", "Quote Token").no_truncate(true),
         TableColumn::new("expiresAt", "Expires At"),
         TableColumn::new("irreversible", "Irreversible"),
@@ -252,7 +255,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
         .with_system("domain")
         .with_tier(Tier::Read)
         .with_default_fields(
-            "domain,available,price,renewalPrice,currency,period,quoteToken,expiresAt,agreements",
+            "domain,available,price,renewalPrice,currency,period,periodLabel,quoteToken,expiresAt,agreements",
         )
         .with_output_schema::<DomainQuoteResult>()
         .with_view(view_columns())
@@ -371,6 +374,22 @@ mod tests {
         // `renewalPrice1Year` can't produce a false pass here.
         let fields = command().spec.default_fields.expect("default fields set");
         assert!(fields.split(',').any(|f| f == "renewalPrice"), "{fields}");
+    }
+
+    #[test]
+    fn period_renders_with_its_unit_in_the_default_table() {
+        // The bare `period` number ("1") read as ambiguous; the table must show
+        // `periodLabel` ("1 year") instead, while `period` itself stays numeric
+        // in the payload for scripting against `--output json`.
+        let quote = json!({
+            "domain": "example.com",
+            "available": true,
+            "period": 1,
+            "periodLabel": "1 year",
+        });
+        let envelope = cli_engine::Envelope::success(quote, "domain");
+        let rendered = cli_engine::render_human_with_view(&envelope, Some(&view_columns()), "");
+        assert!(rendered.contains("1 year"), "{rendered}");
     }
 
     /// Proves `view_columns()` renders `requiredAgreements`/`resolved` shaped


### PR DESCRIPTION
## Summary
- `gddy domain quote` and `gddy domain available` showed the registration period as a bare number ("1"), which read ambiguously. Both now show a `periodLabel` field ("1 year"/"2 years") in the default table.
- `period` itself is unchanged in value and type (still a plain number) — any script parsing `period` numerically from `--output json` keeps working as-is. Note the default JSON payload does gain the new `periodLabel` key (since `default_fields` drives both the table selection and the default JSON projection); this is additive, not a removal or type change.
- `available` didn't have a registered table view before; added one so the "Period" column can point at `periodLabel` instead of the raw number.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `./rust/scripts/check-module-size.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)