### PR TITLE
feat(api-explorer): add `api graphql` command group for GraphQL-backed domains

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -159,6 +159,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-graphql-parser"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,9 +500,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffadbcfb186a0f7175050b56573e4a0a841c49507c04ff8d4f6bc38efc64fe7"
+checksum = "713a9330b7c1a2529c5e7fb4aa8fda5eb5db6b4f39bec63085ec62e9f60d970d"
 dependencies = [
  "async-trait",
  "base64",
@@ -498,7 +522,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "termimad",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "toml",
  "toml_edit 0.22.27",
@@ -524,7 +548,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -532,16 +556,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -873,7 +887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
 ]
 
@@ -1140,9 +1154,10 @@ name = "generate-api-catalog"
 version = "0.2.4"
 dependencies = [
  "anyhow",
+ "async-graphql-parser",
+ "async-graphql-value",
  "base64",
  "chrono",
- "graphql-parser",
  "indexmap",
  "reqwest",
  "serde",
@@ -1226,7 +1241,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -1234,16 +1249,6 @@ dependencies = [
  "url",
  "uuid",
  "zip",
-]
-
-[[package]]
-name = "graphql-parser"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
-dependencies = [
- "combine",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1438,7 +1443,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -2138,6 +2143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
 name = "phonenumber"
 version = "0.3.10+9.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2169,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "strum",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -2296,7 +2311,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror",
  "typify",
  "unicode-ident",
 ]
@@ -2342,7 +2357,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2364,7 +2379,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2507,7 +2522,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -3257,17 +3272,8 @@ dependencies = [
  "lazy-regex",
  "minimad",
  "serde",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3276,18 +3282,7 @@ version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3628,7 +3623,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-ident",
 ]
 
@@ -3648,6 +3643,12 @@ dependencies = [
  "syn 2.0.119",
  "typify-impl",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.8.3" }
+cli-engine = { features = ["pkce-auth"], version = "0.8.4" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/schemas/api/catalog-products.json
+++ b/rust/schemas/api/catalog-products.json
@@ -13,7 +13,7 @@
   "endpoints": [
     {
       "graphql": {
-        "operationCount": 149,
+        "operationCount": 179,
         "operations": [
           {
             "args": [
@@ -209,6 +209,13 @@
             "returnType": "QuerySKUsConnection"
           },
           {
+            "args": [],
+            "deprecated": false,
+            "kind": "query",
+            "name": "_service",
+            "returnType": "_Service!"
+          },
+          {
             "args": [
               {
                 "name": "id",
@@ -357,6 +364,11 @@
                 "type": "SKUGroupIdFilter"
               },
               {
+                "name": "skuGroupStatus",
+                "required": false,
+                "type": "SKUGroupStatusFilter"
+              },
+              {
                 "name": "updatedAt",
                 "required": false,
                 "type": "UpdatedAtFilter"
@@ -366,6 +378,92 @@
             "kind": "query",
             "name": "attributes",
             "returnType": "QueryAttributesConnection"
+          },
+          {
+            "args": [],
+            "deprecated": false,
+            "description": "Special list tree to hold the main categories of the store. It cannot be updated or archived.",
+            "kind": "query",
+            "name": "categoriesListTree",
+            "returnType": "ListTree"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Retrieve a file by its ID.",
+            "kind": "query",
+            "name": "file",
+            "returnType": "File"
+          },
+          {
+            "args": [
+              {
+                "name": "after",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "before",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "createdAt",
+                "required": false,
+                "type": "CreatedAtFilter"
+              },
+              {
+                "name": "first",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "id",
+                "required": false,
+                "type": "FileIdsFilter"
+              },
+              {
+                "name": "last",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "orderBy",
+                "required": false,
+                "type": "FileOrderBy"
+              },
+              {
+                "defaultValue": "CURSOR",
+                "name": "paginationType",
+                "required": false,
+                "type": "PaginationType"
+              },
+              {
+                "name": "status",
+                "required": false,
+                "type": "FileStatusFilter"
+              },
+              {
+                "name": "storageUrl",
+                "required": false,
+                "type": "FileStorageUrlFilter"
+              },
+              {
+                "name": "updatedAt",
+                "required": false,
+                "type": "UpdatedAtFilter"
+              }
+            ],
+            "deprecated": false,
+            "kind": "query",
+            "name": "files",
+            "returnType": "QueryFilesConnection"
           },
           {
             "args": [
@@ -428,7 +526,7 @@
             "description": "List inventory adjustment reasons available to the current store. Includes both store-scoped and global preset reasons.",
             "kind": "query",
             "name": "inventoryAdjustmentReasons",
-            "returnType": "InventoryAdjustmentReasonConnection"
+            "returnType": "QueryInventoryAdjustmentReasonsConnection"
           },
           {
             "args": [
@@ -477,6 +575,11 @@
                 "name": "paginationType",
                 "required": false,
                 "type": "PaginationType"
+              },
+              {
+                "name": "reasonName",
+                "required": false,
+                "type": "InventoryAdjustmentReasonNameFilter"
               },
               {
                 "name": "referenceValue",
@@ -560,6 +663,11 @@
                 "type": "LocationIdFilter"
               },
               {
+                "name": "locationStatus",
+                "required": false,
+                "type": "LocationStatusFilter"
+              },
+              {
                 "name": "orderBy",
                 "required": false,
                 "type": "InventoryCountOrderBy"
@@ -574,6 +682,11 @@
                 "name": "skuId",
                 "required": false,
                 "type": "SKUIdFilter"
+              },
+              {
+                "name": "skuStatus",
+                "required": false,
+                "type": "InventoryCountSKUStatusFilter"
               },
               {
                 "name": "type",
@@ -653,6 +766,11 @@
                 "type": "Int"
               },
               {
+                "name": "hasParent",
+                "required": false,
+                "type": "Boolean"
+              },
+              {
                 "name": "id",
                 "required": false,
                 "type": "ListTreeNodeIdsFilter"
@@ -668,9 +786,20 @@
                 "type": "ListIdFilter"
               },
               {
+                "defaultValue": "{in: [\"ACTIVE\", \"DRAFT\"]}",
+                "name": "listStatus",
+                "required": false,
+                "type": "ListTreeNodeListStatusFilter"
+              },
+              {
                 "name": "listTreeId",
                 "required": false,
                 "type": "ListTreeIdFilter"
+              },
+              {
+                "name": "listTreeStatus",
+                "required": false,
+                "type": "ListTreeNodeListTreeStatusFilter"
               },
               {
                 "name": "orderBy",
@@ -769,6 +898,7 @@
               }
             ],
             "deprecated": false,
+            "description": "List trees. Excludes the special categories list tree.",
             "kind": "query",
             "name": "listTrees",
             "returnType": "QueryListTreesConnection"
@@ -947,6 +1077,193 @@
                 "type": "String"
               },
               {
+                "description": "Filter prices by currency code.",
+                "name": "currencyCode",
+                "required": false,
+                "type": "CurrencyCodeFilter"
+              },
+              {
+                "name": "first",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "id",
+                "required": false,
+                "type": "OptionPriceIdsFilter"
+              },
+              {
+                "name": "last",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "optionId",
+                "required": false,
+                "type": "OptionIdFilter"
+              },
+              {
+                "name": "orderBy",
+                "required": false,
+                "type": "OptionPriceOrderBy"
+              },
+              {
+                "defaultValue": "CURSOR",
+                "name": "paginationType",
+                "required": false,
+                "type": "PaginationType"
+              },
+              {
+                "name": "updatedAt",
+                "required": false,
+                "type": "UpdatedAtFilter"
+              }
+            ],
+            "deprecated": false,
+            "description": "Query all option prices.",
+            "kind": "query",
+            "name": "optionPrices",
+            "returnType": "QueryOptionPricesConnection"
+          },
+          {
+            "args": [
+              {
+                "name": "after",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "before",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "description": "Filter prices by currency code.",
+                "name": "currencyCode",
+                "required": false,
+                "type": "CurrencyCodeFilter"
+              },
+              {
+                "name": "first",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "id",
+                "required": false,
+                "type": "OptionValuePriceIdsFilter"
+              },
+              {
+                "name": "last",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "optionValueId",
+                "required": false,
+                "type": "OptionValueIdFilter"
+              },
+              {
+                "name": "orderBy",
+                "required": false,
+                "type": "OptionValuePriceOrderBy"
+              },
+              {
+                "defaultValue": "CURSOR",
+                "name": "paginationType",
+                "required": false,
+                "type": "PaginationType"
+              },
+              {
+                "name": "updatedAt",
+                "required": false,
+                "type": "UpdatedAtFilter"
+              }
+            ],
+            "deprecated": false,
+            "description": "Query all option value prices.",
+            "kind": "query",
+            "name": "optionValuePrices",
+            "returnType": "QueryOptionValuePricesConnection"
+          },
+          {
+            "args": [
+              {
+                "name": "after",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "before",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "createdAt",
+                "required": false,
+                "type": "CreatedAtFilter"
+              },
+              {
+                "name": "first",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "id",
+                "required": false,
+                "type": "OptionValueIdsFilter"
+              },
+              {
+                "name": "last",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "optionId",
+                "required": false,
+                "type": "OptionIdFilter"
+              },
+              {
+                "name": "orderBy",
+                "required": false,
+                "type": "OptionValueOrderBy"
+              },
+              {
+                "defaultValue": "CURSOR",
+                "name": "paginationType",
+                "required": false,
+                "type": "PaginationType"
+              },
+              {
+                "name": "updatedAt",
+                "required": false,
+                "type": "UpdatedAtFilter"
+              }
+            ],
+            "deprecated": false,
+            "kind": "query",
+            "name": "optionValues",
+            "returnType": "QueryOptionValuesConnection"
+          },
+          {
+            "args": [
+              {
+                "name": "after",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "description": "Returns shareable options that are not already associated with the specified SKU group. Use this to find options that can be added to a SKU group. Cannot be combined with skuGroupId or skuGroupStatus filters.",
+                "name": "assignableToSkuGroupId",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "before",
+                "required": false,
+                "type": "String"
+              },
+              {
                 "name": "createdAt",
                 "required": false,
                 "type": "CreatedAtFilter"
@@ -960,6 +1277,17 @@
                 "name": "id",
                 "required": false,
                 "type": "OptionIdsFilter"
+              },
+              {
+                "description": "Filter options by their shareable status. When true, returns only shareable options; when false, returns only non-shareable options.",
+                "name": "shareable",
+                "required": false,
+                "type": "Boolean"
+              },
+              {
+                "name": "label",
+                "required": false,
+                "type": "LabelFilter"
               },
               {
                 "name": "last",
@@ -986,6 +1314,11 @@
                 "name": "skuGroupId",
                 "required": false,
                 "type": "SKUGroupIdFilter"
+              },
+              {
+                "name": "skuGroupStatus",
+                "required": false,
+                "type": "SKUGroupStatusFilter"
               },
               {
                 "name": "updatedAt",
@@ -1098,6 +1431,11 @@
                 "type": "SKUGroupStatusFilter"
               },
               {
+                "name": "type",
+                "required": false,
+                "type": "SKUGroupTypeFilter"
+              },
+              {
                 "name": "updatedAt",
                 "required": false,
                 "type": "UpdatedAtFilter"
@@ -1107,6 +1445,67 @@
             "kind": "query",
             "name": "skuGroups",
             "returnType": "QuerySkuGroupsConnection"
+          },
+          {
+            "args": [
+              {
+                "name": "after",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "name": "before",
+                "required": false,
+                "type": "String"
+              },
+              {
+                "description": "Filter prices by currency code.",
+                "name": "currencyCode",
+                "required": false,
+                "type": "CurrencyCodeFilter"
+              },
+              {
+                "name": "first",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "id",
+                "required": false,
+                "type": "SKUPriceIdsFilter"
+              },
+              {
+                "name": "last",
+                "required": false,
+                "type": "Int"
+              },
+              {
+                "name": "orderBy",
+                "required": false,
+                "type": "SKUPriceOrderBy"
+              },
+              {
+                "defaultValue": "CURSOR",
+                "name": "paginationType",
+                "required": false,
+                "type": "PaginationType"
+              },
+              {
+                "name": "skuId",
+                "required": false,
+                "type": "SKUIdFilter"
+              },
+              {
+                "name": "updatedAt",
+                "required": false,
+                "type": "UpdatedAtFilter"
+              }
+            ],
+            "deprecated": false,
+            "description": "Query all SKU prices.",
+            "kind": "query",
+            "name": "skuPrices",
+            "returnType": "QuerySkuPricesConnection"
           },
           {
             "args": [
@@ -1136,14 +1535,29 @@
                 "type": "CreatedAtFilter"
               },
               {
+                "name": "eanCode",
+                "required": false,
+                "type": "SKUEanCodeFilter"
+              },
+              {
                 "name": "first",
                 "required": false,
                 "type": "Int"
               },
               {
+                "name": "gtinCode",
+                "required": false,
+                "type": "SKUGtinCodeFilter"
+              },
+              {
                 "name": "id",
                 "required": false,
                 "type": "SKUIdsFilter"
+              },
+              {
+                "name": "isbnCode",
+                "required": false,
+                "type": "SKUIsbnCodeFilter"
               },
               {
                 "name": "label",
@@ -1177,7 +1591,7 @@
                 "type": "PaginationType"
               },
               {
-                "description": "A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\t\nSupported columns: `label`, `code`\n\t\nSupported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\t\nSupported functions: `contains`",
+                "description": "A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\nSupported columns: `label`, `code`\n\nSupported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\nSupported functions: `contains`",
                 "name": "queryFilter",
                 "required": false,
                 "type": "String"
@@ -1193,9 +1607,20 @@
                 "type": "SKUGroupIdFilter"
               },
               {
+                "description": "Filter SKUs by their SKU group's status. SKUs without a SKU group will be excluded when this filter is present.",
+                "name": "skuGroupStatus",
+                "required": false,
+                "type": "SKUGroupStatusFilter"
+              },
+              {
                 "name": "status",
                 "required": false,
                 "type": "SKUStatusFilter"
+              },
+              {
+                "name": "upcCode",
+                "required": false,
+                "type": "SKUUpcCodeFilter"
               },
               {
                 "name": "updatedAt",
@@ -1814,6 +2239,34 @@
               {
                 "name": "input",
                 "required": true,
+                "type": "MutationAdjustInventoryInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Adjust inventory by a positive or negative delta. Positive deltas stock inventory, negative deltas reduce inventory.",
+            "kind": "mutation",
+            "name": "adjustInventory",
+            "returnType": "[InventoryAdjustment!]"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Archive a file.",
+            "kind": "mutation",
+            "name": "archiveFile",
+            "returnType": "File"
+          },
+          {
+            "args": [
+              {
+                "name": "input",
+                "required": true,
                 "type": "MutationArchiveInventoryAdjustmentReasonInput!"
               }
             ],
@@ -1883,6 +2336,11 @@
           {
             "args": [
               {
+                "name": "cascadeArchive",
+                "required": false,
+                "type": "CascadeArchiveInput"
+              },
+              {
                 "name": "id",
                 "required": true,
                 "type": "String!"
@@ -1912,6 +2370,11 @@
           {
             "args": [
               {
+                "name": "cascadeArchive",
+                "required": false,
+                "type": "CascadeArchiveInput"
+              },
+              {
                 "name": "id",
                 "required": true,
                 "type": "String!"
@@ -1922,6 +2385,20 @@
             "kind": "mutation",
             "name": "archiveSkuGroup",
             "returnType": "SKUGroup"
+          },
+          {
+            "args": [
+              {
+                "name": "ids",
+                "required": true,
+                "type": "[String!]!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Archive multiple existing SKUs. Limit 25 SKUs.",
+            "kind": "mutation",
+            "name": "archiveSkus",
+            "returnType": "[SKU!]"
           },
           {
             "args": [
@@ -1984,7 +2461,21 @@
               {
                 "name": "input",
                 "required": true,
-                "type": "MutationCreateInventoryAdjustmentInput!"
+                "type": "CreateFileInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Create a new file.",
+            "kind": "mutation",
+            "name": "createFile",
+            "returnType": "File"
+          },
+          {
+            "args": [
+              {
+                "name": "input",
+                "required": true,
+                "type": "CreateInventoryAdjustmentInput!"
               }
             ],
             "deprecated": false,
@@ -2006,6 +2497,20 @@
             "kind": "mutation",
             "name": "createInventoryAdjustmentReason",
             "returnType": "InventoryAdjustmentReason"
+          },
+          {
+            "args": [
+              {
+                "name": "input",
+                "required": true,
+                "type": "[CreateInventoryAdjustmentInput!]!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Create multiple inventory adjustments in a single operation.",
+            "kind": "mutation",
+            "name": "createInventoryAdjustments",
+            "returnType": "[InventoryAdjustment!]"
           },
           {
             "args": [
@@ -2174,7 +2679,7 @@
             ],
             "deprecated": true,
             "deprecationReason": "Use `createSkus` instead.",
-            "description": "Create multiple new SKUs in a single transaction.",
+            "description": "Create multiple new SKUs in a single transaction. Limit 25 SKUs.",
             "kind": "mutation",
             "name": "createSKUs",
             "returnType": "[SKU!]"
@@ -2230,7 +2735,7 @@
               }
             ],
             "deprecated": false,
-            "description": "Create multiple new SKUs in a single transaction.",
+            "description": "Create multiple new SKUs in a single transaction. Limit 25 SKUs.",
             "kind": "mutation",
             "name": "createSkus",
             "returnType": "[SKU!]"
@@ -2248,6 +2753,20 @@
             "kind": "mutation",
             "name": "deleteSkuGroupById",
             "returnType": "SKUGroup"
+          },
+          {
+            "args": [
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationReduceInventoryInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Reduce inventory by first reducing available, then moving committed to backordered. If insufficient inventory exists, additional available inventory is automatically added to fulfill the reduction. This mutation does not respect backorder limits.",
+            "kind": "mutation",
+            "name": "reduceInventory",
+            "returnType": "[InventoryAdjustment!]"
           },
           {
             "args": [
@@ -2532,6 +3051,177 @@
             "description": "Remove media objects from an existing SKU group.",
             "kind": "mutation",
             "name": "removeMediaObjectsFromSkuGroup",
+            "returnType": "SKUGroup"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromAttributeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing Attribute.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromAttribute",
+            "returnType": "Attribute"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromAttributeValueInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing Attribute Value.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromAttributeValue",
+            "returnType": "AttributeValue"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromListInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing List.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromList",
+            "returnType": "List"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromListTreeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing List Tree.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromListTree",
+            "returnType": "ListTree"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromLocationInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing Location.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromLocation",
+            "returnType": "Location"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromOptionInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing Option.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromOption",
+            "returnType": "Option"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromOptionValueInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing Option Value.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromOptionValue",
+            "returnType": "OptionValue"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromSkuInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing SKU.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromSku",
+            "returnType": "SKU"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationRemoveMetafieldsFromSkuGroupInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Remove metafields from an existing SKU Group.",
+            "kind": "mutation",
+            "name": "removeMetafieldsFromSkuGroup",
             "returnType": "SKUGroup"
           },
           {
@@ -3012,11 +3702,45 @@
               {
                 "name": "input",
                 "required": true,
+                "type": "MutationRestockFromCommittedInventoryInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Restock inventory from committed. If there are not enough committed inventory, this mutation will error.",
+            "kind": "mutation",
+            "name": "restockFromCommittedInventory",
+            "returnType": "[InventoryAdjustment!]"
+          },
+          {
+            "args": [
+              {
+                "description": "SKU Group ID",
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationSetSkuGroupChannelAssociationModeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Set the channel association mode for a SKU Group.",
+            "kind": "mutation",
+            "name": "setSkuGroupChannelAssociationMode",
+            "returnType": "SKUGroup"
+          },
+          {
+            "args": [
+              {
+                "name": "input",
+                "required": true,
                 "type": "MutationStockInventoryInput!"
               }
             ],
             "deprecated": false,
-            "description": "Stock new inventory. If there are backordered inventory, they will be moved to committed. Any extra inventory will be added to available. Documentation: https://godaddy-corp.atlassian.net/wiki/spaces/COMCORE/pages/3758600912/Inventory+Helper+Mutations#1.-stockInventory",
+            "description": "Stock new inventory. If there are backordered inventory, they will be moved to committed. It does not validate aganist backorder limit. Any extra inventory will be added to available. Documentation: https://godaddy-corp.atlassian.net/wiki/spaces/COMCORE/pages/3758600912/Inventory+Helper+Mutations#1.-stockInventory",
             "kind": "mutation",
             "name": "stockInventory",
             "returnType": "[InventoryAdjustment!]"
@@ -3058,6 +3782,25 @@
             "kind": "mutation",
             "name": "updateAttributeValue",
             "returnType": "AttributeValue"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "UpdateFileInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Update an existing file.",
+            "kind": "mutation",
+            "name": "updateFile",
+            "returnType": "File"
           },
           {
             "args": [
@@ -3216,6 +3959,25 @@
               {
                 "name": "input",
                 "required": true,
+                "type": "MutationUpdateOptionPriceCurrencyCodeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Update the currency code for an existing option price. This updates the currency code for both value and compareAtValue.",
+            "kind": "mutation",
+            "name": "updateOptionPriceCurrencyCode",
+            "returnType": "OptionPrice"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
                 "type": "MutationUpdateOptionValueInput!"
               }
             ],
@@ -3242,6 +4004,25 @@
             "description": "Update an existing price object.",
             "kind": "mutation",
             "name": "updateOptionValuePrice",
+            "returnType": "OptionValuePrice"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationUpdateOptionValuePriceCurrencyCodeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Update the currency code for an existing option value price. This updates the currency code for both value and compareAtValue.",
+            "kind": "mutation",
+            "name": "updateOptionValuePriceCurrencyCode",
             "returnType": "OptionValuePrice"
           },
           {
@@ -3371,6 +4152,25 @@
               {
                 "name": "input",
                 "required": true,
+                "type": "MutationUpdateSkuGroupOptionPositionsInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Reorder options within a SKU group by updating the position of each option's association.",
+            "kind": "mutation",
+            "name": "updateSkuGroupOptionPositions",
+            "returnType": "SKUGroup"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
                 "type": "MutationUpdateSkuMediaObjectsInput!"
               }
             ],
@@ -3398,9 +4198,8024 @@
             "kind": "mutation",
             "name": "updateSkuPrice",
             "returnType": "SKUPrice"
+          },
+          {
+            "args": [
+              {
+                "name": "id",
+                "required": true,
+                "type": "String!"
+              },
+              {
+                "name": "input",
+                "required": true,
+                "type": "MutationUpdateSkuPriceCurrencyCodeInput!"
+              }
+            ],
+            "deprecated": false,
+            "description": "Update the currency code for an existing price. This updates the currency code for both value and compareAtValue.",
+            "kind": "mutation",
+            "name": "updateSkuPriceCurrencyCode",
+            "returnType": "SKUPrice"
           }
         ],
-        "schemaRef": "./graphql/schema.graphql"
+        "schemaRef": "./graphql/schema.graphql",
+        "sdl": "extend schema\n  @link(url: \"https://specs.apollo.dev/federation/v2.6\", import: [])\n\ninput AddListTreeNodeInput {\n  listId: String!\n  parentNodeId: String\n  position: Int\n  references: [CreateReferenceInput!]\n}\n\ntype Address {\n  \"\"\"The details of the address.\"\"\"\n  addressDetails: AddressDetails\n\n  \"\"\"The first line of the address.\"\"\"\n  addressLine1: String!\n\n  \"\"\"The second line of the address.\"\"\"\n  addressLine2: String\n\n  \"\"\"The third line of the address.\"\"\"\n  addressLine3: String\n\n  \"\"\"The first administrative area of the address.\"\"\"\n  adminArea1: String\n\n  \"\"\"The second administrative area of the address.\"\"\"\n  adminArea2: String\n\n  \"\"\"The third administrative area of the address.\"\"\"\n  adminArea3: String\n\n  \"\"\"The fourth administrative area of the address.\"\"\"\n  adminArea4: String\n\n  \"\"\"The country code of the address.\"\"\"\n  countryCode: String!\n\n  \"\"\"The postal code of the address.\"\"\"\n  postalCode: String\n}\n\ntype AddressDetails {\n  \"\"\"\n  The type of address. Single character representation of a type. For example: 'B' for building, 'F' for organization, 'G' for general delivery, 'H' for high-rise, 'L' for large-volume organization, 'P' for Post Office box or delivery service, 'R' for rural route, 'S' for street, 'U' for unidentified address.\n  \"\"\"\n  addressType: String\n\n  \"\"\"\n  A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number.\n  \"\"\"\n  buildingName: String\n\n  \"\"\"The delivery service. Post office box, bag number, or post office name\"\"\"\n  deliveryService: String\n\n  \"\"\"The latitude and longitude of the address.\"\"\"\n  geoCoordinates: GeoCoordinates\n\n  \"\"\"The street name. Just `Drury` in `Drury Lane`.\"\"\"\n  streetName: String\n\n  \"\"\"The street number.\"\"\"\n  streetNumber: String\n\n  \"\"\"The street type. For example, avenue, boulevard, road, or expressway.\"\"\"\n  streetType: String\n\n  \"\"\"\n  The first-order entity below a named building or location that represents the sub-premise. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.\n  \"\"\"\n  subBuilding: String\n}\n\ninput AddressDetailsInput {\n  addressType: String\n  buildingName: String\n  deliveryService: String\n  geoCoordinates: GeoCoordinatesInput\n  streetName: String\n  streetNumber: String\n  streetType: String\n  subBuilding: String\n}\n\ninput AssociateAttributeValueInput {\n  label: String!\n  name: String\n  position: Int\n}\n\ninput AssociateAttributeValueToSKUInput {\n  attributeName: String!\n  valueName: String!\n}\n\n\"\"\"A SKU is comprised of a combination of multiple attributes\"\"\"\ntype Attribute {\n  \"\"\"\n  HTML description for the Attribute. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"\n  A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  SKUGroup: SKUGroup @deprecated(reason: \"Use skuGroup instead.\")\n\n  \"\"\"The creation date of the Attribute.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"A description of the Attribute.\"\"\"\n  description: String\n\n  \"\"\"\n  HTML description for the Attribute. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The UUID of the Attribute.\"\"\"\n  id: ID!\n\n  \"\"\"The display label of the Attribute. E.g. 'Color', 'Size', etc.\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): AttributeMetafieldsConnection\n\n  \"\"\"A unique name of the Attribute. E.g. 'color', 'size', etc.\"\"\"\n  name: String!\n\n  \"\"\"The position of the attribute.\"\"\"\n  position: Int\n\n  \"\"\"\n  A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  skuGroup: SKUGroup\n\n  \"\"\"The update date of the Attribute.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"Attribute values of Attribute.\"\"\"\n  values(after: String, before: String, first: Int, id: AttributeValueIdsFilter, last: Int, orderBy: AttributeValueOrderBy, paginationType: PaginationType = CURSOR, skuId: SKUIdFilter): AttributeValuesConnection\n}\n\ninput AttributeIdFilter {\n  eq: String\n  in: [String!]\n}\n\ninput AttributeIdsFilter {\n  in: [String!]\n}\n\ntype AttributeMetafieldsConnection {\n  edges: [AttributeMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype AttributeMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput AttributeOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  label: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  position: OrderByDirectionEnum\n  skuGroupId: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"Value for an Attribute.\"\"\"\ntype AttributeValue {\n  \"\"\"The attribute that this value belongs to.\"\"\"\n  attribute: Attribute\n\n  \"\"\"The creation date of the Attribute Value.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The UUID of the Attribute Value.\"\"\"\n  id: ID!\n\n  \"\"\"The display label of the Attribute Value. E.g. 'Red', 'Blue', etc.\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): AttributeValueMetafieldsConnection\n\n  \"\"\"A unique name of the Attribute Value. E.g. 'red', 'blue', etc.\"\"\"\n  name: String!\n\n  \"\"\"The position of the attribute value.\"\"\"\n  position: Int\n\n  \"\"\"The last update date of the Attribute Value.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput AttributeValueIdsFilter {\n  in: [String!]\n}\n\ntype AttributeValueMetafieldsConnection {\n  edges: [AttributeValueMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype AttributeValueMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput AttributeValueOrderBy {\n  attributeId: OrderByDirectionEnum\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  position: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype AttributeValuesConnection {\n  edges: [AttributeValuesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype AttributeValuesConnectionEdge {\n  cursor: String!\n  node: AttributeValue\n}\n\n\"\"\"Configuration for cascade archiving related entities.\"\"\"\ninput CascadeArchiveInput {\n  \"\"\"Whether to cascade archive SKUs when archiving the SKU Group.\"\"\"\n  skus: Boolean\n}\n\ninput CreateAddressInput {\n  addressDetails: AddressDetailsInput\n  addressLine1: String!\n  addressLine2: String\n  addressLine3: String\n  adminArea1: String\n  adminArea2: String\n  adminArea3: String\n  adminArea4: String\n  countryCode: String!\n  postalCode: String\n}\n\ninput CreateAttributeValueInput {\n  attributeId: String!\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n}\n\n\"\"\"Input for creating a new file.\"\"\"\ninput CreateFileInput {\n  contentType: String!\n  description: String\n  filename: String!\n  sizeBytes: Float!\n  storageUrl: String!\n}\n\ninput CreateInventoryAdjustmentInput {\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n\n  \"\"\"\n  The change in inventory quantity. Positive for additions, negative for removals.\n  \"\"\"\n  delta: Int!\n  locationId: String!\n  metafields: [CreateMetafieldInput!]\n\n  \"\"\"The date and time when the inventory adjustment occurred.\"\"\"\n  occurredAt: DateTime\n\n  \"\"\"\n  The name of an inventory adjustment reason to associate with this adjustment. Use the exact reason name (e.g. \"g-damage\" for global presets, or a store-scoped name).\n  \"\"\"\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: String!\n\n  \"\"\"\n  The type of inventory adjustment, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.\n  \"\"\"\n  type: String!\n}\n\ninput CreateListTreeNodeInput {\n  listId: String!\n  position: Int\n  references: [CreateReferenceInput!]\n}\n\ninput CreateMediaObjectInput {\n  label: String\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n\n  \"\"\"The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.\"\"\"\n  type: String!\n  url: String!\n}\n\ninput CreateMetafieldInput {\n  key: String!\n  namespace: String!\n  type: String!\n  value: String!\n}\n\ninput CreateOptionInput {\n  description: String\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n  prices: [CreateOptionPriceInput!]\n\n  \"\"\"\n  The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.\n  \"\"\"\n  type: String!\n  validation: CreateOptionValidationInput\n  values: [CreateOptionValueInput!]\n}\n\ninput CreateOptionPriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput!\n}\n\ninput CreateOptionValidationInput {\n  max: Int\n  min: Int\n}\n\ninput CreateOptionValueInput {\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n  prices: [CreateOptionValuePriceInput!]\n}\n\ninput CreateOptionValuePriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput!\n}\n\ninput CreateReferenceInput {\n  origin: String!\n  value: String!\n}\n\ninput CreateSKUGroupAttributeInput {\n  description: String\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n  values: [AssociateAttributeValueInput!]\n}\n\ninput CreateSKUGroupSKUInput {\n  backorderLimit: Int\n  code: String\n\n  \"\"\"DEPRECATED. Use unitCost instead.\"\"\"\n  cost: Int @deprecated(reason: \"This cost field cannot specify currency code. Use `unitCost` instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  disableInventoryTracking: Boolean\n  disablePriceOverrides: Boolean\n  disableShipping: Boolean\n  eanCode: String\n  gtinCode: String\n  htmlDescription: String\n  inventoryQuantities: [CreateSKUInventoryInput!]\n  isbnCode: String\n  label: String!\n  mediaObjects: [CreateMediaObjectInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  prices: [CreateSKUPriceInput!]\n  references: [CreateReferenceInput!]\n  shortLabel: String\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  unitCost: SimpleMoneyInput\n\n  \"\"\"The unit of the weight, one of `KG`, `GR`, `LB`, `OZ`.\"\"\"\n  unitOfWeight: String\n  upcCode: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  weight: Float\n}\n\ninput CreateSKUInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  attributeValueIds: [String!]\n  attributeValues: [AssociateAttributeValueToSKUInput!]\n  backorderLimit: Int\n  code: String\n\n  \"\"\"DEPRECATED. Use unitCost instead.\"\"\"\n  cost: Int @deprecated(reason: \"This cost field cannot specify currency code. Use `unitCost` instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  disableInventoryTracking: Boolean\n  disablePriceOverrides: Boolean\n  disableShipping: Boolean\n  eanCode: String\n  gtinCode: String\n  htmlDescription: String\n  inventoryQuantities: [CreateSKUInventoryInput!]\n  isbnCode: String\n  label: String!\n  mediaObjects: [CreateMediaObjectInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  prices: [CreateSKUPriceInput!]\n  references: [CreateReferenceInput!]\n  shortLabel: String\n  skuGroupId: String\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  unitCost: SimpleMoneyInput\n\n  \"\"\"The status of the SKU, one of `KG`, `GR`, `LB`, `OZ`.\"\"\"\n  unitOfWeight: String\n  upcCode: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  weight: Float\n}\n\ninput CreateSKUInventoryInput {\n  locationId: String!\n  quantity: Int!\n}\n\ninput CreateSKUPriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput!\n}\n\n\"\"\"Filters items based on the date they were created.\"\"\"\ninput CreatedAtFilter {\n  gt: String\n  lt: String\n}\n\n\"\"\"\nFilters items by currency code. Can be used to filter for an exact match or for multiple values.\n\"\"\"\ninput CurrencyCodeFilter {\n  \"\"\"\n  Filters items where the currency code equals the specified 3-letter ISO currency code.\n  \"\"\"\n  eq: String\n\n  \"\"\"\n  Filters items where the currency code matches any of the specified 3-letter ISO currency codes.\n  \"\"\"\n  in: [String!]\n}\n\n\"\"\"\nA date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.\n\"\"\"\nscalar DateTime\n\n\"\"\"\nA file represents a stored digital asset such as an image, document, or downloadable content.\n\"\"\"\ntype File {\n  \"\"\"The MIME type of the file.\"\"\"\n  contentType: String!\n\n  \"\"\"The timestamp when the file was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"An optional description of the file.\"\"\"\n  description: String\n\n  \"\"\"The name of the file including extension.\"\"\"\n  filename: String!\n\n  \"\"\"The globally unique identifier of the file.\"\"\"\n  id: ID!\n\n  \"\"\"\n  The size of the file in bytes. Typed as Float to support files larger than 2GB.\n  \"\"\"\n  sizeBytes: Float!\n\n  \"\"\"The current status of the file.\"\"\"\n  status: FileStatus!\n\n  \"\"\"The URL where the file is stored.\"\"\"\n  storageUrl: String!\n\n  \"\"\"The timestamp when the file was last updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput FileIdsFilter {\n  in: [String!]\n}\n\ninput FileOrderBy {\n  createdAt: OrderByDirectionEnum\n  filename: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"The status of a file.\"\"\"\nenum FileStatus {\n  ACTIVE\n  ARCHIVED\n}\n\n\"\"\"Filter for the status of the File, one of `ACTIVE`, `ARCHIVED`.\"\"\"\ninput FileStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"Filter for the storage URL of the File.\"\"\"\ninput FileStorageUrlFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"The geographic latitude and longitude coordinates.\"\"\"\ntype GeoCoordinates {\n  \"\"\"The latitude of the geo coordinates.\"\"\"\n  latitude: Float!\n\n  \"\"\"The longitude of the geo coordinates.\"\"\"\n  longitude: Float!\n}\n\ninput GeoCoordinatesInput {\n  latitude: Float\n  longitude: Float\n}\n\n\"\"\"\nAn immutable entity that represents a change in state of a quantity of SKU at a particular time and location.\n\"\"\"\ntype InventoryAdjustment {\n  \"\"\"The SKU associated with the Inventory Adjustment.\"\"\"\n  SKU: SKU @deprecated(reason: \"Use sku instead.\")\n\n  \"\"\"The creation date of the inventory adjustment.\"\"\"\n  createdAt: DateTime\n\n  \"\"\"The change in quantity of a SKU at a location.\"\"\"\n  delta: Int\n\n  \"\"\"The globally-unique ID of the inventory adjustment object.\"\"\"\n  id: ID\n\n  \"\"\"The Location associated with the Inventory Adjustment.\"\"\"\n  location: Location\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): InventoryAdjustmentMetafieldsConnection\n\n  \"\"\"The date when the inventory adjustment occurred.\"\"\"\n  occurredAt: DateTime\n\n  \"\"\"The reason associated with this inventory adjustment.\"\"\"\n  reason: InventoryAdjustmentReason\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): InventoryAdjustmentReferencesConnection\n\n  \"\"\"The SKU associated with the Inventory Adjustment.\"\"\"\n  sku: SKU\n\n  \"\"\"\n  The adjustment type of the inventory being adjusted, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.\n  \"\"\"\n  type: String!\n}\n\ninput InventoryAdjustmentIdsFilter {\n  in: [String!]\n}\n\ntype InventoryAdjustmentMetafieldsConnection {\n  edges: [InventoryAdjustmentMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype InventoryAdjustmentMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput InventoryAdjustmentOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n}\n\n\"\"\"\nA reason that can be associated with an inventory adjustment to explain why it occurred. Global preset reasons are prefixed with \"g-\" (e.g. g-damage, g-shrinkage). Store-scoped reasons use plain kebab-case names.\n\"\"\"\ntype InventoryAdjustmentReason {\n  \"\"\"The date the reason was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the inventory adjustment reason.\"\"\"\n  id: ID!\n\n  \"\"\"\n  Whether this is a global preset reason. Global reasons are shared across all stores and cannot be modified or archived.\n  \"\"\"\n  isGlobal: Boolean!\n\n  \"\"\"The human-readable display label of the reason.\"\"\"\n  label: String!\n\n  \"\"\"\n  The unique kebab-case name of the reason. Global preset names are prefixed with \"g-\" (e.g. g-damage). Store-scoped names must not use the \"g-\" prefix.\n  \"\"\"\n  name: String!\n\n  \"\"\"The status of the reason, one of ACTIVE, ARCHIVED.\"\"\"\n  status: String!\n\n  \"\"\"The date the reason was last updated.\"\"\"\n  updatedAt: DateTime!\n}\n\n\"\"\"Filters inventory adjustment reasons by name.\"\"\"\ninput InventoryAdjustmentReasonNameFilter {\n  eq: String\n  in: [String!]\n}\n\ninput InventoryAdjustmentReasonOrderBy {\n  id: OrderByDirectionEnum\n}\n\n\"\"\"\nFilter for the status of the Inventory Adjustment Reason, one of `ACTIVE`, `ARCHIVED`.\n\"\"\"\ninput InventoryAdjustmentReasonStatusFilter {\n  eq: String\n  in: [String!]\n}\n\ntype InventoryAdjustmentReferencesConnection {\n  edges: [InventoryAdjustmentReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype InventoryAdjustmentReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\n\"\"\"\nFilter for the type of inventory adjustment, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.\n\"\"\"\ninput InventoryAdjustmentTypeFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"\nRepresents the quantity of a SKU in a specific state at a particular time and location.\n\"\"\"\ntype InventoryCount {\n  \"\"\"The SKU associated with the Inventory Count.\"\"\"\n  SKU: SKU @deprecated(reason: \"Use sku instead.\")\n\n  \"\"\"The timestamp of when the inventory count was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the inventory count object.\"\"\"\n  id: ID!\n\n  \"\"\"The Location associated with the Inventory Count.\"\"\"\n  location: Location\n\n  \"\"\"\n  The on-hand inventory count (available + committed) for this SKU and location.\n  \"\"\"\n  onHand: Int\n\n  \"\"\"The count of the inventory.\"\"\"\n  quantity: Int\n\n  \"\"\"The SKU associated with the Inventory Count.\"\"\"\n  sku: SKU\n\n  \"\"\"\n  The type of inventory count, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.\n  \"\"\"\n  type: String!\n\n  \"\"\"The timestamp of when the inventory count was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput InventoryCountIdsFilter {\n  in: [String!]\n}\n\ninput InventoryCountOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"\nFilter inventory counts by the status of the associated SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\n\"\"\"\ninput InventoryCountSKUStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"\nFilter for the type of inventory count, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.\n\"\"\"\ninput InventoryCountTypeFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"\nFilters items by label. Can be used to either filter for an exact match or for a partial match.\n\"\"\"\ninput LabelFilter {\n  \"\"\"\n  Filters items where the label contains the specified string, case-insensitive.\n  \"\"\"\n  contains: String\n  eq: String\n}\n\n\"\"\"\nA list is a group of SKU groups that are generally organized by similar characteristics.\n\"\"\"\ntype List {\n  \"\"\"\n  HTML description for the List. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"\n  A SKU Group is a grouping of related SKUs. It provides information about all of the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  SKUGroups(after: String, before: String, first: Int, last: Int, paginationType: PaginationType = CURSOR): ListSKUGroupsConnection @deprecated(reason: \"Use skuGroups instead.\")\n\n  \"\"\"The date and time of when the List was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"A single-line textual description of the List.\"\"\"\n  description: String\n\n  \"\"\"\n  HTML description for the List. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The globally-unique ID of the List.\"\"\"\n  id: ID!\n\n  \"\"\"The display label of the List.\"\"\"\n  label: String!\n\n  \"\"\"Media can be images, videos, or files\"\"\"\n  mediaObjects(after: String, before: String, first: Int, last: Int, paginationType: PaginationType = CURSOR): ListMediaObjectsConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): ListMetafieldsConnection\n\n  \"\"\"A unique name for the List.\"\"\"\n  name: String!\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): ListReferencesConnection\n\n  \"\"\"\n  A SKU Group is a grouping of related SKUs. It provides information about all of the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  skuGroups(after: String, before: String, first: Int, last: Int, orderBy: SKUGroupOrderBy, paginationType: PaginationType = CURSOR, status: SKUGroupStatusFilter): ListSkuGroupsConnection\n\n  \"\"\"The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"The date and time of when the List was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput ListIdFilter {\n  eq: String\n  in: [String!]\n  isNull: Boolean\n}\n\ninput ListIdsFilter {\n  in: [String!]\n}\n\ntype ListMediaObjectsConnection {\n  edges: [ListMediaObjectsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListMediaObjectsConnectionEdge {\n  cursor: String!\n  node: Media\n}\n\ntype ListMetafieldsConnection {\n  edges: [ListMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ntype ListOption {\n  \"\"\"\n  The `compareAt` price range of the option, tracks the min and max `compareAt` price of all the option values under this option.\n  \"\"\"\n  compareAtPriceRange: PriceRange\n\n  \"\"\"The timestamp of when the Option was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"A description of the Option.\"\"\"\n  description: String\n\n  \"\"\"The UUID of the Option\"\"\"\n  id: ID!\n\n  \"\"\"\n  Whether the option is shareable across multiple SKU Groups (a global modifier).\n  \"\"\"\n  shareable: Boolean!\n\n  \"\"\"The display lable of the Option\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): OptionMetafieldsConnection\n\n  \"\"\"A unique name of the Option.\"\"\"\n  name: String!\n\n  \"\"\"The position of the option.\"\"\"\n  position: Int\n\n  \"\"\"\n  The price range of the option, tracks the min and max price of all the option values under this option.\n  \"\"\"\n  priceRange: PriceRange\n\n  \"\"\"\n  Represents the additional cost of a List Option. When empty, it indicates this option allows for flexible pricing.\n  \"\"\"\n  prices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    last: Int\n    paginationType: PaginationType = CURSOR\n  ): ListOptionPricesConnection\n\n  \"\"\"The UUID of the SKU Group that the Option belongs to.\"\"\"\n  skuGroupId: ID! @deprecated(reason: \"Use skuGroupIds or the SKUGroup.options connection instead. An option may belong to multiple SKU groups.\")\n\n  \"\"\"The IDs of all SKU groups this option is associated with.\"\"\"\n  skuGroupIds: [String!]!\n\n  \"\"\"\n  The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.\n  \"\"\"\n  type: String\n\n  \"\"\"The timestamp of when the Option was updated.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"\n  Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.\n  \"\"\"\n  validation: OptionValidation\n\n  \"\"\"\n  Represents the additional cost of a List Option. Each value can have one or more prices.\n  \"\"\"\n  values(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: OptionValueIdsFilter, last: Int, orderBy: OptionValueOrderBy, paginationType: PaginationType = CURSOR, updatedAt: UpdatedAtFilter): ListOptionValuesConnection\n}\n\ntype ListOptionPricesConnection {\n  edges: [ListOptionPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListOptionPricesConnectionEdge {\n  cursor: String!\n  node: OptionPrice\n}\n\ntype ListOptionValuesConnection {\n  edges: [ListOptionValuesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListOptionValuesConnectionEdge {\n  cursor: String!\n  node: OptionValue\n}\n\ninput ListOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  label: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype ListReferencesConnection {\n  edges: [ListReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ntype ListSKUGroupsConnection {\n  edges: [ListSKUGroupsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListSKUGroupsConnectionEdge {\n  cursor: String!\n  node: SKUGroup\n}\n\ntype ListSkuGroupsConnection {\n  edges: [ListSkuGroupsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListSkuGroupsConnectionEdge {\n  cursor: String!\n  node: SKUGroup\n}\n\n\"\"\"\nFilter for the status of the List, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.\n\"\"\"\ninput ListStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"A List tree holds the hierarchical information of a group of lists.\"\"\"\ntype ListTree {\n  \"\"\"\n  HTML description for the List Tree. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"The timestamp of when the list tree was activated.\"\"\"\n  activatedAt: DateTime\n\n  \"\"\"The timestamp of when the list tree was archived.\"\"\"\n  archivedAt: DateTime\n\n  \"\"\"The creation date of the list tree.\"\"\"\n  createdAt: DateTime\n\n  \"\"\"The description of the list tree.\"\"\"\n  description: String\n\n  \"\"\"\n  HTML description for the List Tree. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The globally-unique ID of the list tree.\"\"\"\n  id: ID\n\n  \"\"\"The display label of the list tree.\"\"\"\n  label: String!\n\n  \"\"\"\n  List tree node is associated to a single List and a node can be a parent node to provide the hierarchy of list trees.\n  \"\"\"\n  listTreeNodes(after: String, before: String, first: Int, hasParent: Boolean, last: Int, listId: ListIdFilter, listStatus: ListTreeNodeListStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}, orderBy: ListTreeNodeOrderBy, paginationType: PaginationType = CURSOR, parentNodeId: ListTreeNodeParentNodeIdFilter): ListTreeListTreeNodesConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): ListTreeMetafieldsConnection\n\n  \"\"\"A unique name of the list tree.\"\"\"\n  name: String\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): ListTreeReferencesConnection\n\n  \"\"\"The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.\"\"\"\n  status: String\n\n  \"\"\"The last update date of the list tree.\"\"\"\n  updatedAt: DateTime\n}\n\ninput ListTreeIdFilter {\n  eq: String\n}\n\ninput ListTreeIdsFilter {\n  in: [String!]\n}\n\ntype ListTreeListTreeNodesConnection {\n  edges: [ListTreeListTreeNodesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListTreeListTreeNodesConnectionEdge {\n  cursor: String!\n  node: ListTreeNode\n}\n\ntype ListTreeMetafieldsConnection {\n  edges: [ListTreeMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListTreeMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\n\"\"\"\nList tree node is associated to a single List and a node can be a parent node to provide the hierarchy of list trees.\n\"\"\"\ntype ListTreeNode {\n  \"\"\"The creation date of the list node.\"\"\"\n  createdAt: DateTime\n\n  \"\"\"The globally-unique ID of the list node.\"\"\"\n  id: ID\n\n  \"\"\"The list associated with the node.\"\"\"\n  list: List\n\n  \"\"\"The List Tree associated with the node.\"\"\"\n  listTree: ListTree\n\n  \"\"\"The children nodes of the list node.\"\"\"\n  listTreeNodes(after: String, before: String, first: Int, last: Int, listStatus: ListTreeNodeListStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}, orderBy: ListTreeNodeOrderBy, paginationType: PaginationType = CURSOR): ListTreeNodeListTreeNodesConnection\n\n  \"\"\"The parent node of the list node.\"\"\"\n  parentListTreeNode: ListTreeNode\n\n  \"\"\"The position of the node in the list.\"\"\"\n  position: Int\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): ListTreeNodeReferencesConnection\n\n  \"\"\"The last update date of the list node.\"\"\"\n  updatedAt: DateTime\n}\n\ninput ListTreeNodeIdsFilter {\n  in: [String!]\n}\n\n\"\"\"\nFilter for the status of the List, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.\n\"\"\"\ninput ListTreeNodeListStatusFilter {\n  eq: String\n  in: [String!]\n}\n\ntype ListTreeNodeListTreeNodesConnection {\n  edges: [ListTreeNodeListTreeNodesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListTreeNodeListTreeNodesConnectionEdge {\n  cursor: String!\n  node: ListTreeNode\n}\n\n\"\"\"\nFilter for the status of the List Tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.\n\"\"\"\ninput ListTreeNodeListTreeStatusFilter {\n  eq: String\n  in: [String!]\n}\n\ninput ListTreeNodeOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  position: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ninput ListTreeNodeParentNodeIdFilter {\n  eq: String\n}\n\ntype ListTreeNodeReferencesConnection {\n  edges: [ListTreeNodeReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListTreeNodeReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ninput ListTreeOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype ListTreeReferencesConnection {\n  edges: [ListTreeReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype ListTreeReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\n\"\"\"\nFilter for the status of the List Tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.\n\"\"\"\ninput ListTreeStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"A location represents the physical location of an inventory.\"\"\"\ntype Location {\n  \"\"\"The SKUs are purchasable items in the catalog.\"\"\"\n  SKUs(\n    after: String\n    attributeValues: SKUAttributeValueFilter\n    before: String\n    createdAt: CreatedAtFilter\n    first: Int\n    label: LabelFilter\n    last: Int\n    name: NameFilter\n    paginationType: PaginationType = CURSOR\n\n    \"\"\"\n    A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\n    Supported columns: `label`, `code`\n\n    Supported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\n    Supported functions: `contains`\n    \"\"\"\n    queryFilter: String\n    referenceValue: ReferenceValueFilter\n    skuGroupId: SKUGroupIdFilter\n    status: SKUStatusFilter\n    updatedAt: UpdatedAtFilter\n  ): LocationSKUsConnection @deprecated(reason: \"Use skus instead.\")\n\n  \"\"\"The address of the Location.\"\"\"\n  address: Address\n\n  \"\"\"The timestamp of when the Location was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the Location.\"\"\"\n  id: ID!\n\n  \"\"\"\n  An immutable entity that represents a change in state of a quantity of SKU at a particular time and location. Each adjustment will either have a positive, negative, or neutral impact on the count of available SKUs in a location.\n  \"\"\"\n  inventoryAdjustments(after: String, before: String, first: Int, last: Int, orderBy: InventoryAdjustmentOrderBy, paginationType: PaginationType = CURSOR): LocationInventoryAdjustmentsConnection\n\n  \"\"\"\n  The quantity of a SKU in a specific state at a particular time and location.\n  \"\"\"\n  inventoryCounts(after: String, before: String, first: Int, last: Int, locationStatus: LocationStatusFilter, orderBy: InventoryCountOrderBy, paginationType: PaginationType = CURSOR, skuId: SKUIdFilter, skuStatus: InventoryCountSKUStatusFilter, type: InventoryCountTypeFilter): LocationInventoryCountsConnection\n\n  \"\"\"The display name of the Location.\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): LocationMetafieldsConnection\n\n  \"\"\"A unique and human-friendly name of the Location.\"\"\"\n  name: String!\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): LocationReferencesConnection\n\n  \"\"\"The SKUs are purchasable items in the catalog.\"\"\"\n  skus(\n    after: String\n    attributeValues: SKUAttributeValueFilter\n    before: String\n    code: SKUCodeFilter\n    createdAt: CreatedAtFilter\n    eanCode: SKUEanCodeFilter\n    first: Int\n    gtinCode: SKUGtinCodeFilter\n    isbnCode: SKUIsbnCodeFilter\n    label: LabelFilter\n    last: Int\n    name: NameFilter\n    orderBy: SKUOrderBy\n    paginationType: PaginationType = CURSOR\n\n    \"\"\"\n    A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\n    Supported columns: `label`, `code`\n\n    Supported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\n    Supported functions: `contains`\n    \"\"\"\n    queryFilter: String\n    referenceValue: ReferenceValueFilter\n    skuGroupId: SKUGroupIdFilter\n    status: SKUStatusFilter\n    upcCode: SKUUpcCodeFilter\n    updatedAt: UpdatedAtFilter\n  ): LocationSkusConnection\n\n  \"\"\"The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.\"\"\"\n  status: String!\n\n  \"\"\"The timestamp of when the Location was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput LocationIdFilter {\n  eq: String\n}\n\ninput LocationIdsFilter {\n  in: [String!]\n}\n\ntype LocationInventoryAdjustmentsConnection {\n  edges: [LocationInventoryAdjustmentsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationInventoryAdjustmentsConnectionEdge {\n  cursor: String!\n  node: InventoryAdjustment\n}\n\ntype LocationInventoryCountsConnection {\n  edges: [LocationInventoryCountsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationInventoryCountsConnectionEdge {\n  cursor: String!\n  node: InventoryCount\n}\n\ntype LocationMetafieldsConnection {\n  edges: [LocationMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput LocationOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype LocationReferencesConnection {\n  edges: [LocationReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ntype LocationSKUsConnection {\n  edges: [LocationSKUsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationSKUsConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\ntype LocationSkusConnection {\n  edges: [LocationSkusConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype LocationSkusConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\n\"\"\"\nFilter for the status of the Location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.\n\"\"\"\ninput LocationStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"Represents a media object, including photos and videos.\"\"\"\ntype Media {\n  \"\"\"The globally-unique ID of the media.\"\"\"\n  id: ID!\n\n  \"\"\"An optional label for the media.\"\"\"\n  label: String\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): MediaMetafieldsConnection\n\n  \"\"\"A unique name of the media.\"\"\"\n  name: String\n\n  \"\"\"The position of the media.\"\"\"\n  position: Int\n\n  \"\"\"The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.\"\"\"\n  type: String\n\n  \"\"\"The URL of the media.\"\"\"\n  url: String!\n}\n\ntype MediaMetafieldsConnection {\n  edges: [MediaMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype MediaMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\n\"\"\"Custom data\"\"\"\ntype Metafield {\n  createdAt: String\n  id: ID\n  key: String\n  namespace: String\n  resourceId: ID\n  type: String\n  updatedAt: String\n  value: String\n}\n\ntype Mutation {\n  \"\"\"Add Attribute Value(s) to an existing SKU.\"\"\"\n  addAttributeValuesToSKU(id: String!, input: MutationAddAttributeValuesToSKUInput!): SKU @deprecated(reason: \"Use `addAttributeValuesToSku` instead.\")\n\n  \"\"\"Add Attribute Value(s) to an existing SKU.\"\"\"\n  addAttributeValuesToSku(id: String!, input: MutationAddAttributeValuesToSkuInput!): SKU\n\n  \"\"\"Add Attributes to an existing SKU group.\"\"\"\n  addAttributesToSKUGroup(id: String!, input: MutationAddAttributesToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addAttributesToSkuGroup` instead.\")\n\n  \"\"\"Add Attributes to an existing SKU group.\"\"\"\n  addAttributesToSkuGroup(id: String!, input: MutationAddAttributesToSkuGroupInput!): SKUGroup\n\n  \"\"\"Add channels to an existing SKU group.\"\"\"\n  addChannelsToSKUGroup(id: String!, input: MutationAddChannelsToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addChannelsToSkuGroup` instead.\")\n\n  \"\"\"Add channels to an existing SKU group.\"\"\"\n  addChannelsToSkuGroup(id: String!, input: MutationAddChannelsToSkuGroupInput!): SKUGroup\n\n  \"\"\"Add a new node to a list tree.\"\"\"\n  addListTreeNodesToListTree(id: String!, input: MutationAddListTreeNodesToListTreeInput!): ListTree\n\n  \"\"\"Add a new node to a list tree node.\"\"\"\n  addListTreeNodesToParentListTreeNode(id: String!, input: MutationAddListTreeNodesToParentListTreeNodeInput!): ListTreeNode\n\n  \"\"\"Add media objects to an existing List.\"\"\"\n  addMediaObjectsToList(id: String!, input: MutationAddMediaObjectsToListInput!): List\n\n  \"\"\"Add media objects to an existing SKU\"\"\"\n  addMediaObjectsToSKU(id: String!, input: MutationAddMediaObjectsToSKUInput!): SKU @deprecated(reason: \"Use `addMediaObjectsToSku` instead.\")\n\n  \"\"\"Add media objects to an existing SKU group.\"\"\"\n  addMediaObjectsToSKUGroup(id: String!, input: MutationAddMediaObjectsToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addMediaObjectsToSkuGroup` instead.\")\n\n  \"\"\"Add media objects to an existing SKU\"\"\"\n  addMediaObjectsToSku(id: String!, input: MutationAddMediaObjectsToSkuInput!): SKU\n\n  \"\"\"Add media objects to an existing SKU group.\"\"\"\n  addMediaObjectsToSkuGroup(id: String!, input: MutationAddMediaObjectsToSkuGroupInput!): SKUGroup\n\n  \"\"\"Add options to an existing SKU group.\"\"\"\n  addOptionsToSKUGroup(id: String!, input: MutationAddOptionsToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addOptionsToSkuGroup` instead.\")\n\n  \"\"\"Add options to an existing SKU group.\"\"\"\n  addOptionsToSkuGroup(id: String!, input: MutationAddOptionsToSkuGroupInput!): SKUGroup\n\n  \"\"\"Add references to an existing List.\"\"\"\n  addReferencesToList(id: String!, input: MutationAddReferencesToListInput!): List\n\n  \"\"\"Add references to an existing List Tree.\"\"\"\n  addReferencesToListTree(id: String!, input: MutationAddReferencesToListTreeInput!): ListTree\n\n  \"\"\"Add references to an existing List Tree Node\"\"\"\n  addReferencesToListTreeNode(id: String!, input: MutationAddReferencesToListTreeNodeInput!): ListTreeNode\n\n  \"\"\"Add references to an existing location.\"\"\"\n  addReferencesToLocation(id: String!, input: MutationAddReferencesToLocationInput!): Location\n\n  \"\"\"Add references to an existing SKU.\"\"\"\n  addReferencesToSKU(id: String!, input: MutationAddReferencesToSKUInput!): SKU @deprecated(reason: \"Use `addReferencesToSku` instead.\")\n\n  \"\"\"Add references to an existing SKU group.\"\"\"\n  addReferencesToSKUGroup(id: String!, input: MutationAddReferencesToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addReferencesToSkuGroup` instead.\")\n\n  \"\"\"Add references to an existing SKU.\"\"\"\n  addReferencesToSku(id: String!, input: MutationAddReferencesToSkuInput!): SKU\n\n  \"\"\"Add references to an existing SKU group.\"\"\"\n  addReferencesToSkuGroup(id: String!, input: MutationAddReferencesToSkuGroupInput!): SKUGroup\n\n  \"\"\"Add a single SKU Group to multiple lists\"\"\"\n  addSKUGroupToLists(id: String!, input: MutationAddSKUGroupToListsInput!): SKUGroup @deprecated(reason: \"Use `addSkuGroupToLists` instead.\")\n\n  \"\"\"Add SKU Groups to an existing list.\"\"\"\n  addSKUGroupsToList(id: String!, input: MutationAddSKUGroupsToListInput!): List @deprecated(reason: \"Use `addSkuGroupsToList` instead.\")\n\n  \"\"\"Add SKUs to an existing location.\"\"\"\n  addSKUsToLocation(id: String!, input: MutationAddSKUsToLocationInput!): Location @deprecated(reason: \"Use `addSkusToLocation` instead.\")\n\n  \"\"\"Add SKUs to an existing SKU group.\"\"\"\n  addSKUsToSKUGroup(id: String!, input: MutationAddSKUsToSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `addSkusToSkuGroup` instead.\")\n\n  \"\"\"Add a single SKU Group to multiple lists\"\"\"\n  addSkuGroupToLists(id: String!, input: MutationAddSkuGroupToListsInput!): SKUGroup\n\n  \"\"\"Add SKU Groups to an existing list.\"\"\"\n  addSkuGroupsToList(id: String!, input: MutationAddSkuGroupsToListInput!): List\n\n  \"\"\"Add SKUs to an existing location.\"\"\"\n  addSkusToLocation(id: String!, input: MutationAddSkusToLocationInput!): Location\n\n  \"\"\"Add SKUs to an existing SKU group.\"\"\"\n  addSkusToSkuGroup(id: String!, input: MutationAddSkusToSkuGroupInput!): SKUGroup\n\n  \"\"\"\n  Adjust inventory by a positive or negative delta. Positive deltas stock inventory, negative deltas reduce inventory.\n  \"\"\"\n  adjustInventory(input: MutationAdjustInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"Archive a file.\"\"\"\n  archiveFile(id: String!): File\n\n  \"\"\"\n  Archive a store-scoped inventory adjustment reason. Global reasons cannot be archived.\n  \"\"\"\n  archiveInventoryAdjustmentReason(input: MutationArchiveInventoryAdjustmentReasonInput!): InventoryAdjustmentReason\n\n  \"\"\"Archive a list.\"\"\"\n  archiveList(id: String!): List\n\n  \"\"\"Archive a list tree.\"\"\"\n  archiveListTree(id: String!): ListTree\n\n  \"\"\"Archive a location.\"\"\"\n  archiveLocation(id: String!): Location\n\n  \"\"\"Archive an existing SKU.\"\"\"\n  archiveSKU(id: String!): SKU @deprecated(reason: \"Use `archiveSku` instead.\")\n\n  \"\"\"Archive an existing SKU Group.\"\"\"\n  archiveSKUGroup(cascadeArchive: CascadeArchiveInput, id: String!): SKUGroup @deprecated(reason: \"Use `archiveSkuGroup` instead.\")\n\n  \"\"\"Archive an existing SKU.\"\"\"\n  archiveSku(id: String!): SKU\n\n  \"\"\"Archive an existing SKU Group.\"\"\"\n  archiveSkuGroup(cascadeArchive: CascadeArchiveInput, id: String!): SKUGroup\n\n  \"\"\"Archive multiple existing SKUs. Limit 25 SKUs.\"\"\"\n  archiveSkus(ids: [String!]!): [SKU!]\n\n  \"\"\"\n  Commit new inventory. If there are not enough available inventory, they will be moved to backordered if allowed. Documentation: https://godaddy-corp.atlassian.net/wiki/spaces/COMCORE/pages/3758600912/Inventory+Helper+Mutations#2.-commitInventory\n  \"\"\"\n  commitInventory(input: MutationCommitInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"Create a new attribute.\"\"\"\n  createAttribute(input: MutationCreateAttributeInput!): Attribute\n\n  \"\"\"Create a new attribute value.\"\"\"\n  createAttributeValue(input: CreateAttributeValueInput!): AttributeValue\n\n  \"\"\"Create new attribute values.\"\"\"\n  createAttributeValues(input: [CreateAttributeValueInput!]!): [AttributeValue!]\n\n  \"\"\"Create a new file.\"\"\"\n  createFile(input: CreateFileInput!): File\n\n  \"\"\"Create a new inventory adjustment.\"\"\"\n  createInventoryAdjustment(input: CreateInventoryAdjustmentInput!): InventoryAdjustment\n\n  \"\"\"\n  Create a new store-scoped inventory adjustment reason. Name must be kebab-case and must not start with \"g-\" (reserved for global presets). Once created, the name is immutable.\n  \"\"\"\n  createInventoryAdjustmentReason(input: MutationCreateInventoryAdjustmentReasonInput!): InventoryAdjustmentReason\n\n  \"\"\"Create multiple inventory adjustments in a single operation.\"\"\"\n  createInventoryAdjustments(input: [CreateInventoryAdjustmentInput!]!): [InventoryAdjustment!]\n\n  \"\"\"Create a new list.\"\"\"\n  createList(input: MutationCreateListInput!): List\n\n  \"\"\"Create a new list tree.\"\"\"\n  createListTree(input: MutationCreateListTreeInput!): ListTree\n\n  \"\"\"Create a new location.\"\"\"\n  createLocation(input: MutationCreateLocationInput!): Location\n\n  \"\"\"Create a new option.\"\"\"\n  createOption(input: MutationCreateOptionInput!): Option\n\n  \"\"\"\n  Create a flat price for the option. This will be ignore if a price is present on the option values.\n  \"\"\"\n  createOptionPrice(input: MutationCreateOptionPriceInput!): OptionPrice\n\n  \"\"\"Create a new option value.\"\"\"\n  createOptionValue(input: MutationCreateOptionValueInput!): OptionValue\n\n  \"\"\"Create a price.\"\"\"\n  createOptionValuePrice(input: MutationCreateOptionValuePriceInput!): OptionValuePrice\n\n  \"\"\"Create multiple new Option Values in a single transaction.\"\"\"\n  createOptionValues(input: [MutationCreateOptionValueInput!]!): [OptionValue!]\n\n  \"\"\"Create a new SKU.\"\"\"\n  createSKU(input: CreateSKUInput!): SKU @deprecated(reason: \"Use `createSku` instead.\")\n\n  \"\"\"Create a new SKU Group.\"\"\"\n  createSKUGroup(input: MutationCreateSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `createSkuGroup` instead.\")\n\n  \"\"\"Create a price.\"\"\"\n  createSKUPrice(input: MutationCreateSKUPriceInput!): SKUPrice @deprecated(reason: \"Use `createSkuPrice` instead.\")\n\n  \"\"\"Create multiple new SKUs in a single transaction. Limit 25 SKUs.\"\"\"\n  createSKUs(input: [CreateSKUInput!]!): [SKU!] @deprecated(reason: \"Use `createSkus` instead.\")\n\n  \"\"\"Create a new SKU.\"\"\"\n  createSku(input: CreateSKUInput!): SKU\n\n  \"\"\"Create a new SKU Group.\"\"\"\n  createSkuGroup(input: MutationCreateSkuGroupInput!): SKUGroup\n\n  \"\"\"Create a price.\"\"\"\n  createSkuPrice(input: MutationCreateSkuPriceInput!): SKUPrice\n\n  \"\"\"Create multiple new SKUs in a single transaction. Limit 25 SKUs.\"\"\"\n  createSkus(input: [CreateSKUInput!]!): [SKU!]\n\n  \"\"\"\n  WARNING: This mutation hard deletes an existing SKU Group and all its associated records.\n  \"\"\"\n  deleteSkuGroupById(id: String!): SKUGroup\n\n  \"\"\"\n  Reduce inventory by first reducing available, then moving committed to backordered. If insufficient inventory exists, additional available inventory is automatically added to fulfill the reduction. This mutation does not respect backorder limits.\n  \"\"\"\n  reduceInventory(input: MutationReduceInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"\n  Release inventory from committed. If there are not enough committed inventory, this mutation will error. Documentation: https://godaddy-corp.atlassian.net/wiki/spaces/COMCORE/pages/3758600912/Inventory+Helper+Mutations#3.-releaseInventory\n  \"\"\"\n  releaseInventory(input: MutationReleaseInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"Remove Attribute Value(s) from an existing Attribute.\"\"\"\n  removeAttributeValuesFromAttribute(id: String!, input: MutationRemoveAttributeValuesFromAttributeInput!): Attribute\n\n  \"\"\"Remove Attribute Value(s) from an existing SKU.\"\"\"\n  removeAttributeValuesFromSKU(id: String!, input: MutationRemoveAttributeValuesFromSKUInput!): SKU @deprecated(reason: \"Use `removeAttributeValuesFromSku` instead.\")\n\n  \"\"\"Remove Attribute Value(s) from an existing SKU.\"\"\"\n  removeAttributeValuesFromSku(id: String!, input: MutationRemoveAttributeValuesFromSkuInput!): SKU\n\n  \"\"\"Remove Attributes from an existing SKU group.\"\"\"\n  removeAttributesFromSKUGroup(id: String!, input: MutationRemoveAttributesFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeAttributesFromSkuGroup` instead.\")\n\n  \"\"\"Remove Attributes from an existing SKU group.\"\"\"\n  removeAttributesFromSkuGroup(id: String!, input: MutationRemoveAttributesFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove channel associations from an existing SKU group.\"\"\"\n  removeChannelsFromSKUGroup(id: String!, input: MutationRemoveChannelsFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeChannelsFromSkuGroup` instead.\")\n\n  \"\"\"Remove channel associations from an existing SKU group.\"\"\"\n  removeChannelsFromSkuGroup(id: String!, input: MutationRemoveChannelsFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove nodes from a list tree.\"\"\"\n  removeListTreeNodesFromListTree(id: String!, input: MutationRemoveListTreeNodesFromListTreeInput!): ListTree\n\n  \"\"\"Remove nodes from a list tree node.\"\"\"\n  removeListTreeNodesFromParentListTreeNode(id: String!, input: MutationRemoveListTreeNodesFromParentListTreeNodeInput!): ListTreeNode\n\n  \"\"\"Remove media objects from an existing List.\"\"\"\n  removeMediaObjectsFromList(id: String!, input: MutationRemoveMediaObjectsFromListInput!): List\n\n  \"\"\"Remove media objects from an existing SKU\"\"\"\n  removeMediaObjectsFromSKU(id: String!, input: MutationRemoveMediaObjectsFromSKUInput!): SKU @deprecated(reason: \"Use `removeMediaObjectsFromSku` instead.\")\n\n  \"\"\"Remove media objects from an existing SKU group.\"\"\"\n  removeMediaObjectsFromSKUGroup(id: String!, input: MutationRemoveMediaObjectsFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeMediaObjectsFromSkuGroup` instead.\")\n\n  \"\"\"Remove media objects from an existing SKU\"\"\"\n  removeMediaObjectsFromSku(id: String!, input: MutationRemoveMediaObjectsFromSkuInput!): SKU\n\n  \"\"\"Remove media objects from an existing SKU group.\"\"\"\n  removeMediaObjectsFromSkuGroup(id: String!, input: MutationRemoveMediaObjectsFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove metafields from an existing Attribute.\"\"\"\n  removeMetafieldsFromAttribute(id: String!, input: MutationRemoveMetafieldsFromAttributeInput!): Attribute\n\n  \"\"\"Remove metafields from an existing Attribute Value.\"\"\"\n  removeMetafieldsFromAttributeValue(id: String!, input: MutationRemoveMetafieldsFromAttributeValueInput!): AttributeValue\n\n  \"\"\"Remove metafields from an existing List.\"\"\"\n  removeMetafieldsFromList(id: String!, input: MutationRemoveMetafieldsFromListInput!): List\n\n  \"\"\"Remove metafields from an existing List Tree.\"\"\"\n  removeMetafieldsFromListTree(id: String!, input: MutationRemoveMetafieldsFromListTreeInput!): ListTree\n\n  \"\"\"Remove metafields from an existing Location.\"\"\"\n  removeMetafieldsFromLocation(id: String!, input: MutationRemoveMetafieldsFromLocationInput!): Location\n\n  \"\"\"Remove metafields from an existing Option.\"\"\"\n  removeMetafieldsFromOption(id: String!, input: MutationRemoveMetafieldsFromOptionInput!): Option\n\n  \"\"\"Remove metafields from an existing Option Value.\"\"\"\n  removeMetafieldsFromOptionValue(id: String!, input: MutationRemoveMetafieldsFromOptionValueInput!): OptionValue\n\n  \"\"\"Remove metafields from an existing SKU.\"\"\"\n  removeMetafieldsFromSku(id: String!, input: MutationRemoveMetafieldsFromSkuInput!): SKU\n\n  \"\"\"Remove metafields from an existing SKU Group.\"\"\"\n  removeMetafieldsFromSkuGroup(id: String!, input: MutationRemoveMetafieldsFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove an existing option.\"\"\"\n  removeOption(id: String!): Null\n\n  \"\"\"Remove an existing option value.\"\"\"\n  removeOptionValue(id: String!): Null\n\n  \"\"\"Remove values from an existing Option.\"\"\"\n  removeOptionValuesFromListOption(id: String!, input: MutationRemoveOptionValuesFromListOptionInput!): ListOption\n\n  \"\"\"Remove Options from an existing SKU group.\"\"\"\n  removeOptionsFromSKUGroup(id: String!, input: MutationRemoveOptionsFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeOptionsFromSkuGroup` instead.\")\n\n  \"\"\"Remove Options from an existing SKU group.\"\"\"\n  removeOptionsFromSkuGroup(id: String!, input: MutationRemoveOptionsFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove prices from an existing Option.\"\"\"\n  removePricesFromOption(id: String!, input: MutationRemovePricesFromOptionInput!): Option\n\n  \"\"\"Remove prices from an existing OptionValue.\"\"\"\n  removePricesFromOptionValue(id: String!, input: MutationRemovePricesFromOptionValueInput!): OptionValue\n\n  \"\"\"Remove prices from an existing SKU.\"\"\"\n  removePricesFromSKU(id: String!, input: MutationRemovePricesFromSKUInput!): SKU @deprecated(reason: \"Use `removePricesFromSku` instead.\")\n\n  \"\"\"Remove prices from an existing SKU.\"\"\"\n  removePricesFromSku(id: String!, input: MutationRemovePricesFromSkuInput!): SKU\n\n  \"\"\"Remove references from an existing List.\"\"\"\n  removeReferencesFromList(id: String!, input: MutationRemoveReferencesFromListInput!): List\n\n  \"\"\"Remove references from an existing List Tree\"\"\"\n  removeReferencesFromListTree(id: String!, input: MutationRemoveReferencesFromListTreeInput!): ListTree\n\n  \"\"\"Remove references from an existing List Tree Node\"\"\"\n  removeReferencesFromListTreeNode(id: String!, input: MutationRemoveReferencesFromListTreeNodeInput!): ListTreeNode\n\n  \"\"\"Remove references from an existing location.\"\"\"\n  removeReferencesFromLocation(id: String!, input: MutationRemoveReferencesFromLocationInput!): Location\n\n  \"\"\"Remove references from an existing SKU.\"\"\"\n  removeReferencesFromSKU(id: String!, input: MutationRemoveReferencesFromSKUInput!): SKU @deprecated(reason: \"Use `removeReferencesFromSku` instead.\")\n\n  \"\"\"Remove references from an existing SKU group.\"\"\"\n  removeReferencesFromSKUGroup(id: String!, input: MutationRemoveReferencesFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeReferencesFromSkuGroup` instead.\")\n\n  \"\"\"Remove references from an existing SKU.\"\"\"\n  removeReferencesFromSku(id: String!, input: MutationRemoveReferencesFromSkuInput!): SKU\n\n  \"\"\"Remove references from an existing SKU group.\"\"\"\n  removeReferencesFromSkuGroup(id: String!, input: MutationRemoveReferencesFromSkuGroupInput!): SKUGroup\n\n  \"\"\"Remove a single SKU Group from multiple lists\"\"\"\n  removeSKUGroupFromLists(id: String!, input: MutationRemoveSKUGroupFromListsInput!): SKUGroup @deprecated(reason: \"Use `removeSkuGroupFromLists` instead.\")\n\n  \"\"\"Remove SKU Groups from an existing list.\"\"\"\n  removeSKUGroupsFromList(id: String!, input: MutationRemoveSKUGroupsFromListInput!): List @deprecated(reason: \"Use `removeSkuGroupsFromList` instead.\")\n\n  \"\"\"Remove SKU from an existing location.\"\"\"\n  removeSKUsFromLocation(id: String!, input: MutationRemoveSKUsFromLocationInput!): Location @deprecated(reason: \"Use `removeSkusFromLocation` instead.\")\n\n  \"\"\"Remove SKUs from an existing SKU group.\"\"\"\n  removeSKUsFromSKUGroup(id: String!, input: MutationRemoveSKUsFromSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `removeSkusFromSkuGroup` instead.\")\n\n  \"\"\"Remove a single SKU Group from multiple lists\"\"\"\n  removeSkuGroupFromLists(id: String!, input: MutationRemoveSkuGroupFromListsInput!): SKUGroup\n\n  \"\"\"Remove SKU Groups from an existing list.\"\"\"\n  removeSkuGroupsFromList(id: String!, input: MutationRemoveSkuGroupsFromListInput!): List\n\n  \"\"\"Remove SKU from an existing location.\"\"\"\n  removeSkusFromLocation(id: String!, input: MutationRemoveSkusFromLocationInput!): Location\n\n  \"\"\"Remove SKUs from an existing SKU group.\"\"\"\n  removeSkusFromSkuGroup(id: String!, input: MutationRemoveSkusFromSkuGroupInput!): SKUGroup\n\n  \"\"\"\n  Restock inventory from committed. If there are not enough committed inventory, this mutation will error.\n  \"\"\"\n  restockFromCommittedInventory(input: MutationRestockFromCommittedInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"Set the channel association mode for a SKU Group.\"\"\"\n  setSkuGroupChannelAssociationMode(\n    \"\"\"SKU Group ID\"\"\"\n    id: String!\n    input: MutationSetSkuGroupChannelAssociationModeInput!\n  ): SKUGroup\n\n  \"\"\"\n  Stock new inventory. If there are backordered inventory, they will be moved to committed. It does not validate aganist backorder limit. Any extra inventory will be added to available. Documentation: https://godaddy-corp.atlassian.net/wiki/spaces/COMCORE/pages/3758600912/Inventory+Helper+Mutations#1.-stockInventory\n  \"\"\"\n  stockInventory(input: MutationStockInventoryInput!): [InventoryAdjustment!]\n\n  \"\"\"Update an existing attribute.\"\"\"\n  updateAttribute(id: String!, input: MutationUpdateAttributeInput!): Attribute\n\n  \"\"\"Update an existing attribute value.\"\"\"\n  updateAttributeValue(id: String!, input: MutationUpdateAttributeValueInput!): AttributeValue\n\n  \"\"\"Update an existing file.\"\"\"\n  updateFile(id: String!, input: UpdateFileInput!): File\n\n  \"\"\"\n  Update the label of a store-scoped inventory adjustment reason. Global preset reasons cannot be updated.\n  \"\"\"\n  updateInventoryAdjustmentReason(input: MutationUpdateInventoryAdjustmentReasonInput!): InventoryAdjustmentReason\n\n  \"\"\"Update an existing list.\"\"\"\n  updateList(id: String!, input: MutationUpdateListInput!): List\n\n  \"\"\"Add media objects or update existing media objects to existing List.\"\"\"\n  updateListMediaObjects(id: String!, input: MutationUpdateListMediaObjectsInput!): List\n\n  \"\"\"Update an existing list tree.\"\"\"\n  updateListTree(id: String!, input: MutationUpdateListTreeInput!): ListTree\n\n  \"\"\"Update an existing list tree node.\"\"\"\n  updateListTreeNode(id: String!, input: MutationUpdateListTreeNodeInput!): ListTreeNode\n\n  \"\"\"Update an existing location.\"\"\"\n  updateLocation(id: String!, input: MutationUpdateLocationInput!): Location\n\n  \"\"\"Update an existing option.\"\"\"\n  updateOption(id: String!, input: MutationUpdateOptionInput!): Option\n\n  \"\"\"Update an existing price object for an option.\"\"\"\n  updateOptionPrice(id: String!, input: MutationUpdateOptionPriceInput!): OptionPrice\n\n  \"\"\"\n  Update the currency code for an existing option price. This updates the currency code for both value and compareAtValue.\n  \"\"\"\n  updateOptionPriceCurrencyCode(id: String!, input: MutationUpdateOptionPriceCurrencyCodeInput!): OptionPrice\n\n  \"\"\"Update an existing option value.\"\"\"\n  updateOptionValue(id: String!, input: MutationUpdateOptionValueInput!): OptionValue\n\n  \"\"\"Update an existing price object.\"\"\"\n  updateOptionValuePrice(id: String!, input: MutationUpdateOptionValuePriceInput!): OptionValuePrice\n\n  \"\"\"\n  Update the currency code for an existing option value price. This updates the currency code for both value and compareAtValue.\n  \"\"\"\n  updateOptionValuePriceCurrencyCode(id: String!, input: MutationUpdateOptionValuePriceCurrencyCodeInput!): OptionValuePrice\n\n  \"\"\"Update an existing SKU.\"\"\"\n  updateSKU(id: String!, input: MutationUpdateSKUInput!): SKU @deprecated(reason: \"Use `updateSku` instead.\")\n\n  \"\"\"Update an existing SKU Group.\"\"\"\n  updateSKUGroup(id: String!, input: MutationUpdateSKUGroupInput!): SKUGroup @deprecated(reason: \"Use `updateSkuGroup` instead.\")\n\n  \"\"\"Update an existing price object.\"\"\"\n  updateSKUPrice(id: String!, input: MutationUpdateSKUPriceInput!): SKUPrice @deprecated(reason: \"Use `updateSkuPrice` instead.\")\n\n  \"\"\"Update an existing SKU.\"\"\"\n  updateSku(id: String!, input: MutationUpdateSkuInput!): SKU\n\n  \"\"\"Update an existing SKU Group.\"\"\"\n  updateSkuGroup(id: String!, input: MutationUpdateSkuGroupInput!): SKUGroup\n\n  \"\"\"\n  Add media objects or update existing media objects to existing SKU Group.\n  \"\"\"\n  updateSkuGroupMediaObjects(id: String!, input: MutationUpdateSkuGroupMediaObjectsInput!): SKUGroup\n\n  \"\"\"\n  Reorder options within a SKU group by updating the position of each option's association.\n  \"\"\"\n  updateSkuGroupOptionPositions(id: String!, input: MutationUpdateSkuGroupOptionPositionsInput!): SKUGroup\n\n  \"\"\"Add media objects or update existing media objects to existing SKU.\"\"\"\n  updateSkuMediaObjects(id: String!, input: MutationUpdateSkuMediaObjectsInput!): SKU\n\n  \"\"\"Update an existing price object.\"\"\"\n  updateSkuPrice(id: String!, input: MutationUpdateSkuPriceInput!): SKUPrice\n\n  \"\"\"\n  Update the currency code for an existing price. This updates the currency code for both value and compareAtValue.\n  \"\"\"\n  updateSkuPriceCurrencyCode(id: String!, input: MutationUpdateSkuPriceCurrencyCodeInput!): SKUPrice\n}\n\ninput MutationAddAttributeValuesToSKUInput {\n  attributeValueIds: [String!]!\n}\n\ninput MutationAddAttributeValuesToSkuInput {\n  attributeValueIds: [String!]!\n}\n\ninput MutationAddAttributesToSKUGroupInput {\n  attributes: [CreateSKUGroupAttributeInput!]!\n}\n\ninput MutationAddAttributesToSkuGroupInput {\n  attributes: [CreateSKUGroupAttributeInput!]!\n}\n\ninput MutationAddChannelsToSKUGroupInput {\n  \"\"\"\n  The channels to add to the SKU group.\n  \t\t\t\tThese are pointers to the Channels API, Catalog API\n  \t\t\t\tdoes not create the channel resources.\n  \"\"\"\n  channels: [SKUGroupChannelAddInput!]!\n}\n\ninput MutationAddChannelsToSkuGroupInput {\n  \"\"\"\n  The channels to add to the SKU group.\n  \t\t\t\tThese are pointers to the Channels API, Catalog API\n  \t\t\t\tdoes not create the channel resources.\n  \"\"\"\n  channels: [SKUGroupChannelAddInput!]!\n}\n\ninput MutationAddListTreeNodesToListTreeInput {\n  listTreeNodes: [AddListTreeNodeInput!]!\n}\n\ninput MutationAddListTreeNodesToParentListTreeNodeInput {\n  listTreeNodes: [AddListTreeNodeInput!]!\n}\n\ninput MutationAddMediaObjectsToListInput {\n  mediaObjects: [CreateMediaObjectInput!]!\n}\n\ninput MutationAddMediaObjectsToSKUGroupInput {\n  mediaObjects: [CreateMediaObjectInput!]!\n}\n\ninput MutationAddMediaObjectsToSKUInput {\n  mediaObjects: [CreateMediaObjectInput!]!\n}\n\ninput MutationAddMediaObjectsToSkuGroupInput {\n  mediaObjects: [CreateMediaObjectInput!]!\n}\n\ninput MutationAddMediaObjectsToSkuInput {\n  mediaObjects: [CreateMediaObjectInput!]!\n}\n\ninput MutationAddOptionsToSKUGroupInput {\n  \"\"\"UUIDs of existing options to associate with this SKU group.\"\"\"\n  optionIds: [String!]\n  options: [CreateOptionInput!]\n}\n\ninput MutationAddOptionsToSkuGroupInput {\n  \"\"\"UUIDs of existing options to associate with this SKU group.\"\"\"\n  optionIds: [String!]\n  options: [CreateOptionInput!]\n}\n\ninput MutationAddReferencesToListInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToListTreeInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToListTreeNodeInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToLocationInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToSKUGroupInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToSKUInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToSkuGroupInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddReferencesToSkuInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationAddSKUGroupToListsInput {\n  listIds: [String!]!\n}\n\ninput MutationAddSKUGroupsToListInput {\n  skuGroupIds: [String!]!\n}\n\ninput MutationAddSKUsToLocationInput {\n  skuIds: [String!]!\n}\n\ninput MutationAddSKUsToSKUGroupInput {\n  skuIds: [String!]!\n}\n\ninput MutationAddSkuGroupToListsInput {\n  listIds: [String!]!\n}\n\ninput MutationAddSkuGroupsToListInput {\n  skuGroupIds: [String!]!\n}\n\ninput MutationAddSkusToLocationInput {\n  skuIds: [String!]!\n}\n\ninput MutationAddSkusToSkuGroupInput {\n  skuIds: [String!]!\n}\n\ninput MutationAdjustInventoryInput {\n  delta: Int!\n  locationId: ID!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationArchiveInventoryAdjustmentReasonInput {\n  id: ID!\n}\n\ninput MutationCommitInventoryInput {\n  allowBackorders: Boolean\n  locationId: ID!\n  quantity: Int!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationCreateAttributeInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  description: String\n  htmlDescription: String\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n  skuGroupId: ID!\n  values: [AssociateAttributeValueInput!]\n}\n\ninput MutationCreateInventoryAdjustmentReasonInput {\n  label: String!\n  name: String!\n}\n\ninput MutationCreateListInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String!\n  mediaObjects: [CreateMediaObjectInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  references: [CreateReferenceInput!]\n\n  \"\"\"The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationCreateListTreeInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String!\n  listTreeNodes: [CreateListTreeNodeInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  references: [CreateReferenceInput!]\n\n  \"\"\"The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationCreateLocationInput {\n  address: CreateAddressInput!\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  references: [CreateReferenceInput!]\n\n  \"\"\"The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationCreateOptionInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  description: String\n  htmlDescription: String\n\n  \"\"\"Whether this option is shareable across multiple SKU Groups.\"\"\"\n  shareable: Boolean\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  position: Int\n  prices: [CreateOptionPriceInput!]\n  skuGroupId: String @deprecated(reason: \"Use skuGroupIds instead.\")\n\n  \"\"\"The UUIDs of the SKU Groups to associate the Option with.\"\"\"\n  skuGroupIds: [String!]\n\n  \"\"\"\n  The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.\n  \"\"\"\n  type: String!\n  validation: CreateOptionValidationInput\n  values: [CreateOptionValueInput!]\n}\n\ninput MutationCreateOptionPriceInput {\n  compareAtValue: SimpleMoneyInput\n  optionId: String!\n  value: SimpleMoneyInput!\n}\n\ninput MutationCreateOptionValueInput {\n  label: String!\n  metafields: [CreateMetafieldInput!]\n  name: String\n  optionId: String!\n  position: Int\n  prices: [CreateOptionValuePriceInput!]\n}\n\ninput MutationCreateOptionValuePriceInput {\n  compareAtValue: SimpleMoneyInput\n  optionValueId: String!\n  value: SimpleMoneyInput!\n}\n\ninput MutationCreateSKUGroupInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  attributes: [CreateSKUGroupAttributeInput!]\n  channels: [SKUGroupChannelAddInput!]\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String!\n  mediaObjects: [CreateMediaObjectInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  options: [CreateOptionInput!]\n  references: [CreateReferenceInput!]\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n  skus: [CreateSKUGroupSKUInput!]\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  type: String!\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationCreateSKUPriceInput {\n  compareAtValue: SimpleMoneyInput\n  skuId: ID!\n  value: SimpleMoneyInput!\n}\n\ninput MutationCreateSkuGroupInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  attributes: [CreateSKUGroupAttributeInput!]\n  channels: [SKUGroupChannelAddInput!]\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String!\n  mediaObjects: [CreateMediaObjectInput!]\n  metafields: [CreateMetafieldInput!]\n  name: String\n  options: [CreateOptionInput!]\n  references: [CreateReferenceInput!]\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n  skus: [CreateSKUGroupSKUInput!]\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  type: String!\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationCreateSkuPriceInput {\n  compareAtValue: SimpleMoneyInput\n  skuId: ID!\n  value: SimpleMoneyInput!\n}\n\ninput MutationReduceInventoryInput {\n  locationId: ID!\n  quantity: Int!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationReleaseInventoryInput {\n  locationId: ID!\n  quantity: Int!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationRemoveAttributeValuesFromAttributeInput {\n  attributeValueIds: [String!]!\n}\n\ninput MutationRemoveAttributeValuesFromSKUInput {\n  attributeValueIds: [String!]!\n}\n\ninput MutationRemoveAttributeValuesFromSkuInput {\n  attributeValueIds: [String!]!\n}\n\ninput MutationRemoveAttributesFromSKUGroupInput {\n  attributeIds: [String!]!\n}\n\ninput MutationRemoveAttributesFromSkuGroupInput {\n  attributeIds: [String!]!\n}\n\ninput MutationRemoveChannelsFromSKUGroupInput {\n  channelIds: [String!]!\n}\n\ninput MutationRemoveChannelsFromSkuGroupInput {\n  channelIds: [String!]!\n}\n\ninput MutationRemoveListTreeNodesFromListTreeInput {\n  listTreeNodeIds: [String!]!\n}\n\ninput MutationRemoveListTreeNodesFromParentListTreeNodeInput {\n  listTreeNodeIds: [String!]!\n}\n\ninput MutationRemoveMediaObjectsFromListInput {\n  mediaObjectIds: [String!]!\n}\n\ninput MutationRemoveMediaObjectsFromSKUGroupInput {\n  mediaObjectIds: [String!]!\n}\n\ninput MutationRemoveMediaObjectsFromSKUInput {\n  mediaObjectIds: [String!]!\n}\n\ninput MutationRemoveMediaObjectsFromSkuGroupInput {\n  mediaObjectIds: [String!]!\n}\n\ninput MutationRemoveMediaObjectsFromSkuInput {\n  mediaObjectIds: [String!]!\n}\n\ninput MutationRemoveMetafieldsFromAttributeInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromAttributeValueInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromListInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromListTreeInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromLocationInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromOptionInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromOptionValueInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromSkuGroupInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveMetafieldsFromSkuInput {\n  metafields: [RemoveMetafieldInput!]!\n}\n\ninput MutationRemoveOptionValuesFromListOptionInput {\n  valueIds: [String!]!\n}\n\ninput MutationRemoveOptionsFromSKUGroupInput {\n  optionIds: [String!]!\n}\n\ninput MutationRemoveOptionsFromSkuGroupInput {\n  optionIds: [String!]!\n}\n\ninput MutationRemovePricesFromOptionInput {\n  priceIds: [String!]!\n}\n\ninput MutationRemovePricesFromOptionValueInput {\n  priceIds: [String!]!\n}\n\ninput MutationRemovePricesFromSKUInput {\n  priceIds: [String!]!\n}\n\ninput MutationRemovePricesFromSkuInput {\n  priceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromListInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromListTreeInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromListTreeNodeInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromLocationInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromSKUGroupInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromSKUInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromSkuGroupInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveReferencesFromSkuInput {\n  referenceIds: [String!]!\n}\n\ninput MutationRemoveSKUGroupFromListsInput {\n  listIds: [String!]!\n}\n\ninput MutationRemoveSKUGroupsFromListInput {\n  skuGroupIds: [String!]!\n}\n\ninput MutationRemoveSKUsFromLocationInput {\n  skuIds: [String!]!\n}\n\ninput MutationRemoveSKUsFromSKUGroupInput {\n  skuIds: [String!]!\n}\n\ninput MutationRemoveSkuGroupFromListsInput {\n  listIds: [String!]!\n}\n\ninput MutationRemoveSkuGroupsFromListInput {\n  skuGroupIds: [String!]!\n}\n\ninput MutationRemoveSkusFromLocationInput {\n  skuIds: [String!]!\n}\n\ninput MutationRemoveSkusFromSkuGroupInput {\n  skuIds: [String!]!\n}\n\ninput MutationRestockFromCommittedInventoryInput {\n  locationId: ID!\n  quantity: Int!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationSetSkuGroupChannelAssociationModeInput {\n  \"\"\"\n  The channel association mode for this SKU Group. Can be ALL (uses active channels registered to the store) or\n  \t\t\t\t\tSELECTIVE (uses custom channel associations).\n  \"\"\"\n  mode: String!\n}\n\ninput MutationStockInventoryInput {\n  locationId: ID!\n  quantity: Int!\n  reasonName: String\n  references: [CreateReferenceInput!]\n  skuId: ID!\n}\n\ninput MutationUpdateAttributeInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  description: String\n  htmlDescription: String\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  position: Int\n}\n\ninput MutationUpdateAttributeValueInput {\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  position: Int\n}\n\ninput MutationUpdateInventoryAdjustmentReasonInput {\n  id: ID!\n  label: String\n}\n\ninput MutationUpdateListInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n\n  \"\"\"The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationUpdateListMediaObjectsInput {\n  mediaObjects: [UpdateMediaObjectInput!]!\n}\n\ninput MutationUpdateListTreeInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n\n  \"\"\"The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationUpdateListTreeNodeInput {\n  listId: String\n  listTreeId: String\n  parentNodeId: String\n  position: Int\n}\n\ninput MutationUpdateLocationInput {\n  address: UpdateAddressInput\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n\n  \"\"\"The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationUpdateOptionInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  description: String\n  htmlDescription: String\n  shareable: Boolean\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  position: Int\n\n  \"\"\"\n  The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.\n  \"\"\"\n  type: String\n  validation: CreateOptionValidationInput\n}\n\ninput MutationUpdateOptionPriceCurrencyCodeInput {\n  currencyCode: String!\n}\n\ninput MutationUpdateOptionPriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput\n}\n\ninput MutationUpdateOptionValueInput {\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  position: Int\n}\n\ninput MutationUpdateOptionValuePriceCurrencyCodeInput {\n  currencyCode: String!\n}\n\ninput MutationUpdateOptionValuePriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput\n}\n\ninput MutationUpdateSKUGroupInput {\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  label: String\n  name: String\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationUpdateSKUInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  backorderLimit: Int\n  code: String\n\n  \"\"\"DEPRECATED. Use unitCost instead.\"\"\"\n  cost: Int @deprecated(reason: \"This cost field cannot specify currency code. Use `unitCost` instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  disableInventoryTracking: Boolean\n  disablePriceOverrides: Boolean\n  disableShipping: Boolean\n  eanCode: String\n  gtinCode: String\n  htmlDescription: String\n  isbnCode: String\n  label: String\n  name: String\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  unitCost: SimpleMoneyInput\n\n  \"\"\"The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.\"\"\"\n  unitOfWeight: String\n  upcCode: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  weight: Float\n}\n\ninput MutationUpdateSKUPriceInput {\n  compareAtValue: SimpleMoneyInput\n\n  \"\"\"\n  Update the currency code for this price. When provided, updates the currency code while keeping the numeric value unchanged.\n  \"\"\"\n  currencyCode: String\n  value: SimpleMoneyInput\n}\n\ninput MutationUpdateSkuGroupInput {\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  htmlDescription: String\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n}\n\ninput MutationUpdateSkuGroupMediaObjectsInput {\n  mediaObjects: [UpdateMediaObjectInput!]!\n}\n\ninput MutationUpdateSkuGroupOptionPositionsInput {\n  positions: [UpdateSKUGroupOptionPositionInput!]!\n}\n\ninput MutationUpdateSkuInput {\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n  backorderLimit: Int\n  code: String\n\n  \"\"\"DEPRECATED. Use unitCost instead.\"\"\"\n  cost: Int @deprecated(reason: \"This cost field cannot specify currency code. Use `unitCost` instead.\")\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  description: String\n  disableInventoryTracking: Boolean\n  disablePriceOverrides: Boolean\n  disableShipping: Boolean\n  eanCode: String\n  gtinCode: String\n  htmlDescription: String\n  isbnCode: String\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n  unitCost: SimpleMoneyInput\n\n  \"\"\"The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.\"\"\"\n  unitOfWeight: String\n  upcCode: String\n\n  \"\"\"DEPRECATED: Do not use this field.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is only used for Catalog v1 > v2 sync and will be removed in the future.\")\n  weight: Float\n}\n\ninput MutationUpdateSkuMediaObjectsInput {\n  mediaObjects: [UpdateMediaObjectInput!]!\n}\n\ninput MutationUpdateSkuPriceCurrencyCodeInput {\n  currencyCode: String!\n}\n\ninput MutationUpdateSkuPriceInput {\n  compareAtValue: SimpleMoneyInput\n  value: SimpleMoneyInput\n}\n\n\"\"\"\nFilters items where the name is equal to the specified string or in an array of strings.\n\"\"\"\ninput NameFilter {\n  \"\"\"\n  Filters items where the name contains the specified string, case-insensitive.\n  \"\"\"\n  contains: String\n  eq: String\n\n  \"\"\"Filters items where the name matches any of the specified names.\"\"\"\n  in: [String!]\n}\n\nscalar Null\n\ntype NumericOption {\n  \"\"\"The timestamp of when the Option was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"A description of the Option.\"\"\"\n  description: String\n\n  \"\"\"The UUID of the Option\"\"\"\n  id: ID!\n\n  \"\"\"\n  Whether the option is shareable across multiple SKU Groups (a global modifier).\n  \"\"\"\n  shareable: Boolean!\n\n  \"\"\"The display lable of the Option\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): OptionMetafieldsConnection\n\n  \"\"\"A unique name of the Option.\"\"\"\n  name: String!\n\n  \"\"\"The position of the option.\"\"\"\n  position: Int\n\n  \"\"\"\n  Represents the additional cost of a Numeric Option. When empty, it indicates this option allows for flexible pricing.\n  \"\"\"\n  prices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    last: Int\n    paginationType: PaginationType = CURSOR\n  ): NumericOptionPricesConnection\n\n  \"\"\"The UUID of the SKU Group that the Option belongs to.\"\"\"\n  skuGroupId: ID! @deprecated(reason: \"Use skuGroupIds or the SKUGroup.options connection instead. An option may belong to multiple SKU groups.\")\n\n  \"\"\"The IDs of all SKU groups this option is associated with.\"\"\"\n  skuGroupIds: [String!]!\n\n  \"\"\"\n  The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.\n  \"\"\"\n  type: String\n\n  \"\"\"The timestamp of when the Option was updated.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"\n  Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.\n  \"\"\"\n  validation: OptionValidation\n}\n\ntype NumericOptionPricesConnection {\n  edges: [NumericOptionPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype NumericOptionPricesConnectionEdge {\n  cursor: String!\n  node: OptionPrice\n}\n\nunion Option = ListOption | NumericOption | TextOption\n\ninput OptionIdFilter {\n  eq: String\n  in: [String!]\n}\n\ninput OptionIdsFilter {\n  in: [String!]\n}\n\ntype OptionMetafieldsConnection {\n  edges: [OptionMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype OptionMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput OptionOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  label: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  position: OrderByDirectionEnum\n  price: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"\nRepresents the additional cost of an option added to a SKU group (e.g 'Toppings' option for a coffee drink).\n\"\"\"\ntype OptionPrice {\n  \"\"\"The compare-at value of the price.\"\"\"\n  compareAtValue: SimpleMoney\n\n  \"\"\"The timestamp of when the price was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the price.\"\"\"\n  id: ID!\n\n  \"\"\"The option that this price belongs to.\"\"\"\n  option: Option\n\n  \"\"\"The last update timestamp of the price.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"The value of the price.\"\"\"\n  value: SimpleMoney!\n}\n\ninput OptionPriceIdsFilter {\n  in: [String!]\n}\n\ninput OptionPriceOrderBy {\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"\nProvide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.\n\"\"\"\ntype OptionValidation {\n  \"\"\"The maximum number that can be applied to the option.\"\"\"\n  max: Int\n\n  \"\"\"The minimum number that can be applied to the option.\"\"\"\n  min: Int\n}\n\ntype OptionValue {\n  \"\"\"The timestamp of when the Option Value was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The UUID of the Option Value.\"\"\"\n  id: ID!\n\n  \"\"\"The display label of the Option Value.\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): OptionValueMetafieldsConnection\n\n  \"\"\"A unique name of the Option Value.\"\"\"\n  name: String!\n\n  \"\"\"The option that this value belongs to.\"\"\"\n  option: ListOption\n\n  \"\"\"The position of the option value.\"\"\"\n  position: Int\n\n  \"\"\"\n  These are all the prices the Option Value can be sold at. The price can be different based the channel where it is listed or if there is a promotion running.\n  \"\"\"\n  prices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    last: Int\n    paginationType: PaginationType = CURSOR\n  ): OptionValuePricesConnection\n\n  \"\"\"The timestamp of when the Option Value was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput OptionValueIdFilter {\n  eq: String\n}\n\ninput OptionValueIdsFilter {\n  in: [String!]\n}\n\ntype OptionValueMetafieldsConnection {\n  edges: [OptionValueMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype OptionValueMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput OptionValueOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  position: OrderByDirectionEnum\n  price: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"\nRepresents the additional cost of the option value added to a SKU (e.g the option value 'Caramel Drizzle' could have a different cost to other 'Topping' options).\n\"\"\"\ntype OptionValuePrice {\n  \"\"\"The compare-at value of the price.\"\"\"\n  compareAtValue: SimpleMoney\n\n  \"\"\"The timestamp of when the price was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the price.\"\"\"\n  id: ID!\n\n  \"\"\"The option value that this price belongs to.\"\"\"\n  optionValue: OptionValue\n\n  \"\"\"The last update timestamp of the price.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"The value of the price.\"\"\"\n  value: SimpleMoney!\n}\n\ninput OptionValuePriceIdsFilter {\n  in: [String!]\n}\n\ninput OptionValuePriceOrderBy {\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype OptionValuePricesConnection {\n  edges: [OptionValuePricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype OptionValuePricesConnectionEdge {\n  cursor: String!\n  node: OptionValuePrice\n}\n\n\"\"\"The direction in which to order items.\"\"\"\nenum OrderByDirectionEnum {\n  ASC\n  DESC\n}\n\ntype PageInfo {\n  endCursor: String\n  hasNextPage: Boolean!\n  hasPreviousPage: Boolean!\n  startCursor: String\n}\n\nenum PaginationType {\n  CURSOR\n  OFFSET\n}\n\n\"\"\"Defines a range of prices.\"\"\"\ntype PriceRange {\n  \"\"\"Maximum price.\"\"\"\n  max: Float\n\n  \"\"\"Minimum price.\"\"\"\n  min: Float\n}\n\ntype Query {\n  SKU(id: String!): SKU @deprecated(reason: \"Use sku instead.\")\n  SKUGroup(id: String!): SKUGroup @deprecated(reason: \"Use skuGroup instead.\")\n  SKUGroups(after: String, before: String, channelId: SKUGroupChannelIdFilter, createdAt: CreatedAtFilter, first: Int, id: SKUGroupIdsFilter, last: Int, listId: ListIdFilter, name: NameFilter, orderBy: SKUGroupOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, status: SKUGroupStatusFilter, updatedAt: UpdatedAtFilter): QuerySKUGroupsConnection @deprecated(reason: \"Use skuGroups instead.\")\n  SKUs(after: String, attributeValues: SKUAttributeValueFilter, before: String, createdAt: CreatedAtFilter, first: Int, id: SKUIdsFilter, last: Int, locationId: LocationIdFilter, name: NameFilter, orderBy: SKUOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, skuGroupId: SKUGroupIdFilter, status: SKUStatusFilter, updatedAt: UpdatedAtFilter): QuerySKUsConnection @deprecated(reason: \"Use skus instead.\")\n  _service: _Service!\n  attribute(id: String!): Attribute\n  attributeValue(id: String!): AttributeValue\n  attributeValues(after: String, attributeId: AttributeIdFilter, before: String, createdAt: CreatedAtFilter, first: Int, id: AttributeValueIdsFilter, last: Int, name: NameFilter, orderBy: AttributeValueOrderBy, paginationType: PaginationType = CURSOR, skuId: SKUIdFilter, updatedAt: UpdatedAtFilter): QueryAttributeValuesConnection\n  attributes(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: AttributeIdsFilter, last: Int, name: NameFilter, orderBy: AttributeOrderBy, paginationType: PaginationType = CURSOR, skuGroupId: SKUGroupIdFilter, skuGroupStatus: SKUGroupStatusFilter, updatedAt: UpdatedAtFilter): QueryAttributesConnection\n\n  \"\"\"\n  Special list tree to hold the main categories of the store. It cannot be updated or archived.\n  \"\"\"\n  categoriesListTree: ListTree\n\n  \"\"\"Retrieve a file by its ID.\"\"\"\n  file(id: String!): File\n  files(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: FileIdsFilter, last: Int, orderBy: FileOrderBy, paginationType: PaginationType = CURSOR, status: FileStatusFilter, storageUrl: FileStorageUrlFilter, updatedAt: UpdatedAtFilter): QueryFilesConnection\n  inventoryAdjustment(id: String!): InventoryAdjustment\n\n  \"\"\"\n  List inventory adjustment reasons available to the current store. Includes both store-scoped and global preset reasons.\n  \"\"\"\n  inventoryAdjustmentReasons(after: String, before: String, first: Int, last: Int, name: NameFilter, orderBy: InventoryAdjustmentReasonOrderBy, paginationType: PaginationType = CURSOR, status: InventoryAdjustmentReasonStatusFilter): QueryInventoryAdjustmentReasonsConnection\n  inventoryAdjustments(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: InventoryAdjustmentIdsFilter, last: Int, locationId: LocationIdFilter, orderBy: InventoryAdjustmentOrderBy, paginationType: PaginationType = CURSOR, reasonName: InventoryAdjustmentReasonNameFilter, referenceValue: ReferenceValueFilter, skuId: SKUIdFilter, type: InventoryAdjustmentTypeFilter): QueryInventoryAdjustmentsConnection\n  inventoryCount(locationId: String!, skuId: String!, type: String): [InventoryCount!]\n  inventoryCounts(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: InventoryCountIdsFilter, last: Int, locationId: LocationIdFilter, locationStatus: LocationStatusFilter, orderBy: InventoryCountOrderBy, paginationType: PaginationType = CURSOR, skuId: SKUIdFilter, skuStatus: InventoryCountSKUStatusFilter, type: InventoryCountTypeFilter, updatedAt: UpdatedAtFilter): QueryInventoryCountsConnection\n  list(id: String!): List\n  listTree(id: String!): ListTree\n  listTreeNode(id: String!): ListTreeNode\n  listTreeNodes(after: String, before: String, createdAt: CreatedAtFilter, first: Int, hasParent: Boolean, id: ListTreeNodeIdsFilter, last: Int, listId: ListIdFilter, listStatus: ListTreeNodeListStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}, listTreeId: ListTreeIdFilter, listTreeStatus: ListTreeNodeListTreeStatusFilter, orderBy: ListTreeNodeOrderBy, paginationType: PaginationType = CURSOR, parentNodeId: ListTreeNodeParentNodeIdFilter, referenceValue: ReferenceValueFilter, updatedAt: UpdatedAtFilter): QueryListTreeNodesConnection\n\n  \"\"\"List trees. Excludes the special categories list tree.\"\"\"\n  listTrees(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: ListTreeIdsFilter, last: Int, name: NameFilter, orderBy: ListTreeOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, status: ListTreeStatusFilter, updatedAt: UpdatedAtFilter): QueryListTreesConnection\n  lists(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: ListIdsFilter, last: Int, name: NameFilter, orderBy: ListOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, skuGroupId: SKUGroupIdFilter, status: ListStatusFilter, updatedAt: UpdatedAtFilter): QueryListsConnection\n  location(id: String!): Location\n  locations(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: LocationIdsFilter, last: Int, name: NameFilter, orderBy: LocationOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, skuId: SKUIdFilter, status: LocationStatusFilter, updatedAt: UpdatedAtFilter): QueryLocationsConnection\n\n  \"\"\"Query all option prices.\"\"\"\n  optionPrices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    id: OptionPriceIdsFilter\n    last: Int\n    optionId: OptionIdFilter\n    orderBy: OptionPriceOrderBy\n    paginationType: PaginationType = CURSOR\n    updatedAt: UpdatedAtFilter\n  ): QueryOptionPricesConnection\n\n  \"\"\"Query all option value prices.\"\"\"\n  optionValuePrices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    id: OptionValuePriceIdsFilter\n    last: Int\n    optionValueId: OptionValueIdFilter\n    orderBy: OptionValuePriceOrderBy\n    paginationType: PaginationType = CURSOR\n    updatedAt: UpdatedAtFilter\n  ): QueryOptionValuePricesConnection\n  optionValues(after: String, before: String, createdAt: CreatedAtFilter, first: Int, id: OptionValueIdsFilter, last: Int, optionId: OptionIdFilter, orderBy: OptionValueOrderBy, paginationType: PaginationType = CURSOR, updatedAt: UpdatedAtFilter): QueryOptionValuesConnection\n  options(\n    after: String\n\n    \"\"\"\n    Returns shareable options that are not already associated with the specified SKU group. Use this to find options that can be added to a SKU group. Cannot be combined with skuGroupId or skuGroupStatus filters.\n    \"\"\"\n    assignableToSkuGroupId: String\n    before: String\n    createdAt: CreatedAtFilter\n    first: Int\n    id: OptionIdsFilter\n\n    \"\"\"\n    Filter options by their shareable status. When true, returns only shareable options; when false, returns only non-shareable options.\n    \"\"\"\n    shareable: Boolean\n    label: LabelFilter\n    last: Int\n    name: NameFilter\n    orderBy: OptionOrderBy\n    paginationType: PaginationType = CURSOR\n    skuGroupId: SKUGroupIdFilter\n    skuGroupStatus: SKUGroupStatusFilter\n    updatedAt: UpdatedAtFilter\n  ): QueryOptionsConnection\n  sku(id: String!): SKU\n  skuGroup(id: String!): SKUGroup\n  skuGroups(after: String, before: String, channelId: SKUGroupChannelIdFilter, createdAt: CreatedAtFilter, first: Int, id: SKUGroupIdsFilter, label: LabelFilter, last: Int, listId: ListIdFilter, name: NameFilter, orderBy: SKUGroupOrderBy, paginationType: PaginationType = CURSOR, referenceValue: ReferenceValueFilter, status: SKUGroupStatusFilter, type: SKUGroupTypeFilter, updatedAt: UpdatedAtFilter): QuerySkuGroupsConnection\n\n  \"\"\"Query all SKU prices.\"\"\"\n  skuPrices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    id: SKUPriceIdsFilter\n    last: Int\n    orderBy: SKUPriceOrderBy\n    paginationType: PaginationType = CURSOR\n    skuId: SKUIdFilter\n    updatedAt: UpdatedAtFilter\n  ): QuerySkuPricesConnection\n  skus(\n    after: String\n    attributeValues: SKUAttributeValueFilter\n    before: String\n    code: SKUCodeFilter\n    createdAt: CreatedAtFilter\n    eanCode: SKUEanCodeFilter\n    first: Int\n    gtinCode: SKUGtinCodeFilter\n    id: SKUIdsFilter\n    isbnCode: SKUIsbnCodeFilter\n    label: LabelFilter\n    last: Int\n    locationId: LocationIdFilter\n    name: NameFilter\n    orderBy: SKUOrderBy\n    paginationType: PaginationType = CURSOR\n\n    \"\"\"\n    A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\n    Supported columns: `label`, `code`\n\n    Supported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\n    Supported functions: `contains`\n    \"\"\"\n    queryFilter: String\n    referenceValue: ReferenceValueFilter\n    skuGroupId: SKUGroupIdFilter\n\n    \"\"\"\n    Filter SKUs by their SKU group's status. SKUs without a SKU group will be excluded when this filter is present.\n    \"\"\"\n    skuGroupStatus: SKUGroupStatusFilter\n    status: SKUStatusFilter\n    upcCode: SKUUpcCodeFilter\n    updatedAt: UpdatedAtFilter\n  ): QuerySkusConnection\n}\n\ntype QueryAttributeValuesConnection {\n  edges: [QueryAttributeValuesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryAttributeValuesConnectionEdge {\n  cursor: String!\n  node: AttributeValue\n}\n\ntype QueryAttributesConnection {\n  edges: [QueryAttributesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryAttributesConnectionEdge {\n  cursor: String!\n  node: Attribute\n}\n\ntype QueryFilesConnection {\n  edges: [QueryFilesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryFilesConnectionEdge {\n  cursor: String!\n  node: File\n}\n\ntype QueryInventoryAdjustmentReasonsConnection {\n  edges: [QueryInventoryAdjustmentReasonsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryInventoryAdjustmentReasonsConnectionEdge {\n  cursor: String!\n  node: InventoryAdjustmentReason\n}\n\ntype QueryInventoryAdjustmentsConnection {\n  edges: [QueryInventoryAdjustmentsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryInventoryAdjustmentsConnectionEdge {\n  cursor: String!\n  node: InventoryAdjustment\n}\n\ntype QueryInventoryCountsConnection {\n  edges: [QueryInventoryCountsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryInventoryCountsConnectionEdge {\n  cursor: String!\n  node: InventoryCount\n}\n\ntype QueryListTreeNodesConnection {\n  edges: [QueryListTreeNodesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryListTreeNodesConnectionEdge {\n  cursor: String!\n  node: ListTreeNode\n}\n\ntype QueryListTreesConnection {\n  edges: [QueryListTreesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryListTreesConnectionEdge {\n  cursor: String!\n  node: ListTree\n}\n\ntype QueryListsConnection {\n  edges: [QueryListsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryListsConnectionEdge {\n  cursor: String!\n  node: List\n}\n\ntype QueryLocationsConnection {\n  edges: [QueryLocationsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryLocationsConnectionEdge {\n  cursor: String!\n  node: Location\n}\n\ntype QueryOptionPricesConnection {\n  edges: [QueryOptionPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryOptionPricesConnectionEdge {\n  cursor: String!\n  node: OptionPrice\n}\n\ntype QueryOptionValuePricesConnection {\n  edges: [QueryOptionValuePricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryOptionValuePricesConnectionEdge {\n  cursor: String!\n  node: OptionValuePrice\n}\n\ntype QueryOptionValuesConnection {\n  edges: [QueryOptionValuesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryOptionValuesConnectionEdge {\n  cursor: String!\n  node: OptionValue\n}\n\ntype QueryOptionsConnection {\n  edges: [QueryOptionsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QueryOptionsConnectionEdge {\n  cursor: String!\n  node: Option\n}\n\ntype QuerySKUGroupsConnection {\n  edges: [QuerySKUGroupsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QuerySKUGroupsConnectionEdge {\n  cursor: String!\n  node: SKUGroup\n}\n\ntype QuerySKUsConnection {\n  edges: [QuerySKUsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QuerySKUsConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\ntype QuerySkuGroupsConnection {\n  edges: [QuerySkuGroupsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QuerySkuGroupsConnectionEdge {\n  cursor: String!\n  node: SKUGroup\n}\n\ntype QuerySkuPricesConnection {\n  edges: [QuerySkuPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QuerySkuPricesConnectionEdge {\n  cursor: String!\n  node: SKUPrice\n}\n\ntype QuerySkusConnection {\n  edges: [QuerySkusConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype QuerySkusConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\n\"\"\"A reference to the resource in an external service.\"\"\"\ntype Reference {\n  \"\"\"The globally-unique ID of the reference.\"\"\"\n  id: ID\n\n  \"\"\"The origin or location of the reference. Ex. OLS or POYNT\"\"\"\n  origin: String\n\n  \"\"\"The identifier of the resource in an external service\"\"\"\n  value: String\n}\n\ninput ReferenceOriginFilter {\n  eq: String\n  in: [String!]\n}\n\ninput ReferenceValueFilter {\n  eq: String\n  in: [String!]\n}\n\ninput RemoveMetafieldInput {\n  key: String!\n  namespace: String!\n}\n\n\"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\ntype SKU {\n  \"\"\"\n  HTML description for the SKU. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"\n  A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  SKUGroup: SKUGroup @deprecated(reason: \"Use skuGroup instead.\")\n\n  \"\"\"The timestamp of when the SKU was archived.\"\"\"\n  archivedAt: DateTime\n\n  \"\"\"Attribute values of SKU.\"\"\"\n  attributeValues(after: String, before: String, first: Int, last: Int, orderBy: AttributeValueOrderBy, paginationType: PaginationType = CURSOR): SKUAttributeValuesConnection\n\n  \"\"\"\n  Attributes are properties or characteristics of the SKU. For example, color or size.\n  \"\"\"\n  attributes(after: String, before: String, first: Int, id: AttributeIdsFilter, last: Int, orderBy: AttributeOrderBy, paginationType: PaginationType = CURSOR): SKUAttributesConnection\n\n  \"\"\"\n  The number of backorders allowed for the SKU. If set to 0, backorders are not allowed. If set to null, backorders are allowed without limit.\n  \"\"\"\n  backorderLimit: Int\n\n  \"\"\"The unique code for the SKU.\"\"\"\n  code: String!\n\n  \"\"\"DEPRECATED. Use unitCost instead.\"\"\"\n  cost: Int @deprecated(reason: \"This cost field cannot specify currency code. Use `unitCost` instead.\")\n\n  \"\"\"The timestamp of when the SKU was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The description of the SKU.\"\"\"\n  description: String\n\n  \"\"\"Flag to mark whether stock should be tracked for the SKU.\"\"\"\n  disableInventoryTracking: Boolean\n\n  \"\"\"Flag to mark whether or not a custom price can be provided.\"\"\"\n  disablePriceOverrides: Boolean\n\n  \"\"\"Flag to mark whether the SKU should be shipped or not.\"\"\"\n  disableShipping: Boolean\n\n  \"\"\"The EAN code for the SKU.\"\"\"\n  eanCode: String\n\n  \"\"\"The GTIN code for the SKU.\"\"\"\n  gtinCode: String\n\n  \"\"\"\n  HTML description for the SKU. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The globally-unique ID of the SKU.\"\"\"\n  id: ID!\n\n  \"\"\"\n  An immutable entity that represents a change in state of a quantity of SKU at a particular time and location. Each adjustment will either have a positive, negative, or neutral impact on the count of available SKUs in a location.\n  \"\"\"\n  inventoryAdjustments(after: String, before: String, first: Int, last: Int, orderBy: InventoryAdjustmentOrderBy, paginationType: PaginationType = CURSOR): SKUInventoryAdjustmentsConnection\n\n  \"\"\"\n  The quantity of a SKU in a specific state at a particular time and location.\n  \"\"\"\n  inventoryCounts(after: String, before: String, first: Int, last: Int, locationId: LocationIdFilter, locationStatus: LocationStatusFilter, orderBy: InventoryCountOrderBy, paginationType: PaginationType = CURSOR, skuStatus: InventoryCountSKUStatusFilter, type: InventoryCountTypeFilter): SKUInventoryCountsConnection\n\n  \"\"\"The ISBN code for the SKU.\"\"\"\n  isbnCode: String\n\n  \"\"\"The display label of the SKU.\"\"\"\n  label: String!\n\n  \"\"\"The locations where the SKU is available.\"\"\"\n  locations(after: String, before: String, first: Int, last: Int, orderBy: LocationOrderBy, paginationType: PaginationType = CURSOR, status: LocationStatusFilter): SKULocationsConnection\n\n  \"\"\"Media stored under this SKU.\"\"\"\n  mediaObjects(after: String, before: String, first: Int, last: Int, paginationType: PaginationType = CURSOR): SKUMediaObjectsConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): SKUMetafieldsConnection\n\n  \"\"\"A unique name for the SKU.\"\"\"\n  name: String!\n\n  \"\"\"\n  These are all the prices the SKU can be sold at. The price can be different based the channel where it is listed or if there is a promotion running.\n  \"\"\"\n  prices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    last: Int\n  ): SKUPricesConnection\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): SKUReferencesConnection\n\n  \"\"\"A short label for the SKU, useful for UI with limited space.\"\"\"\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"\n  A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.\n  \"\"\"\n  skuGroup: SKUGroup\n\n  \"\"\"The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String\n\n  \"\"\"\n  The cost of the SKU per unit. This is a money object that includes the value and currency code.\n  \"\"\"\n  unitCost: SimpleMoney\n\n  \"\"\"The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.\"\"\"\n  unitOfWeight: String\n\n  \"\"\"The UPC code for the SKU.\"\"\"\n  upcCode: String\n\n  \"\"\"The timestamp of when the SKU was updated.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"The weight of the SKU.\"\"\"\n  weight: Float\n}\n\ninput SKUAttributeValueFilter {\n  has: [String!]\n}\n\ntype SKUAttributeValuesConnection {\n  edges: [SKUAttributeValuesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUAttributeValuesConnectionEdge {\n  cursor: String!\n  node: AttributeValue\n}\n\ntype SKUAttributesConnection {\n  edges: [SKUAttributesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUAttributesConnectionEdge {\n  cursor: String!\n  node: Attribute\n}\n\ninput SKUCodeFilter {\n  \"\"\"\n  Filters SKUs where the code contains the specified string, case-insensitive.\n  \"\"\"\n  contains: String\n  eq: String\n\n  \"\"\"Filters SKUs where the code matches any of the specified codes.\"\"\"\n  in: [String!]\n}\n\ninput SKUEanCodeFilter {\n  eq: String\n  in: [String!]\n}\n\ntype SKUGroup {\n  \"\"\"\n  HTML description for the SKU group. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\n  SKUs(\n    after: String\n    attributeValues: SKUAttributeValueFilter\n    before: String\n    createdAt: CreatedAtFilter\n    first: Int\n    label: LabelFilter\n    last: Int\n    locationId: LocationIdFilter\n    name: NameFilter\n    paginationType: PaginationType = CURSOR\n\n    \"\"\"\n    A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\n    Supported columns: `label`, `code`\n\n    Supported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\n    Supported functions: `contains`\n    \"\"\"\n    queryFilter: String\n    referenceValue: ReferenceValueFilter\n    status: SKUStatusFilter\n    updatedAt: UpdatedAtFilter\n  ): SKUGroupSKUsConnection @deprecated(reason: \"Use skus instead.\")\n\n  \"\"\"The timestamp of when the SKU was activated.\"\"\"\n  activatedAt: DateTime\n\n  \"\"\"The timestamp of when the SKU was archived.\"\"\"\n  archivedAt: DateTime\n\n  \"\"\"Attributes of SKU Group.\"\"\"\n  attributes(after: String, before: String, first: Int, id: AttributeIdsFilter, last: Int, orderBy: AttributeOrderBy, paginationType: PaginationType = CURSOR): SKUGroupAttributesConnection\n\n  \"\"\"\n  The channel association mode for this SKU Group. Can be ALL (uses active channels registered to the store) or\n  \t\t\t\tSELECTIVE (uses custom channel associations).\n  \"\"\"\n  channelAssociationMode: String\n\n  \"\"\"An association to a channel that exists in the Channel API.\"\"\"\n  channels(after: String, before: String, first: Int, last: Int): SKUGroupChannelsConnection\n\n  \"\"\"\n  The compare-at price range of the SKU group, showing min and max compare-at prices of SKUs in the group.\n  \"\"\"\n  compareAtPriceRange(\n    \"\"\"\n    Filter SKUs by status. Defaults to ACTIVE and DRAFT, excluding ARCHIVED SKUs.\n    \"\"\"\n    status: SKUStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}\n  ): PriceRange\n\n  \"\"\"The timestamp of when the SKU was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The merchant defined description of the group.\"\"\"\n  description: String\n\n  \"\"\"\n  HTML description for the SKU group. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The globally-unique ID of the group.\"\"\"\n  id: ID!\n\n  \"\"\"The display label of the group.\"\"\"\n  label: String!\n\n  \"\"\"\n  A list is a group of SKU groups that are generally organized by similar characteristics.\n  \"\"\"\n  lists(after: String, before: String, first: Int, id: ListIdFilter, last: Int, orderBy: ListOrderBy, paginationType: PaginationType = CURSOR, status: ListStatusFilter): SKUGroupListsConnection\n\n  \"\"\"Media objects stored under the SKU Group.\"\"\"\n  mediaObjects(after: String, before: String, first: Int, last: Int, paginationType: PaginationType = CURSOR): SKUGroupMediaObjectsConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): SKUGroupMetafieldsConnection\n\n  \"\"\"A unique human-friendly identifier for the group.\"\"\"\n  name: String!\n\n  \"\"\"An option is a add-on that can be added on to a SKU group.\"\"\"\n  options(after: String, before: String, first: Int, last: Int, orderBy: OptionOrderBy, paginationType: PaginationType = CURSOR): SKUGroupOptionsConnection\n\n  \"\"\"\n  The price range of the SKU group, showing min and max prices of SKUs in the group.\n  \"\"\"\n  priceRange(\n    \"\"\"\n    Filter SKUs by status. Defaults to ACTIVE and DRAFT, excluding ARCHIVED SKUs.\n    \"\"\"\n    status: SKUStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}\n  ): PriceRange\n\n  \"\"\"\n  A reference to the resource in an external service. This can be useful for integrating the resource to any external service.\n  \"\"\"\n  references(after: String, before: String, first: Int, last: Int, origin: ReferenceOriginFilter, paginationType: PaginationType = CURSOR): SKUGroupReferencesConnection\n\n  \"\"\"\n  A short label for the group. Can be used instead of the label on smaller screens.\n  \"\"\"\n  shortLabel: String @deprecated(reason: \"Use channel-specific overrides for short labels.\")\n\n  \"\"\"\n  The count of all SKUs associated with the SKU Group. Can be filtered by status. The default statuses are ACTIVE and DRAFT.\n  \"\"\"\n  skuCount(status: SKUStatusFilter = {in: [\"ACTIVE\", \"DRAFT\"]}): Int\n\n  \"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\n  skus(\n    after: String\n    attributeValues: SKUAttributeValueFilter\n    before: String\n    code: SKUCodeFilter\n    createdAt: CreatedAtFilter\n    eanCode: SKUEanCodeFilter\n    first: Int\n    gtinCode: SKUGtinCodeFilter\n    isbnCode: SKUIsbnCodeFilter\n    label: LabelFilter\n    last: Int\n    locationId: LocationIdFilter\n    name: NameFilter\n    orderBy: SKUOrderBy\n    paginationType: PaginationType = CURSOR\n\n    \"\"\"\n    A string filter in the ODATA format. ex: \"label eq 'shirt' and contains(code, '123')\".\n\n\n    Supported columns: `label`, `code`\n\n    Supported operators: `eq`, `ne`, `lt`, `gt`, `and`, `or`\n\n    Supported functions: `contains`\n    \"\"\"\n    queryFilter: String\n    referenceValue: ReferenceValueFilter\n    status: SKUStatusFilter\n    upcCode: SKUUpcCodeFilter\n    updatedAt: UpdatedAtFilter\n  ): SKUGroupSkusConnection\n\n  \"\"\"The status of the SKU Group, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\"\"\"\n  status: String!\n\n  \"\"\"\n  The type of the SKU Group, typically PHYSICAL or DIGITAL, but can also be a custom type.\n  \"\"\"\n  type: String!\n\n  \"\"\"The timestamp of when the SKU was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ntype SKUGroupAttributesConnection {\n  edges: [SKUGroupAttributesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupAttributesConnectionEdge {\n  cursor: String!\n  node: Attribute\n}\n\n\"\"\"\nA SKU Group Channel represents an association with the application by which your SKUs are sold. Can be a platform, marketplace, POS, and more.\n\"\"\"\ntype SKUGroupChannel {\n  \"\"\"The globally-unique ID of the channel.\"\"\"\n  channelId: ID!\n\n  \"\"\"The timestamp of when the channel association was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the channel association.\"\"\"\n  id: ID!\n\n  \"\"\"The status of the channel association. One of `ACTIVE`, `INACTIVE`\"\"\"\n  status: String!\n\n  \"\"\"The timestamp of when the channel association was updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput SKUGroupChannelAddInput {\n  channelId: String!\n}\n\ninput SKUGroupChannelIdFilter {\n  eq: String\n  in: [String!]\n}\n\ntype SKUGroupChannelsConnection {\n  edges: [SKUGroupChannelsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupChannelsConnectionEdge {\n  cursor: String!\n  node: SKUGroupChannel\n}\n\ninput SKUGroupIdFilter {\n  eq: String\n  in: [String!]\n}\n\ninput SKUGroupIdsFilter {\n  eq: String\n  in: [String!]\n}\n\ntype SKUGroupListsConnection {\n  edges: [SKUGroupListsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupListsConnectionEdge {\n  cursor: String!\n  node: List\n}\n\ntype SKUGroupMediaObjectsConnection {\n  edges: [SKUGroupMediaObjectsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupMediaObjectsConnectionEdge {\n  cursor: String!\n  node: Media\n}\n\ntype SKUGroupMetafieldsConnection {\n  edges: [SKUGroupMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ntype SKUGroupOptionsConnection {\n  edges: [SKUGroupOptionsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupOptionsConnectionEdge {\n  cursor: String!\n  node: Option\n}\n\ninput SKUGroupOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  label: OrderByDirectionEnum\n  lowestPrice: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  saleCount: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype SKUGroupReferencesConnection {\n  edges: [SKUGroupReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ntype SKUGroupSKUsConnection {\n  edges: [SKUGroupSKUsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupSKUsConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\ntype SKUGroupSkusConnection {\n  edges: [SKUGroupSkusConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUGroupSkusConnectionEdge {\n  cursor: String!\n  node: SKU\n}\n\n\"\"\"\nFilter for the status of the SKU Group, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\n\"\"\"\ninput SKUGroupStatusFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"\nFilter for the type of the SKU Group, typically PHYSICAL or DIGITAL, but can also be a custom type.\n\"\"\"\ninput SKUGroupTypeFilter {\n  eq: String\n  in: [String!]\n}\n\ninput SKUGtinCodeFilter {\n  eq: String\n  in: [String!]\n}\n\ninput SKUIdFilter {\n  eq: String\n  in: [String!]\n}\n\ninput SKUIdsFilter {\n  in: [String!]\n}\n\ntype SKUInventoryAdjustmentsConnection {\n  edges: [SKUInventoryAdjustmentsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUInventoryAdjustmentsConnectionEdge {\n  cursor: String!\n  node: InventoryAdjustment\n}\n\ntype SKUInventoryCountsConnection {\n  edges: [SKUInventoryCountsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUInventoryCountsConnectionEdge {\n  cursor: String!\n  node: InventoryCount\n}\n\ninput SKUIsbnCodeFilter {\n  eq: String\n  in: [String!]\n}\n\ntype SKULocationsConnection {\n  edges: [SKULocationsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKULocationsConnectionEdge {\n  cursor: String!\n  node: Location\n}\n\ntype SKUMediaObjectsConnection {\n  edges: [SKUMediaObjectsConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUMediaObjectsConnectionEdge {\n  cursor: String!\n  node: Media\n}\n\ntype SKUMetafieldsConnection {\n  edges: [SKUMetafieldsEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput SKUOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  label: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  price: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"Represents the cost of a SKU\"\"\"\ntype SKUPrice {\n  \"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\n  SKU: SKU @deprecated(reason: \"Use sku instead.\")\n\n  \"\"\"The compare-at value of the price.\"\"\"\n  compareAtValue: SimpleMoney\n\n  \"\"\"The timestamp of when the price was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID of the price.\"\"\"\n  id: ID!\n\n  \"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\n  sku: SKU\n\n  \"\"\"The last update timestamp of the price.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"The value of the price.\"\"\"\n  value: SimpleMoney!\n}\n\ninput SKUPriceIdsFilter {\n  in: [String!]\n}\n\ninput SKUPriceOrderBy {\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype SKUPricesConnection {\n  edges: [SKUPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUPricesConnectionEdge {\n  cursor: String!\n  node: SKUPrice\n}\n\ntype SKUReferencesConnection {\n  edges: [SKUReferencesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype SKUReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\n\"\"\"\nFilter for the status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.\n\"\"\"\ninput SKUStatusFilter {\n  eq: String\n  in: [String!]\n}\n\ninput SKUUpcCodeFilter {\n  eq: String\n  in: [String!]\n}\n\n\"\"\"\nThe currency and amount for a financial transaction, such as a balance or payment due. Use for value representations with default transactable-value precision.\n\"\"\"\ntype SimpleMoney {\n  \"\"\"A three-character ISO-4217 currency code.\"\"\"\n  currencyCode: String!\n\n  \"\"\"\n  The integer value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies that are subdivided into hundredths, like USD; or, subdivided into thousandths, like TND. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes. This field is typed as Float to be able to support values larger than GraphQL's 32-bit Integer.\n  \"\"\"\n  value: Float!\n}\n\n\"\"\"\nThe currency and amount for a financial transaction, such as a balance or payment due. Use for value representations with default transactable-value precision.\n\"\"\"\ninput SimpleMoneyInput {\n  currencyCode: String!\n\n  \"\"\"\n  The integer value, which might represent intergrals for currencies like `JPY` that are not typically fractional; or, with an implied decimal fraction for currencies that are subdivided into hundredths, like USD; or, subdivided into thousandths, like TND. Only accepts integer value. Decimals are not accepted. This input is typed as Float to be able to support values larger than GraphQL's 32-bit Integer.\n  \"\"\"\n  value: Float!\n}\n\ntype TextOption {\n  \"\"\"\n  HTML description for the Option. Will be used to display rich text content to customers.\n  \"\"\"\n  HTMLDescription: String @deprecated(reason: \"Use htmlDescription instead.\")\n\n  \"\"\"The timestamp of when the Option was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"A description of the Option.\"\"\"\n  description: String\n\n  \"\"\"\n  HTML description for the Option. Will be used to display rich text content to customers.\n  \"\"\"\n  htmlDescription: String\n\n  \"\"\"The UUID of the Option\"\"\"\n  id: ID!\n\n  \"\"\"\n  Whether the option is shareable across multiple SKU Groups (a global modifier).\n  \"\"\"\n  shareable: Boolean!\n\n  \"\"\"The display lable of the Option\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield. Requires namespace to be provided.\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield. Required when key is provided.\"\"\"\n    namespace: String\n  ): OptionMetafieldsConnection\n\n  \"\"\"A unique name of the Option.\"\"\"\n  name: String!\n\n  \"\"\"The position of the option.\"\"\"\n  position: Int\n\n  \"\"\"\n  Represents the additional cost of a Text Option. When empty, it indicates this option allows for flexible pricing.\n  \"\"\"\n  prices(\n    after: String\n    before: String\n\n    \"\"\"Filter prices by currency code.\"\"\"\n    currencyCode: CurrencyCodeFilter\n    first: Int\n    last: Int\n    paginationType: PaginationType = CURSOR\n  ): TextOptionPricesConnection\n\n  \"\"\"The UUID of the SKU Group that the Option belongs to.\"\"\"\n  skuGroupId: ID! @deprecated(reason: \"Use skuGroupIds or the SKUGroup.options connection instead. An option may belong to multiple SKU groups.\")\n\n  \"\"\"The IDs of all SKU groups this option is associated with.\"\"\"\n  skuGroupIds: [String!]!\n\n  \"\"\"\n  The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.\n  \"\"\"\n  type: String\n\n  \"\"\"The timestamp of when the Option was updated.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"\n  Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.\n  \"\"\"\n  validation: OptionValidation\n}\n\ntype TextOptionPricesConnection {\n  edges: [TextOptionPricesConnectionEdge]\n  pageInfo: PageInfo!\n  totalCount: Int!\n}\n\ntype TextOptionPricesConnectionEdge {\n  cursor: String!\n  node: OptionPrice\n}\n\ninput UpdateAddressInput {\n  addressDetails: AddressDetailsInput\n  addressLine1: String\n  addressLine2: String\n  addressLine3: String\n  adminArea1: String\n  adminArea2: String\n  adminArea3: String\n  adminArea4: String\n  countryCode: String\n  postalCode: String\n}\n\n\"\"\"Input for updating an existing file.\"\"\"\ninput UpdateFileInput {\n  contentType: String\n  description: String\n  filename: String\n}\n\ninput UpdateMediaObjectInput {\n  id: String!\n  label: String\n  metafields: [UpsertMetafieldInput!]\n  name: String\n  position: Int\n\n  \"\"\"The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.\"\"\"\n  type: String\n  url: String\n}\n\n\"\"\"A single option and its new position within a SKU group.\"\"\"\ninput UpdateSKUGroupOptionPositionInput {\n  optionId: String!\n  position: Int!\n}\n\n\"\"\"Filters items based on the date they were last updated.\"\"\"\ninput UpdatedAtFilter {\n  gt: String\n  lt: String\n}\n\ninput UpsertMetafieldInput {\n  key: String!\n  namespace: String!\n  type: String!\n  value: String!\n}\n\ntype _Service {\n  \"\"\"\n  The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied\n  \"\"\"\n  sdl: String\n}",
+        "types": [
+          {
+            "fields": [
+              {
+                "name": "listId",
+                "type": "String!"
+              },
+              {
+                "name": "parentNodeId",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "AddListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The details of the address.",
+                "name": "addressDetails",
+                "type": "AddressDetails"
+              },
+              {
+                "description": "The first line of the address.",
+                "name": "addressLine1",
+                "type": "String!"
+              },
+              {
+                "description": "The second line of the address.",
+                "name": "addressLine2",
+                "type": "String"
+              },
+              {
+                "description": "The third line of the address.",
+                "name": "addressLine3",
+                "type": "String"
+              },
+              {
+                "description": "The first administrative area of the address.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The second administrative area of the address.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The third administrative area of the address.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The fourth administrative area of the address.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The country code of the address.",
+                "name": "countryCode",
+                "type": "String!"
+              },
+              {
+                "description": "The postal code of the address.",
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "Address"
+          },
+          {
+            "fields": [
+              {
+                "description": "The type of address. Single character representation of a type. For example: 'B' for building, 'F' for organization, 'G' for general delivery, 'H' for high-rise, 'L' for large-volume organization, 'P' for Post Office box or delivery service, 'R' for rural route, 'S' for street, 'U' for unidentified address.",
+                "name": "addressType",
+                "type": "String"
+              },
+              {
+                "description": "A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number.",
+                "name": "buildingName",
+                "type": "String"
+              },
+              {
+                "description": "The delivery service. Post office box, bag number, or post office name",
+                "name": "deliveryService",
+                "type": "String"
+              },
+              {
+                "description": "The latitude and longitude of the address.",
+                "name": "geoCoordinates",
+                "type": "GeoCoordinates"
+              },
+              {
+                "description": "The street name. Just `Drury` in `Drury Lane`.",
+                "name": "streetName",
+                "type": "String"
+              },
+              {
+                "description": "The street number.",
+                "name": "streetNumber",
+                "type": "String"
+              },
+              {
+                "description": "The street type. For example, avenue, boulevard, road, or expressway.",
+                "name": "streetType",
+                "type": "String"
+              },
+              {
+                "description": "The first-order entity below a named building or location that represents the sub-premise. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.",
+                "name": "subBuilding",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "AddressDetails"
+          },
+          {
+            "fields": [
+              {
+                "name": "addressType",
+                "type": "String"
+              },
+              {
+                "name": "buildingName",
+                "type": "String"
+              },
+              {
+                "name": "deliveryService",
+                "type": "String"
+              },
+              {
+                "name": "geoCoordinates",
+                "type": "GeoCoordinatesInput"
+              },
+              {
+                "name": "streetName",
+                "type": "String"
+              },
+              {
+                "name": "streetNumber",
+                "type": "String"
+              },
+              {
+                "name": "streetType",
+                "type": "String"
+              },
+              {
+                "name": "subBuilding",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "AddressDetailsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "AssociateAttributeValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeName",
+                "type": "String!"
+              },
+              {
+                "name": "valueName",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "AssociateAttributeValueToSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the Attribute. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.",
+                "name": "SKUGroup",
+                "type": "SKUGroup"
+              },
+              {
+                "description": "The creation date of the Attribute.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "A description of the Attribute.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the Attribute. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The UUID of the Attribute.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The display label of the Attribute. E.g. 'Color', 'Size', etc.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "AttributeMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Attribute. E.g. 'color', 'size', etc.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The position of the attribute.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.",
+                "name": "skuGroup",
+                "type": "SKUGroup"
+              },
+              {
+                "description": "The update date of the Attribute.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "Attribute values of Attribute.",
+                "name": "values",
+                "type": "AttributeValuesConnection"
+              }
+            ],
+            "kind": "object",
+            "name": "Attribute"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "AttributeIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "AttributeIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[AttributeMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "label",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "position",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "skuGroupId",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "AttributeOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The attribute that this value belongs to.",
+                "name": "attribute",
+                "type": "Attribute"
+              },
+              {
+                "description": "The creation date of the Attribute Value.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The UUID of the Attribute Value.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The display label of the Attribute Value. E.g. 'Red', 'Blue', etc.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "AttributeValueMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Attribute Value. E.g. 'red', 'blue', etc.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The position of the attribute value.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The last update date of the Attribute Value.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeValue"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "AttributeValueIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[AttributeValueMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeValueMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeValueMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeId",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "position",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "AttributeValueOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[AttributeValuesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeValuesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "AttributeValue"
+              }
+            ],
+            "kind": "object",
+            "name": "AttributeValuesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "Whether to cascade archive SKUs when archiving the SKU Group.",
+                "name": "skus",
+                "type": "Boolean"
+              }
+            ],
+            "kind": "input",
+            "name": "CascadeArchiveInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "addressDetails",
+                "type": "AddressDetailsInput"
+              },
+              {
+                "name": "addressLine1",
+                "type": "String!"
+              },
+              {
+                "name": "addressLine2",
+                "type": "String"
+              },
+              {
+                "name": "addressLine3",
+                "type": "String"
+              },
+              {
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "name": "countryCode",
+                "type": "String!"
+              },
+              {
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateAddressInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeId",
+                "type": "String!"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateAttributeValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "contentType",
+                "type": "String!"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "filename",
+                "type": "String!"
+              },
+              {
+                "name": "sizeBytes",
+                "type": "Float!"
+              },
+              {
+                "name": "storageUrl",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateFileInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The change in inventory quantity. Positive for additions, negative for removals.",
+                "name": "delta",
+                "type": "Int!"
+              },
+              {
+                "name": "locationId",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "description": "The date and time when the inventory adjustment occurred.",
+                "name": "occurredAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The name of an inventory adjustment reason to associate with this adjustment. Use the exact reason name (e.g. \"g-damage\" for global presets, or a store-scoped name).",
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "String!"
+              },
+              {
+                "description": "The type of inventory adjustment, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.",
+                "name": "type",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateInventoryAdjustmentInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listId",
+                "type": "String!"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.",
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "url",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateMediaObjectInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "key",
+                "type": "String!"
+              },
+              {
+                "name": "namespace",
+                "type": "String!"
+              },
+              {
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateMetafieldInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateOptionPriceInput!]"
+              },
+              {
+                "description": "The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.",
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "validation",
+                "type": "CreateOptionValidationInput"
+              },
+              {
+                "name": "values",
+                "type": "[CreateOptionValueInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateOptionPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "max",
+                "type": "Int"
+              },
+              {
+                "name": "min",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateOptionValidationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateOptionValuePriceInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateOptionValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateOptionValuePriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "origin",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateReferenceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "values",
+                "type": "[AssociateAttributeValueInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateSKUGroupAttributeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "backorderLimit",
+                "type": "Int"
+              },
+              {
+                "name": "code",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED. Use unitCost instead.",
+                "name": "cost",
+                "type": "Int"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "disableInventoryTracking",
+                "type": "Boolean"
+              },
+              {
+                "name": "disablePriceOverrides",
+                "type": "Boolean"
+              },
+              {
+                "name": "disableShipping",
+                "type": "Boolean"
+              },
+              {
+                "name": "eanCode",
+                "type": "String"
+              },
+              {
+                "name": "gtinCode",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "inventoryQuantities",
+                "type": "[CreateSKUInventoryInput!]"
+              },
+              {
+                "name": "isbnCode",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateSKUPriceInput!]"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "unitCost",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "The unit of the weight, one of `KG`, `GR`, `LB`, `OZ`.",
+                "name": "unitOfWeight",
+                "type": "String"
+              },
+              {
+                "name": "upcCode",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "weight",
+                "type": "Float"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateSKUGroupSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]"
+              },
+              {
+                "name": "attributeValues",
+                "type": "[AssociateAttributeValueToSKUInput!]"
+              },
+              {
+                "name": "backorderLimit",
+                "type": "Int"
+              },
+              {
+                "name": "code",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED. Use unitCost instead.",
+                "name": "cost",
+                "type": "Int"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "disableInventoryTracking",
+                "type": "Boolean"
+              },
+              {
+                "name": "disablePriceOverrides",
+                "type": "Boolean"
+              },
+              {
+                "name": "disableShipping",
+                "type": "Boolean"
+              },
+              {
+                "name": "eanCode",
+                "type": "String"
+              },
+              {
+                "name": "gtinCode",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "inventoryQuantities",
+                "type": "[CreateSKUInventoryInput!]"
+              },
+              {
+                "name": "isbnCode",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateSKUPriceInput!]"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "name": "skuGroupId",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "unitCost",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "The status of the SKU, one of `KG`, `GR`, `LB`, `OZ`.",
+                "name": "unitOfWeight",
+                "type": "String"
+              },
+              {
+                "name": "upcCode",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "weight",
+                "type": "Float"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "locationId",
+                "type": "String!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateSKUInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateSKUPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "gt",
+                "type": "String"
+              },
+              {
+                "name": "lt",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "CreatedAtFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "Filters items where the currency code equals the specified 3-letter ISO currency code.",
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "description": "Filters items where the currency code matches any of the specified 3-letter ISO currency codes.",
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "CurrencyCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The MIME type of the file.",
+                "name": "contentType",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp when the file was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "An optional description of the file.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The name of the file including extension.",
+                "name": "filename",
+                "type": "String!"
+              },
+              {
+                "description": "The globally unique identifier of the file.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The size of the file in bytes. Typed as Float to support files larger than 2GB.",
+                "name": "sizeBytes",
+                "type": "Float!"
+              },
+              {
+                "description": "The current status of the file.",
+                "name": "status",
+                "type": "FileStatus!"
+              },
+              {
+                "description": "The URL where the file is stored.",
+                "name": "storageUrl",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp when the file was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "File"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "FileIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "filename",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "FileOrderBy"
+          },
+          {
+            "kind": "enum",
+            "name": "FileStatus",
+            "values": [
+              "ACTIVE",
+              "ARCHIVED"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "FileStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "FileStorageUrlFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The latitude of the geo coordinates.",
+                "name": "latitude",
+                "type": "Float!"
+              },
+              {
+                "description": "The longitude of the geo coordinates.",
+                "name": "longitude",
+                "type": "Float!"
+              }
+            ],
+            "kind": "object",
+            "name": "GeoCoordinates"
+          },
+          {
+            "fields": [
+              {
+                "name": "latitude",
+                "type": "Float"
+              },
+              {
+                "name": "longitude",
+                "type": "Float"
+              }
+            ],
+            "kind": "input",
+            "name": "GeoCoordinatesInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The SKU associated with the Inventory Adjustment.",
+                "name": "SKU",
+                "type": "SKU"
+              },
+              {
+                "description": "The creation date of the inventory adjustment.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The change in quantity of a SKU at a location.",
+                "name": "delta",
+                "type": "Int"
+              },
+              {
+                "description": "The globally-unique ID of the inventory adjustment object.",
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "description": "The Location associated with the Inventory Adjustment.",
+                "name": "location",
+                "type": "Location"
+              },
+              {
+                "name": "metafields",
+                "type": "InventoryAdjustmentMetafieldsConnection"
+              },
+              {
+                "description": "The date when the inventory adjustment occurred.",
+                "name": "occurredAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The reason associated with this inventory adjustment.",
+                "name": "reason",
+                "type": "InventoryAdjustmentReason"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "InventoryAdjustmentReferencesConnection"
+              },
+              {
+                "description": "The SKU associated with the Inventory Adjustment.",
+                "name": "sku",
+                "type": "SKU"
+              },
+              {
+                "description": "The adjustment type of the inventory being adjusted, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.",
+                "name": "type",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustment"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[InventoryAdjustmentMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustmentMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustmentMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The date the reason was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the inventory adjustment reason.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "Whether this is a global preset reason. Global reasons are shared across all stores and cannot be modified or archived.",
+                "name": "isGlobal",
+                "type": "Boolean!"
+              },
+              {
+                "description": "The human-readable display label of the reason.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "The unique kebab-case name of the reason. Global preset names are prefixed with \"g-\" (e.g. g-damage). Store-scoped names must not use the \"g-\" prefix.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The status of the reason, one of ACTIVE, ARCHIVED.",
+                "name": "status",
+                "type": "String!"
+              },
+              {
+                "description": "The date the reason was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustmentReason"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentReasonNameFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentReasonOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentReasonStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[InventoryAdjustmentReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustmentReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryAdjustmentReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryAdjustmentTypeFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The SKU associated with the Inventory Count.",
+                "name": "SKU",
+                "type": "SKU"
+              },
+              {
+                "description": "The timestamp of when the inventory count was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the inventory count object.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The Location associated with the Inventory Count.",
+                "name": "location",
+                "type": "Location"
+              },
+              {
+                "description": "The on-hand inventory count (available + committed) for this SKU and location.",
+                "name": "onHand",
+                "type": "Int"
+              },
+              {
+                "description": "The count of the inventory.",
+                "name": "quantity",
+                "type": "Int"
+              },
+              {
+                "description": "The SKU associated with the Inventory Count.",
+                "name": "sku",
+                "type": "SKU"
+              },
+              {
+                "description": "The type of inventory count, one of `AVAILABLE`, `COMMITTED`, `BACKORDERED`.",
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp of when the inventory count was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "InventoryCount"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryCountIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryCountOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryCountSKUStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "InventoryCountTypeFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "Filters items where the label contains the specified string, case-insensitive.",
+                "name": "contains",
+                "type": "String"
+              },
+              {
+                "name": "eq",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "LabelFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the List. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "A SKU Group is a grouping of related SKUs. It provides information about all of the SKUs that are sold together on storefronts or devices.",
+                "name": "SKUGroups",
+                "type": "ListSKUGroupsConnection"
+              },
+              {
+                "description": "The date and time of when the List was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "A single-line textual description of the List.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the List. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID of the List.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The display label of the List.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "Media can be images, videos, or files",
+                "name": "mediaObjects",
+                "type": "ListMediaObjectsConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "ListMetafieldsConnection"
+              },
+              {
+                "description": "A unique name for the List.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "ListReferencesConnection"
+              },
+              {
+                "description": "A SKU Group is a grouping of related SKUs. It provides information about all of the SKUs that are sold together on storefronts or devices.",
+                "name": "skuGroups",
+                "type": "ListSkuGroupsConnection"
+              },
+              {
+                "description": "The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "The date and time of when the List was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "List"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              },
+              {
+                "name": "isNull",
+                "type": "Boolean"
+              }
+            ],
+            "kind": "input",
+            "name": "ListIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListMediaObjectsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListMediaObjectsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Media"
+              }
+            ],
+            "kind": "object",
+            "name": "ListMediaObjectsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "ListMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "The `compareAt` price range of the option, tracks the min and max `compareAt` price of all the option values under this option.",
+                "name": "compareAtPriceRange",
+                "type": "PriceRange"
+              },
+              {
+                "description": "The timestamp of when the Option was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "A description of the Option.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The UUID of the Option",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "Whether the option is shareable across multiple SKU Groups (a global modifier).",
+                "name": "shareable",
+                "type": "Boolean!"
+              },
+              {
+                "description": "The display lable of the Option",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "OptionMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Option.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The position of the option.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The price range of the option, tracks the min and max price of all the option values under this option.",
+                "name": "priceRange",
+                "type": "PriceRange"
+              },
+              {
+                "description": "Represents the additional cost of a List Option. When empty, it indicates this option allows for flexible pricing.",
+                "name": "prices",
+                "type": "ListOptionPricesConnection"
+              },
+              {
+                "description": "The UUID of the SKU Group that the Option belongs to.",
+                "name": "skuGroupId",
+                "type": "ID!"
+              },
+              {
+                "description": "The IDs of all SKU groups this option is associated with.",
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              },
+              {
+                "description": "The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the Option was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.",
+                "name": "validation",
+                "type": "OptionValidation"
+              },
+              {
+                "description": "Represents the additional cost of a List Option. Each value can have one or more prices.",
+                "name": "values",
+                "type": "ListOptionValuesConnection"
+              }
+            ],
+            "kind": "object",
+            "name": "ListOption"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListOptionPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListOptionPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "ListOptionPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListOptionValuesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListOptionValuesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionValue"
+              }
+            ],
+            "kind": "object",
+            "name": "ListOptionValuesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "label",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "ListOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "ListReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListSKUGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListSKUGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "ListSKUGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListSkuGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListSkuGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "ListSkuGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the List Tree. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the list tree was activated.",
+                "name": "activatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The timestamp of when the list tree was archived.",
+                "name": "archivedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The creation date of the list tree.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The description of the list tree.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the List Tree. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID of the list tree.",
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "description": "The display label of the list tree.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "List tree node is associated to a single List and a node can be a parent node to provide the hierarchy of list trees.",
+                "name": "listTreeNodes",
+                "type": "ListTreeListTreeNodesConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "ListTreeMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the list tree.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "ListTreeReferencesConnection"
+              },
+              {
+                "description": "The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "The last update date of the list tree.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTree"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListTreeListTreeNodesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeListTreeNodesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "ListTreeNode"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeListTreeNodesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListTreeMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "The creation date of the list node.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The globally-unique ID of the list node.",
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "description": "The list associated with the node.",
+                "name": "list",
+                "type": "List"
+              },
+              {
+                "description": "The List Tree associated with the node.",
+                "name": "listTree",
+                "type": "ListTree"
+              },
+              {
+                "description": "The children nodes of the list node.",
+                "name": "listTreeNodes",
+                "type": "ListTreeNodeListTreeNodesConnection"
+              },
+              {
+                "description": "The parent node of the list node.",
+                "name": "parentListTreeNode",
+                "type": "ListTreeNode"
+              },
+              {
+                "description": "The position of the node in the list.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "ListTreeNodeReferencesConnection"
+              },
+              {
+                "description": "The last update date of the list node.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeNode"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeNodeIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeNodeListStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListTreeNodeListTreeNodesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeNodeListTreeNodesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "ListTreeNode"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeNodeListTreeNodesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeNodeListTreeStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "position",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeNodeOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeNodeParentNodeIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListTreeNodeReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeNodeReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeNodeReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ListTreeReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "ListTreeReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ListTreeStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The SKUs are purchasable items in the catalog.",
+                "name": "SKUs",
+                "type": "LocationSKUsConnection"
+              },
+              {
+                "description": "The address of the Location.",
+                "name": "address",
+                "type": "Address"
+              },
+              {
+                "description": "The timestamp of when the Location was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the Location.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "An immutable entity that represents a change in state of a quantity of SKU at a particular time and location. Each adjustment will either have a positive, negative, or neutral impact on the count of available SKUs in a location.",
+                "name": "inventoryAdjustments",
+                "type": "LocationInventoryAdjustmentsConnection"
+              },
+              {
+                "description": "The quantity of a SKU in a specific state at a particular time and location.",
+                "name": "inventoryCounts",
+                "type": "LocationInventoryCountsConnection"
+              },
+              {
+                "description": "The display name of the Location.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "LocationMetafieldsConnection"
+              },
+              {
+                "description": "A unique and human-friendly name of the Location.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "LocationReferencesConnection"
+              },
+              {
+                "description": "The SKUs are purchasable items in the catalog.",
+                "name": "skus",
+                "type": "LocationSkusConnection"
+              },
+              {
+                "description": "The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp of when the Location was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "Location"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "LocationIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "LocationIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationInventoryAdjustmentsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationInventoryAdjustmentsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryAdjustment"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationInventoryAdjustmentsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationInventoryCountsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationInventoryCountsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryCount"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationInventoryCountsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "LocationOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationSKUsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationSKUsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationSKUsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[LocationSkusConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationSkusConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "LocationSkusConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "LocationStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the media.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "An optional label for the media.",
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "MediaMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the media.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The position of the media.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "description": "The URL of the media.",
+                "name": "url",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "Media"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[MediaMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "MediaMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "MediaMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "String"
+              },
+              {
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "name": "key",
+                "type": "String"
+              },
+              {
+                "name": "namespace",
+                "type": "String"
+              },
+              {
+                "name": "resourceId",
+                "type": "ID"
+              },
+              {
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "name": "updatedAt",
+                "type": "String"
+              },
+              {
+                "name": "value",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "Metafield"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddAttributeValuesToSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddAttributeValuesToSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributes",
+                "type": "[CreateSKUGroupAttributeInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddAttributesToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributes",
+                "type": "[CreateSKUGroupAttributeInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddAttributesToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The channels to add to the SKU group.\n\t\t\t\tThese are pointers to the Channels API, Catalog API\n\t\t\t\tdoes not create the channel resources.",
+                "name": "channels",
+                "type": "[SKUGroupChannelAddInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddChannelsToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The channels to add to the SKU group.\n\t\t\t\tThese are pointers to the Channels API, Catalog API\n\t\t\t\tdoes not create the channel resources.",
+                "name": "channels",
+                "type": "[SKUGroupChannelAddInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddChannelsToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listTreeNodes",
+                "type": "[AddListTreeNodeInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddListTreeNodesToListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listTreeNodes",
+                "type": "[AddListTreeNodeInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddListTreeNodesToParentListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddMediaObjectsToListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddMediaObjectsToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddMediaObjectsToSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddMediaObjectsToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddMediaObjectsToSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "UUIDs of existing options to associate with this SKU group.",
+                "name": "optionIds",
+                "type": "[String!]"
+              },
+              {
+                "name": "options",
+                "type": "[CreateOptionInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddOptionsToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "UUIDs of existing options to associate with this SKU group.",
+                "name": "optionIds",
+                "type": "[String!]"
+              },
+              {
+                "name": "options",
+                "type": "[CreateOptionInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddOptionsToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddReferencesToSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSKUGroupToListsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSKUGroupsToListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSKUsToLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSKUsToSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkuGroupToListsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkuGroupsToListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkusToLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkusToSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "delta",
+                "type": "Int!"
+              },
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAdjustInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationArchiveInventoryAdjustmentReasonInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "allowBackorders",
+                "type": "Boolean"
+              },
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCommitInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "skuGroupId",
+                "type": "ID!"
+              },
+              {
+                "name": "values",
+                "type": "[AssociateAttributeValueInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateAttributeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "name",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateInventoryAdjustmentReasonInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "description": "The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "listTreeNodes",
+                "type": "[CreateListTreeNodeInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "description": "The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "address",
+                "type": "CreateAddressInput!"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "description": "The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "Whether this option is shareable across multiple SKU Groups.",
+                "name": "shareable",
+                "type": "Boolean"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateOptionPriceInput!]"
+              },
+              {
+                "name": "skuGroupId",
+                "type": "String"
+              },
+              {
+                "description": "The UUIDs of the SKU Groups to associate the Option with.",
+                "name": "skuGroupIds",
+                "type": "[String!]"
+              },
+              {
+                "description": "The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.",
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "validation",
+                "type": "CreateOptionValidationInput"
+              },
+              {
+                "name": "values",
+                "type": "[CreateOptionValueInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "optionId",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateOptionPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "optionId",
+                "type": "String!"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "name": "prices",
+                "type": "[CreateOptionValuePriceInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateOptionValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "optionValueId",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateOptionValuePriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "attributes",
+                "type": "[CreateSKUGroupAttributeInput!]"
+              },
+              {
+                "name": "channels",
+                "type": "[SKUGroupChannelAddInput!]"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "options",
+                "type": "[CreateOptionInput!]"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "name": "skus",
+                "type": "[CreateSKUGroupSKUInput!]"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateSKUPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "attributes",
+                "type": "[CreateSKUGroupAttributeInput!]"
+              },
+              {
+                "name": "channels",
+                "type": "[SKUGroupChannelAddInput!]"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "mediaObjects",
+                "type": "[CreateMediaObjectInput!]"
+              },
+              {
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "options",
+                "type": "[CreateOptionInput!]"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "name": "skus",
+                "type": "[CreateSKUGroupSKUInput!]"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateSkuPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationReduceInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationReleaseInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveAttributeValuesFromAttributeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveAttributeValuesFromSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeValueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveAttributeValuesFromSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveAttributesFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "attributeIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveAttributesFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "channelIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveChannelsFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "channelIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveChannelsFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listTreeNodeIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveListTreeNodesFromListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listTreeNodeIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveListTreeNodesFromParentListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjectIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMediaObjectsFromListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjectIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMediaObjectsFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjectIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMediaObjectsFromSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjectIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMediaObjectsFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjectIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMediaObjectsFromSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromAttributeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromAttributeValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromOptionValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "metafields",
+                "type": "[RemoveMetafieldInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveMetafieldsFromSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "valueIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveOptionValuesFromListOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "optionIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveOptionsFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "optionIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveOptionsFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "priceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemovePricesFromOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "priceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemovePricesFromOptionValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "priceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemovePricesFromSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "priceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemovePricesFromSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveReferencesFromSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSKUGroupFromListsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSKUGroupsFromListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSKUsFromLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSKUsFromSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkuGroupFromListsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkuGroupsFromListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusFromLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[String!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusFromSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRestockFromCommittedInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The channel association mode for this SKU Group. Can be ALL (uses active channels registered to the store) or\n\t\t\t\t\tSELECTIVE (uses custom channel associations).",
+                "name": "mode",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationSetSkuGroupChannelAssociationModeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "locationId",
+                "type": "ID!"
+              },
+              {
+                "name": "quantity",
+                "type": "Int!"
+              },
+              {
+                "name": "reasonName",
+                "type": "String"
+              },
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "name": "skuId",
+                "type": "ID!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationStockInventoryInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateAttributeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateAttributeValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateInventoryAdjustmentReasonInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The status of the list, one of `ACTIVE`, `DRAFT`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateListInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[UpdateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateListMediaObjectsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The status of the list tree, one of `ACTIVE`, `ARCHIVED`, `DRAFT`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateListTreeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listId",
+                "type": "String"
+              },
+              {
+                "name": "listTreeId",
+                "type": "String"
+              },
+              {
+                "name": "parentNodeId",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateListTreeNodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "address",
+                "type": "UpdateAddressInput"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The status of the location, one of `ACTIVE`, `INACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "shareable",
+                "type": "Boolean"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The type of the Option, one of `TEXT`, `NUMBER`, `LIST`. Option Values are only available on the 'LIST' type.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "name": "validation",
+                "type": "CreateOptionValidationInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "currencyCode",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionPriceCurrencyCodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionValueInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "currencyCode",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionValuePriceCurrencyCodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOptionValuePriceInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSKUGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "backorderLimit",
+                "type": "Int"
+              },
+              {
+                "name": "code",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED. Use unitCost instead.",
+                "name": "cost",
+                "type": "Int"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "disableInventoryTracking",
+                "type": "Boolean"
+              },
+              {
+                "name": "disablePriceOverrides",
+                "type": "Boolean"
+              },
+              {
+                "name": "disableShipping",
+                "type": "Boolean"
+              },
+              {
+                "name": "eanCode",
+                "type": "String"
+              },
+              {
+                "name": "gtinCode",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "isbnCode",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "unitCost",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.",
+                "name": "unitOfWeight",
+                "type": "String"
+              },
+              {
+                "name": "upcCode",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "weight",
+                "type": "Float"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSKUInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "Update the currency code for this price. When provided, updates the currency code while keeping the numeric value unchanged.",
+                "name": "currencyCode",
+                "type": "String"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSKUPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuGroupInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[UpdateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuGroupMediaObjectsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "positions",
+                "type": "[UpdateSKUGroupOptionPositionInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuGroupOptionPositionsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "name": "backorderLimit",
+                "type": "Int"
+              },
+              {
+                "name": "code",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED. Use unitCost instead.",
+                "name": "cost",
+                "type": "Int"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "disableInventoryTracking",
+                "type": "Boolean"
+              },
+              {
+                "name": "disablePriceOverrides",
+                "type": "Boolean"
+              },
+              {
+                "name": "disableShipping",
+                "type": "Boolean"
+              },
+              {
+                "name": "eanCode",
+                "type": "String"
+              },
+              {
+                "name": "gtinCode",
+                "type": "String"
+              },
+              {
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "name": "isbnCode",
+                "type": "String"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "name": "unitCost",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.",
+                "name": "unitOfWeight",
+                "type": "String"
+              },
+              {
+                "name": "upcCode",
+                "type": "String"
+              },
+              {
+                "description": "DEPRECATED: Do not use this field.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "name": "weight",
+                "type": "Float"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "mediaObjects",
+                "type": "[UpdateMediaObjectInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuMediaObjectsInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "currencyCode",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuPriceCurrencyCodeInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "compareAtValue",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "name": "value",
+                "type": "SimpleMoneyInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateSkuPriceInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "Filters items where the name contains the specified string, case-insensitive.",
+                "name": "contains",
+                "type": "String"
+              },
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "description": "Filters items where the name matches any of the specified names.",
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "NameFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The timestamp of when the Option was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "A description of the Option.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The UUID of the Option",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "Whether the option is shareable across multiple SKU Groups (a global modifier).",
+                "name": "shareable",
+                "type": "Boolean!"
+              },
+              {
+                "description": "The display lable of the Option",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "OptionMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Option.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The position of the option.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "Represents the additional cost of a Numeric Option. When empty, it indicates this option allows for flexible pricing.",
+                "name": "prices",
+                "type": "NumericOptionPricesConnection"
+              },
+              {
+                "description": "The UUID of the SKU Group that the Option belongs to.",
+                "name": "skuGroupId",
+                "type": "ID!"
+              },
+              {
+                "description": "The IDs of all SKU groups this option is associated with.",
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              },
+              {
+                "description": "The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the Option was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.",
+                "name": "validation",
+                "type": "OptionValidation"
+              }
+            ],
+            "kind": "object",
+            "name": "NumericOption"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[NumericOptionPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "NumericOptionPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "NumericOptionPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OptionMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "label",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "position",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "price",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The compare-at value of the price.",
+                "name": "compareAtValue",
+                "type": "SimpleMoney"
+              },
+              {
+                "description": "The timestamp of when the price was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the price.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The option that this price belongs to.",
+                "name": "option",
+                "type": "Option"
+              },
+              {
+                "description": "The last update timestamp of the price.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The value of the price.",
+                "name": "value",
+                "type": "SimpleMoney!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionPrice"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionPriceIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionPriceOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The maximum number that can be applied to the option.",
+                "name": "max",
+                "type": "Int"
+              },
+              {
+                "description": "The minimum number that can be applied to the option.",
+                "name": "min",
+                "type": "Int"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValidation"
+          },
+          {
+            "fields": [
+              {
+                "description": "The timestamp of when the Option Value was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The UUID of the Option Value.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The display label of the Option Value.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "OptionValueMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Option Value.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The option that this value belongs to.",
+                "name": "option",
+                "type": "ListOption"
+              },
+              {
+                "description": "The position of the option value.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "These are all the prices the Option Value can be sold at. The price can be different based the channel where it is listed or if there is a promotion running.",
+                "name": "prices",
+                "type": "OptionValuePricesConnection"
+              },
+              {
+                "description": "The timestamp of when the Option Value was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValue"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionValueIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionValueIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OptionValueMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValueMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValueMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "position",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "price",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionValueOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The compare-at value of the price.",
+                "name": "compareAtValue",
+                "type": "SimpleMoney"
+              },
+              {
+                "description": "The timestamp of when the price was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the price.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The option value that this price belongs to.",
+                "name": "optionValue",
+                "type": "OptionValue"
+              },
+              {
+                "description": "The last update timestamp of the price.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The value of the price.",
+                "name": "value",
+                "type": "SimpleMoney!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValuePrice"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionValuePriceIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "OptionValuePriceOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OptionValuePricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValuePricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionValuePrice"
+              }
+            ],
+            "kind": "object",
+            "name": "OptionValuePricesConnectionEdge"
+          },
+          {
+            "kind": "enum",
+            "name": "OrderByDirectionEnum",
+            "values": [
+              "ASC",
+              "DESC"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "name": "endCursor",
+                "type": "String"
+              },
+              {
+                "name": "hasNextPage",
+                "type": "Boolean!"
+              },
+              {
+                "name": "hasPreviousPage",
+                "type": "Boolean!"
+              },
+              {
+                "name": "startCursor",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "PageInfo"
+          },
+          {
+            "kind": "enum",
+            "name": "PaginationType",
+            "values": [
+              "CURSOR",
+              "OFFSET"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "description": "Maximum price.",
+                "name": "max",
+                "type": "Float"
+              },
+              {
+                "description": "Minimum price.",
+                "name": "min",
+                "type": "Float"
+              }
+            ],
+            "kind": "object",
+            "name": "PriceRange"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryAttributeValuesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryAttributeValuesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "AttributeValue"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryAttributeValuesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryAttributesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryAttributesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Attribute"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryAttributesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryFilesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryFilesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "File"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryFilesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryInventoryAdjustmentReasonsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryAdjustmentReasonsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryAdjustmentReason"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryAdjustmentReasonsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryInventoryAdjustmentsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryAdjustmentsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryAdjustment"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryAdjustmentsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryInventoryCountsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryCountsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryCount"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryInventoryCountsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryListTreeNodesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListTreeNodesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "ListTreeNode"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListTreeNodesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryListTreesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListTreesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "ListTree"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListTreesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryListsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "List"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryListsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryLocationsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryLocationsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Location"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryLocationsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryOptionPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryOptionValuePricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionValuePricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionValuePrice"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionValuePricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryOptionValuesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionValuesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionValue"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionValuesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryOptionsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Option"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOptionsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QuerySKUGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySKUGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySKUGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QuerySKUsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySKUsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySKUsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QuerySkuGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkuGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkuGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QuerySkuPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkuPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkuPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QuerySkusConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkusConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "QuerySkusConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the reference.",
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "description": "The origin or location of the reference. Ex. OLS or POYNT",
+                "name": "origin",
+                "type": "String"
+              },
+              {
+                "description": "The identifier of the resource in an external service",
+                "name": "value",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "Reference"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ReferenceOriginFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ReferenceValueFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "key",
+                "type": "String!"
+              },
+              {
+                "name": "namespace",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "RemoveMetafieldInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the SKU. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.",
+                "name": "SKUGroup",
+                "type": "SKUGroup"
+              },
+              {
+                "description": "The timestamp of when the SKU was archived.",
+                "name": "archivedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "Attribute values of SKU.",
+                "name": "attributeValues",
+                "type": "SKUAttributeValuesConnection"
+              },
+              {
+                "description": "Attributes are properties or characteristics of the SKU. For example, color or size.",
+                "name": "attributes",
+                "type": "SKUAttributesConnection"
+              },
+              {
+                "description": "The number of backorders allowed for the SKU. If set to 0, backorders are not allowed. If set to null, backorders are allowed without limit.",
+                "name": "backorderLimit",
+                "type": "Int"
+              },
+              {
+                "description": "The unique code for the SKU.",
+                "name": "code",
+                "type": "String!"
+              },
+              {
+                "description": "DEPRECATED. Use unitCost instead.",
+                "name": "cost",
+                "type": "Int"
+              },
+              {
+                "description": "The timestamp of when the SKU was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The description of the SKU.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "Flag to mark whether stock should be tracked for the SKU.",
+                "name": "disableInventoryTracking",
+                "type": "Boolean"
+              },
+              {
+                "description": "Flag to mark whether or not a custom price can be provided.",
+                "name": "disablePriceOverrides",
+                "type": "Boolean"
+              },
+              {
+                "description": "Flag to mark whether the SKU should be shipped or not.",
+                "name": "disableShipping",
+                "type": "Boolean"
+              },
+              {
+                "description": "The EAN code for the SKU.",
+                "name": "eanCode",
+                "type": "String"
+              },
+              {
+                "description": "The GTIN code for the SKU.",
+                "name": "gtinCode",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the SKU. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID of the SKU.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "An immutable entity that represents a change in state of a quantity of SKU at a particular time and location. Each adjustment will either have a positive, negative, or neutral impact on the count of available SKUs in a location.",
+                "name": "inventoryAdjustments",
+                "type": "SKUInventoryAdjustmentsConnection"
+              },
+              {
+                "description": "The quantity of a SKU in a specific state at a particular time and location.",
+                "name": "inventoryCounts",
+                "type": "SKUInventoryCountsConnection"
+              },
+              {
+                "description": "The ISBN code for the SKU.",
+                "name": "isbnCode",
+                "type": "String"
+              },
+              {
+                "description": "The display label of the SKU.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "The locations where the SKU is available.",
+                "name": "locations",
+                "type": "SKULocationsConnection"
+              },
+              {
+                "description": "Media stored under this SKU.",
+                "name": "mediaObjects",
+                "type": "SKUMediaObjectsConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "SKUMetafieldsConnection"
+              },
+              {
+                "description": "A unique name for the SKU.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "These are all the prices the SKU can be sold at. The price can be different based the channel where it is listed or if there is a promotion running.",
+                "name": "prices",
+                "type": "SKUPricesConnection"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "SKUReferencesConnection"
+              },
+              {
+                "description": "A short label for the SKU, useful for UI with limited space.",
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "A SKU group is a grouping of related SKUs. It provides information about all the SKUs that are sold together on storefronts or devices.",
+                "name": "skuGroup",
+                "type": "SKUGroup"
+              },
+              {
+                "description": "The status of the SKU, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String"
+              },
+              {
+                "description": "The cost of the SKU per unit. This is a money object that includes the value and currency code.",
+                "name": "unitCost",
+                "type": "SimpleMoney"
+              },
+              {
+                "description": "The unit of weight, one of `KG`, `GR`, `LB`, `OZ`.",
+                "name": "unitOfWeight",
+                "type": "String"
+              },
+              {
+                "description": "The UPC code for the SKU.",
+                "name": "upcCode",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the SKU was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The weight of the SKU.",
+                "name": "weight",
+                "type": "Float"
+              }
+            ],
+            "kind": "object",
+            "name": "SKU"
+          },
+          {
+            "fields": [
+              {
+                "name": "has",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUAttributeValueFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUAttributeValuesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUAttributeValuesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "AttributeValue"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUAttributeValuesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUAttributesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUAttributesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Attribute"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUAttributesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "Filters SKUs where the code contains the specified string, case-insensitive.",
+                "name": "contains",
+                "type": "String"
+              },
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "description": "Filters SKUs where the code matches any of the specified codes.",
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUEanCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the SKU group. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "A SKU represents a stock keeping unit (SKU) in the catalog.",
+                "name": "SKUs",
+                "type": "SKUGroupSKUsConnection"
+              },
+              {
+                "description": "The timestamp of when the SKU was activated.",
+                "name": "activatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The timestamp of when the SKU was archived.",
+                "name": "archivedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "Attributes of SKU Group.",
+                "name": "attributes",
+                "type": "SKUGroupAttributesConnection"
+              },
+              {
+                "description": "The channel association mode for this SKU Group. Can be ALL (uses active channels registered to the store) or\n\t\t\t\tSELECTIVE (uses custom channel associations).",
+                "name": "channelAssociationMode",
+                "type": "String"
+              },
+              {
+                "description": "An association to a channel that exists in the Channel API.",
+                "name": "channels",
+                "type": "SKUGroupChannelsConnection"
+              },
+              {
+                "description": "The compare-at price range of the SKU group, showing min and max compare-at prices of SKUs in the group.",
+                "name": "compareAtPriceRange",
+                "type": "PriceRange"
+              },
+              {
+                "description": "The timestamp of when the SKU was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The merchant defined description of the group.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the SKU group. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID of the group.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The display label of the group.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "A list is a group of SKU groups that are generally organized by similar characteristics.",
+                "name": "lists",
+                "type": "SKUGroupListsConnection"
+              },
+              {
+                "description": "Media objects stored under the SKU Group.",
+                "name": "mediaObjects",
+                "type": "SKUGroupMediaObjectsConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "SKUGroupMetafieldsConnection"
+              },
+              {
+                "description": "A unique human-friendly identifier for the group.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "An option is a add-on that can be added on to a SKU group.",
+                "name": "options",
+                "type": "SKUGroupOptionsConnection"
+              },
+              {
+                "description": "The price range of the SKU group, showing min and max prices of SKUs in the group.",
+                "name": "priceRange",
+                "type": "PriceRange"
+              },
+              {
+                "description": "A reference to the resource in an external service. This can be useful for integrating the resource to any external service.",
+                "name": "references",
+                "type": "SKUGroupReferencesConnection"
+              },
+              {
+                "description": "A short label for the group. Can be used instead of the label on smaller screens.",
+                "name": "shortLabel",
+                "type": "String"
+              },
+              {
+                "description": "The count of all SKUs associated with the SKU Group. Can be filtered by status. The default statuses are ACTIVE and DRAFT.",
+                "name": "skuCount",
+                "type": "Int"
+              },
+              {
+                "description": "A SKU represents a stock keeping unit (SKU) in the catalog.",
+                "name": "skus",
+                "type": "SKUGroupSkusConnection"
+              },
+              {
+                "description": "The status of the SKU Group, one of `DRAFT`, `ACTIVE`, `ARCHIVED`.",
+                "name": "status",
+                "type": "String!"
+              },
+              {
+                "description": "The type of the SKU Group, typically PHYSICAL or DIGITAL, but can also be a custom type.",
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp of when the SKU was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroup"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupAttributesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupAttributesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Attribute"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupAttributesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the channel.",
+                "name": "channelId",
+                "type": "ID!"
+              },
+              {
+                "description": "The timestamp of when the channel association was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the channel association.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The status of the channel association. One of `ACTIVE`, `INACTIVE`",
+                "name": "status",
+                "type": "String!"
+              },
+              {
+                "description": "The timestamp of when the channel association was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupChannel"
+          },
+          {
+            "fields": [
+              {
+                "name": "channelId",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupChannelAddInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupChannelIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupChannelsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupChannelsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUGroupChannel"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupChannelsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupListsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupListsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "List"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupListsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupMediaObjectsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupMediaObjectsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Media"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupMediaObjectsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupOptionsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupOptionsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Option"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupOptionsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "label",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "lowestPrice",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "saleCount",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupSKUsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupSKUsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupSKUsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUGroupSkusConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupSkusConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKU"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUGroupSkusConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGroupTypeFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUGtinCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUInventoryAdjustmentsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUInventoryAdjustmentsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryAdjustment"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUInventoryAdjustmentsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUInventoryCountsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUInventoryCountsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "InventoryCount"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUInventoryCountsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUIsbnCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKULocationsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKULocationsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Location"
+              }
+            ],
+            "kind": "object",
+            "name": "SKULocationsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUMediaObjectsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUMediaObjectsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Media"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUMediaObjectsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "label",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "price",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "A SKU represents a stock keeping unit (SKU) in the catalog.",
+                "name": "SKU",
+                "type": "SKU"
+              },
+              {
+                "description": "The compare-at value of the price.",
+                "name": "compareAtValue",
+                "type": "SimpleMoney"
+              },
+              {
+                "description": "The timestamp of when the price was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID of the price.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "A SKU represents a stock keeping unit (SKU) in the catalog.",
+                "name": "sku",
+                "type": "SKU"
+              },
+              {
+                "description": "The last update timestamp of the price.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The value of the price.",
+                "name": "value",
+                "type": "SimpleMoney!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUPrice"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUPriceIdsFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUPriceOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "SKUPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[SKUReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "SKUReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "String"
+              },
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "SKUUpcCodeFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "A three-character ISO-4217 currency code.",
+                "name": "currencyCode",
+                "type": "String!"
+              },
+              {
+                "description": "The integer value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies that are subdivided into hundredths, like USD; or, subdivided into thousandths, like TND. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes. This field is typed as Float to be able to support values larger than GraphQL's 32-bit Integer.",
+                "name": "value",
+                "type": "Float!"
+              }
+            ],
+            "kind": "object",
+            "name": "SimpleMoney"
+          },
+          {
+            "fields": [
+              {
+                "name": "currencyCode",
+                "type": "String!"
+              },
+              {
+                "description": "The integer value, which might represent intergrals for currencies like `JPY` that are not typically fractional; or, with an implied decimal fraction for currencies that are subdivided into hundredths, like USD; or, subdivided into thousandths, like TND. Only accepts integer value. Decimals are not accepted. This input is typed as Float to be able to support values larger than GraphQL's 32-bit Integer.",
+                "name": "value",
+                "type": "Float!"
+              }
+            ],
+            "kind": "input",
+            "name": "SimpleMoneyInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "HTML description for the Option. Will be used to display rich text content to customers.",
+                "name": "HTMLDescription",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the Option was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "A description of the Option.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "HTML description for the Option. Will be used to display rich text content to customers.",
+                "name": "htmlDescription",
+                "type": "String"
+              },
+              {
+                "description": "The UUID of the Option",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "Whether the option is shareable across multiple SKU Groups (a global modifier).",
+                "name": "shareable",
+                "type": "Boolean!"
+              },
+              {
+                "description": "The display lable of the Option",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "OptionMetafieldsConnection"
+              },
+              {
+                "description": "A unique name of the Option.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The position of the option.",
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "Represents the additional cost of a Text Option. When empty, it indicates this option allows for flexible pricing.",
+                "name": "prices",
+                "type": "TextOptionPricesConnection"
+              },
+              {
+                "description": "The UUID of the SKU Group that the Option belongs to.",
+                "name": "skuGroupId",
+                "type": "ID!"
+              },
+              {
+                "description": "The IDs of all SKU groups this option is associated with.",
+                "name": "skuGroupIds",
+                "type": "[String!]!"
+              },
+              {
+                "description": "The type of the option, one of `TEXT`, `NUMBER`, `LIST`, Option Values are available for the 'LIST' type.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "description": "The timestamp of when the Option was updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "Provide validations on how the option can be applied to a SKU. If `TEXT` option then `min` and `max` apply to the number of characters. If `NUMBER` then `min` and `max` apply to the actual number value. If `LIST` then `min` and `max` apply to the number of values that can be selected.",
+                "name": "validation",
+                "type": "OptionValidation"
+              }
+            ],
+            "kind": "object",
+            "name": "TextOption"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[TextOptionPricesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              },
+              {
+                "name": "totalCount",
+                "type": "Int!"
+              }
+            ],
+            "kind": "object",
+            "name": "TextOptionPricesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "OptionPrice"
+              }
+            ],
+            "kind": "object",
+            "name": "TextOptionPricesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "addressDetails",
+                "type": "AddressDetailsInput"
+              },
+              {
+                "name": "addressLine1",
+                "type": "String"
+              },
+              {
+                "name": "addressLine2",
+                "type": "String"
+              },
+              {
+                "name": "addressLine3",
+                "type": "String"
+              },
+              {
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "name": "countryCode",
+                "type": "String"
+              },
+              {
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "UpdateAddressInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "contentType",
+                "type": "String"
+              },
+              {
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "name": "filename",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "UpdateFileInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "String!"
+              },
+              {
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "name": "metafields",
+                "type": "[UpsertMetafieldInput!]"
+              },
+              {
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "name": "position",
+                "type": "Int"
+              },
+              {
+                "description": "The type of the media, one of `PHOTO`, `VIDEO`, `IMAGE`, `AUDIO`.",
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "name": "url",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "UpdateMediaObjectInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "optionId",
+                "type": "String!"
+              },
+              {
+                "name": "position",
+                "type": "Int!"
+              }
+            ],
+            "kind": "input",
+            "name": "UpdateSKUGroupOptionPositionInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "gt",
+                "type": "String"
+              },
+              {
+                "name": "lt",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "UpdatedAtFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "key",
+                "type": "String!"
+              },
+              {
+                "name": "namespace",
+                "type": "String!"
+              },
+              {
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "UpsertMetafieldInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied",
+                "name": "sdl",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "_Service"
+          }
+        ]
       },
       "method": "POST",
       "operationId": "postCatalogGraphql",
@@ -3492,5 +12307,5 @@
   ],
   "name": "catalog-products",
   "title": "Catalog GraphQL API",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/rust/schemas/api/taxes.json
+++ b/rust/schemas/api/taxes.json
@@ -942,7 +942,2273 @@
             "returnType": "Rate"
           }
         ],
-        "schemaRef": "./graphql/schema.graphql"
+        "schemaRef": "./graphql/schema.graphql",
+        "sdl": "\"\"\"An individual line item that was calculated.\"\"\"\ntype CalculatedLine {\n  calculationLine: CalculationLine!\n\n  \"\"\"\n  The individual tax amounts for the rates that were applied to the line.\n  \"\"\"\n  taxAmounts: [TaxAmount!]!\n\n  \"\"\"The total money amount of tax calculated for the line.\"\"\"\n  totalTaxAmount: TotalTaxAmount!\n}\n\n\"\"\"The rate that was used for the calculated amount.\"\"\"\ntype CalculatedRate {\n  \"\"\"The method that was used to apply the rate to a purchase amount.\"\"\"\n  calculationMethod: RateCalculationMethodEnum!\n\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID\n\n  \"\"\"The label for display.\"\"\"\n  label: String\n\n  \"\"\"The unique human-friendly identifier.\"\"\"\n  name: String\n\n  \"\"\"The rate's value\"\"\"\n  value: CalculatedRateValue!\n}\n\n\"\"\"The rate value represented as a fixed money amount.\"\"\"\ntype CalculatedRateAmount {\n  amount: SimpleMoney\n  appliedAmount: SimpleMoney\n}\n\n\"\"\"The rate value represented as a percentage.\"\"\"\ntype CalculatedRatePercentage {\n  \"\"\"The percentage applied by the rate, out of 100.\"\"\"\n  appliedPercentage: String!\n\n  \"\"\"The percentage value of the rate, out of 100.\"\"\"\n  percentage: String!\n}\n\nunion CalculatedRateValue = CalculatedRateAmount | CalculatedRatePercentage\n\ninput CalculationAddressInput {\n  \"\"\"The first line of the address. For example, number and street name.\"\"\"\n  addressLine1: String\n\n  \"\"\"\n  The second line of the address. For example, office suite or apartment number.\n  \"\"\"\n  addressLine2: String\n\n  \"\"\"The third line of the address, if needed.\"\"\"\n  addressLine3: String\n\n  \"\"\"\n  The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.\n  \"\"\"\n  adminArea1: String\n\n  \"\"\"The city, town, or village. Smaller than `adminArea1`.\"\"\"\n  adminArea2: String\n\n  \"\"\"\n  The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.\n  \"\"\"\n  adminArea3: String\n\n  \"\"\"\n  The neighborhood, ward, or district. Smaller than `adminArea3` or `subLocality`.\n  \"\"\"\n  adminArea4: String\n\n  \"\"\"\n  The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.\n  \"\"\"\n  countryCode: String\n\n  \"\"\"The postal code, which is the zip code or equivalent.\"\"\"\n  postalCode: String\n}\n\n\"\"\"\nAn individual line item that was used in the calculation, passed back unmodified from the request.\n\"\"\"\ntype CalculationLine {\n  \"\"\"The client-defined ID for the line.\"\"\"\n  id: String!\n}\n\n\"\"\"An individual line item to be calculated.\"\"\"\ninput CalculationLineInput {\n  \"\"\"The ID or code for the item's classification.\"\"\"\n  classification: String\n\n  \"\"\"\n  The location to which the item is being sent. e.g. the customer's address. Overrides the top-level value if provided.\n  \"\"\"\n  destination: CalculationLocationInput\n\n  \"\"\"\n  The client-defined ID for the line. This could be a UUID of the SKU, or a shipping method/package name.\n  \"\"\"\n  id: String!\n\n  \"\"\"\n  The location from which the item is originating. Overrides the top-level value if provided.\n  \"\"\"\n  origin: CalculationLocationInput\n\n  \"\"\"The number of units being purchased.\"\"\"\n  quantity: Float\n\n  \"\"\"The money amount for the total quantity being purchased.\"\"\"\n  subtotalPrice: SimpleMoneyInput!\n  type: CalculationLineType!\n\n  \"\"\"The money amount for a single unit of the item being purchased.\"\"\"\n  unitPrice: SimpleMoneyInput\n}\n\nenum CalculationLineType {\n  FEE\n  SHIPPING\n  SKU\n}\n\n\"\"\"The location address.\"\"\"\ntype CalculationLocation {\n  \"\"\"The location address.\"\"\"\n  address: CalculationLocationAddress!\n}\n\n\"\"\"The location address.\"\"\"\ntype CalculationLocationAddress {\n  \"\"\"The first line of the address.\"\"\"\n  addressLine1: String\n\n  \"\"\"The second line of the address.\"\"\"\n  addressLine2: String\n\n  \"\"\"The third line of the address.\"\"\"\n  addressLine3: String\n\n  \"\"\"\n  The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\n  \"\"\"\n  adminArea1: String\n\n  \"\"\"The city, town, or village.\"\"\"\n  adminArea2: String\n\n  \"\"\"The sub-locality, suburb, neighborhood, or district.\"\"\"\n  adminArea3: String\n\n  \"\"\"The neighborhood, ward, or district.\"\"\"\n  adminArea4: String\n\n  \"\"\"The country code of the address.\"\"\"\n  countryCode: String!\n\n  \"\"\"The postal code of the address.\"\"\"\n  postalCode: String\n}\n\ninput CalculationLocationInput {\n  \"\"\"The location address.\"\"\"\n  address: CalculationAddressInput\n}\n\ntype CalculationResult {\n  lines: [CalculatedLine!]!\n\n  \"\"\"\n  The individual tax amounts for the rates that were applied to the purchase. A combined summary of all of the rates that applied across all of the lines.\n  \"\"\"\n  taxAmounts: [TaxAmount!]!\n\n  \"\"\"\n  The total money amount of tax calculated for the purchase. A sum of each individual line tax amount.\n  \"\"\"\n  totalTaxAmount: TotalTaxAmount!\n}\n\n\"\"\"\nA list is a group of SKU groups that are generally organized by similar characteristics.\n\"\"\"\ntype CatalogList {\n  \"\"\"The globally-unique ID of the list.\"\"\"\n  id: ID!\n}\n\n\"\"\"A SKU represents a stock keeping unit (SKU) in the catalog.\"\"\"\ntype CatalogSKU {\n  \"\"\"The globally-unique ID of the SKU.\"\"\"\n  id: ID!\n}\n\n\"\"\"A SKU Group is a grouping of SKUs.\"\"\"\ntype CatalogSKUGroup {\n  \"\"\"The globally-unique ID of the SKU group.\"\"\"\n  id: ID!\n}\n\n\"\"\"A grouping of rates that share common taxation criteria.\"\"\"\ntype Classification {\n  \"\"\"The data & time at which the classification was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID!\n\n  \"\"\"The label for display.\"\"\"\n  label: String!\n\n  \"\"\"The catalog lists to which the classification applies.\"\"\"\n  lists(after: String, before: String, first: Int, last: Int): ClassificationListsConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield\"\"\"\n    namespace: String\n  ): ClassificationMetafieldsConnection\n\n  \"\"\"The unique human-friendly identifier.\"\"\"\n  name: String!\n\n  \"\"\"The rates associated with the classification.\"\"\"\n  rates(after: String, before: String, first: Int, last: Int, orderBy: RateOrderBy, status: RateStatusFilter): ClassificationRatesConnection\n\n  \"\"\"A reference to the resource in an external service.\"\"\"\n  references(after: String, before: String, first: Int, last: Int, orderBy: ReferenceOrderByInput): ClassificationReferencesConnection\n\n  \"\"\"The catalog SKU groups to which the classification applies.\"\"\"\n  skuGroups(after: String, before: String, first: Int, last: Int): ClassificationSkuGroupsConnection\n\n  \"\"\"The catalog SKUs to which the classification applies.\"\"\"\n  skus(after: String, before: String, first: Int, last: Int): ClassificationSkusConnection\n\n  \"\"\"The data & time at which the classification was last updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput ClassificationIdFilter {\n  in: [ID!]\n}\n\ntype ClassificationListsConnection {\n  edges: [ClassificationListsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationListsConnectionEdge {\n  cursor: String!\n  node: CatalogList\n}\n\ntype ClassificationMetafieldsConnection {\n  edges: [ClassificationMetafieldsEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput ClassificationOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype ClassificationRatesConnection {\n  edges: [ClassificationRatesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationRatesConnectionEdge {\n  cursor: String!\n  node: Rate\n}\n\ntype ClassificationReferencesConnection {\n  edges: [ClassificationReferencesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ntype ClassificationSkuGroupsConnection {\n  edges: [ClassificationSkuGroupsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationSkuGroupsConnectionEdge {\n  cursor: String!\n  node: CatalogSKUGroup\n}\n\ntype ClassificationSkusConnection {\n  edges: [ClassificationSkusConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype ClassificationSkusConnectionEdge {\n  cursor: String!\n  node: CatalogSKU\n}\n\ninput CreateMetafieldInput {\n  key: String!\n  namespace: String!\n  type: String!\n  value: String!\n}\n\ninput CreateReferenceInput {\n  \"\"\"The origin of the reference.\"\"\"\n  origin: String!\n\n  \"\"\"The value of the reference.\"\"\"\n  value: String!\n}\n\n\"\"\"\nA date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.\n\"\"\"\nscalar DateTime\n\n\"\"\"A geographic area or \"zone\" in which a rate or set of rates applies.\"\"\"\ntype Jurisdiction {\n  \"\"\"\n  The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\n  \"\"\"\n  adminArea1: String\n\n  \"\"\"The city, town, or village.\"\"\"\n  adminArea2: String\n\n  \"\"\"The sub-locality, suburb, neighborhood, or district.\"\"\"\n  adminArea3: String\n\n  \"\"\"The neighborhood, ward, or district.\"\"\"\n  adminArea4: String\n\n  \"\"\"The country code of the address.\"\"\"\n  countryCode: String!\n\n  \"\"\"The data & time at which the jurisdiction was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield\"\"\"\n    namespace: String\n  ): JurisdictionMetafieldsConnection\n\n  \"\"\"The postal code of the address.\"\"\"\n  postalCode: String\n\n  \"\"\"The rates associated with the jurisdiction.\"\"\"\n  rates(after: String, before: String, first: Int, last: Int, orderBy: RateOrderBy, status: RateStatusFilter): JurisdictionRatesConnection\n\n  \"\"\"The data & time at which the jurisdiction was last updated.\"\"\"\n  updatedAt: DateTime!\n}\n\ninput JurisdictionIdFilter {\n  in: [ID!]\n}\n\ntype JurisdictionMetafieldsConnection {\n  edges: [JurisdictionMetafieldsEdge]\n  pageInfo: PageInfo!\n}\n\ntype JurisdictionMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput JurisdictionOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype JurisdictionRatesConnection {\n  edges: [JurisdictionRatesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype JurisdictionRatesConnectionEdge {\n  cursor: String!\n  node: Rate\n}\n\n\"\"\"Custom data\"\"\"\ntype Metafield {\n  createdAt: String\n  id: ID\n  key: String\n  namespace: String\n  resourceId: ID\n  type: String\n  updatedAt: String\n  value: String\n}\n\ntype Mutation {\n  \"\"\"Activate an existing override.\"\"\"\n  activateOverride(id: ID!): Override\n\n  \"\"\"Activate an existing rate.\"\"\"\n  activateRate(id: ID!): Rate\n\n  \"\"\"Add existing lists to an existing classification.\"\"\"\n  addListsToClassification(\n    \"\"\"The ID of the classification to which the lists should be added.\"\"\"\n    classificationId: ID!\n    input: MutationAddListsToClassificationInput!\n  ): Classification\n\n  \"\"\"Add existing lists to an existing override.\"\"\"\n  addListsToOverride(input: MutationAddListsToOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Add existing rates to an existing classification.\"\"\"\n  addRatesToClassification(\n    \"\"\"The ID of the classification to which the rates should be added.\"\"\"\n    classificationId: ID!\n    input: MutationAddRatesToClassificationInput!\n  ): Classification\n\n  \"\"\"Add existing rates to an existing override.\"\"\"\n  addRatesToOverride(input: MutationAddRatesToOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Add existing SKU groups to an existing override.\"\"\"\n  addSkuGroupsToOverride(input: MutationAddSkuGroupsToOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Add existing SKU groups to an existing classification.\"\"\"\n  addSkusGroupsToClassification(\n    \"\"\"The ID of the classification to which the SKU groups should be added.\"\"\"\n    classificationId: ID!\n    input: MutationAddSkusGroupsToClassificationInput!\n  ): Classification\n\n  \"\"\"Add existing SKUs to an existing classification.\"\"\"\n  addSkusToClassification(\n    \"\"\"The ID of the classification to which the SKUs should be added.\"\"\"\n    classificationId: ID!\n    input: MutationAddSkusToClassificationInput!\n  ): Classification\n\n  \"\"\"Add existing SKUs to an existing override.\"\"\"\n  addSkusToOverride(input: MutationAddSkusToOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Calculate taxes.\"\"\"\n  calculateTaxes(channelId: ID!, input: MutationCalculateTaxesInput!): CalculationResult\n\n  \"\"\"Create a new classification.\"\"\"\n  createClassification(input: MutationCreateClassificationInput!): Classification\n\n  \"\"\"Create a new jurisdiction.\"\"\"\n  createJurisdiction(input: MutationCreateJurisdictionInput!): Jurisdiction\n\n  \"\"\"Create a new override.\"\"\"\n  createOverride(input: MutationCreateOverrideInput!): Override\n\n  \"\"\"Create a new rate.\"\"\"\n  createRate(input: MutationCreateRateInput!): Rate\n\n  \"\"\"Create references for an existing classifiction.\"\"\"\n  createReferencesForClassification(\n    \"\"\"\n    The ID of the classification for which the references should be created.\n    \"\"\"\n    id: ID!\n    input: MutationCreateReferencesForClassificationInput!\n  ): Classification\n\n  \"\"\"Create references for an existing override.\"\"\"\n  createReferencesForOverride(id: ID!, input: MutationCreateReferencesForOverrideInput!): Override\n\n  \"\"\"Create references for an existing rate.\"\"\"\n  createReferencesForRate(id: ID!, input: MutationCreateReferencesForRateInput!): Rate\n\n  \"\"\"Deactivate an existing override.\"\"\"\n  deactivateOverride(id: ID!): Override\n\n  \"\"\"Deactivate an existing rate.\"\"\"\n  deactivateRate(id: ID!): Rate\n\n  \"\"\"Delete an existing classification.\"\"\"\n  deleteClassification(\n    \"\"\"The ID of the classification to be deleted.\"\"\"\n    id: ID!\n  ): Classification\n\n  \"\"\"Delete an existing jurisdiction.\"\"\"\n  deleteJurisdiction(\n    \"\"\"The ID of the jurisdiction to be deleted.\"\"\"\n    id: ID!\n  ): Jurisdiction\n\n  \"\"\"Delete an existing override.\"\"\"\n  deleteOverride(id: ID!): Override\n\n  \"\"\"Delete an existing rate.\"\"\"\n  deleteRate(id: ID!): Rate\n\n  \"\"\"Delete references from an existing classification.\"\"\"\n  deleteReferencesFromClassification(\n    \"\"\"\n    The ID of the classification for which the references should be deleted.\n    \"\"\"\n    id: ID!\n    input: MutationDeleteReferencesFromClassificationInput!\n  ): Classification\n\n  \"\"\"Delete references from an existing override.\"\"\"\n  deleteReferencesFromOverride(id: ID!, input: MutationDeleteReferencesFromOverrideInput!): Override\n\n  \"\"\"Delete references from an existing rate.\"\"\"\n  deleteReferencesFromRate(id: ID!, input: MutationDeleteReferencesFromRateInput!): Rate\n\n  \"\"\"Remove existing lists from an existing classification.\"\"\"\n  removeListsFromClassification(\n    \"\"\"The ID of the classification to which the lists should be removed.\"\"\"\n    classificationId: ID!\n    input: MutationRemoveListsFromClassificationInput!\n  ): Classification\n\n  \"\"\"Remove existing lists from an existing override.\"\"\"\n  removeListsFromOverride(input: MutationRemoveListsFromOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Remove existing rates from an existing classification.\"\"\"\n  removeRatesFromClassification(\n    \"\"\"The ID of the classification to which the rates should be removed.\"\"\"\n    classificationId: ID!\n    input: MutationRemoveRatesFromClassificationInput!\n  ): Classification\n\n  \"\"\"Remove existing rates from an existing override.\"\"\"\n  removeRatesFromOverride(input: MutationRemoveRatesFromOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Remove existing SKUs from an existing classification.\"\"\"\n  removeSkusFromClassification(\n    \"\"\"The ID of the classification to which the SKUs should be removed.\"\"\"\n    classificationId: ID!\n    input: MutationRemoveSkusFromClassificationInput!\n  ): Classification\n\n  \"\"\"Remove existing SKUs from an existing override.\"\"\"\n  removeSkusFromOverride(input: MutationRemoveSkusFromOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Remove existing SKU groups from an existing classification.\"\"\"\n  removeSkusGroupsFromClassification(\n    \"\"\"The ID of the classification to which the SKU groups should be added.\"\"\"\n    classificationId: ID!\n    input: MutationRemoveSkusGroupsFromClassificationInput!\n  ): Classification\n\n  \"\"\"Remove existing SKU groups from an existing override.\"\"\"\n  removeSkusGroupsFromOverride(input: MutationRemoveSkusGroupsFromOverrideInput!, overrideId: ID!): Override\n\n  \"\"\"Update an existing classification.\"\"\"\n  updateClassification(\n    \"\"\"The ID of the classification to be updated.\"\"\"\n    id: ID!\n    input: MutationUpdateClassificationInput!\n  ): Classification\n\n  \"\"\"Update an existing jurisdiction.\"\"\"\n  updateJurisdiction(\n    \"\"\"The ID of the jurisdiction to be updated.\"\"\"\n    id: ID!\n    input: MutationUpdateJurisdictionInput!\n  ): Jurisdiction\n\n  \"\"\"Update an existing override.\"\"\"\n  updateOverride(id: ID!, input: MutationUpdateOverrideInput!): Override\n\n  \"\"\"Update an existing rate.\"\"\"\n  updateRate(id: ID!, input: MutationUpdateRateInput!): Rate\n}\n\ninput MutationAddListsToClassificationInput {\n  \"\"\"The IDs of the lists to be added to the classification.\"\"\"\n  listIds: [ID!]!\n}\n\ninput MutationAddListsToOverrideInput {\n  listIds: [ID!]!\n}\n\ninput MutationAddRatesToClassificationInput {\n  \"\"\"The IDs of the rates to be added to the classification.\"\"\"\n  rateIds: [ID!]!\n}\n\ninput MutationAddRatesToOverrideInput {\n  rateIds: [ID!]!\n}\n\ninput MutationAddSkuGroupsToOverrideInput {\n  skuGroupIds: [ID!]!\n}\n\ninput MutationAddSkusGroupsToClassificationInput {\n  \"\"\"The IDs of the SKU groups to be added to the classification.\"\"\"\n  skuGroupIds: [ID!]!\n}\n\ninput MutationAddSkusToClassificationInput {\n  \"\"\"The IDs of the SKUs to be added to the classification.\"\"\"\n  skuIds: [ID!]!\n}\n\ninput MutationAddSkusToOverrideInput {\n  skuIds: [ID!]!\n}\n\ninput MutationCalculateTaxesInput {\n  destination: CalculationLocationInput\n  lines: [CalculationLineInput!]!\n  origin: CalculationLocationInput\n}\n\ninput MutationCreateClassificationInput {\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"A label for display.\"\"\"\n  label: String!\n\n  \"\"\"Any metafields to be created and assigned to the new classification.\"\"\"\n  metafields: [CreateMetafieldInput!]\n\n  \"\"\"\n  A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.\n  \"\"\"\n  name: String\n\n  \"\"\"Any references to be created and assigned to the new classification.\"\"\"\n  references: [CreateReferenceInput!]\n}\n\ninput MutationCreateJurisdictionInput {\n  \"\"\"\n  The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.\n  \"\"\"\n  adminArea1: String\n\n  \"\"\"The city, town, or village. Smaller than `adminArea1`.\"\"\"\n  adminArea2: String\n\n  \"\"\"\n  The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.\n  \"\"\"\n  adminArea3: String\n\n  \"\"\"The neighborhood, ward, or district. Smaller than `adminArea3`.\"\"\"\n  adminArea4: String\n\n  \"\"\"\n  The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.\n  \"\"\"\n  countryCode: String!\n\n  \"\"\"Any metafields to be created and assigned to the new jurisdiction.\"\"\"\n  metafields: [CreateMetafieldInput!]\n\n  \"\"\"The postal code, which is the zip code or equivalent.\"\"\"\n  postalCode: String\n}\n\ninput MutationCreateOverrideInput {\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"A custom rate to be applied by the override.\"\"\"\n  customRate: OverrideCustomRateCreateInput\n\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"A label for display.\"\"\"\n  label: String!\n\n  \"\"\"Any metafields to be created and assigned to the new override.\"\"\"\n  metafields: [CreateMetafieldInput!]\n\n  \"\"\"\n  A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.\n  \"\"\"\n  name: String\n\n  \"\"\"Any references to be created and assigned to the new override.\"\"\"\n  references: [CreateReferenceInput!]\n\n  \"\"\"The desired status.\"\"\"\n  status: OverrideStatusEnum = ACTIVE\n\n  \"\"\"The ID of the target rate that this override references.\"\"\"\n  targetRateId: ID\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n}\n\ninput MutationCreateRateInput {\n  \"\"\"The method to be used when applying the rate to a purchase amount.\"\"\"\n  calculationMethod: RateCalculationMethodEnum = ADDITIVE\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"The ID of the jurisdiction in which this rate applies.\"\"\"\n  jurisdictionId: ID\n\n  \"\"\"A label for display.\"\"\"\n  label: String!\n\n  \"\"\"Any metafields to be created and assigned to the new rate.\"\"\"\n  metafields: [CreateMetafieldInput!]\n\n  \"\"\"\n  A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.\n  \"\"\"\n  name: String\n\n  \"\"\"Any references to be created and assigned to the new rate.\"\"\"\n  references: [CreateReferenceInput!]\n\n  \"\"\"The desired status.\"\"\"\n  status: RateStatusEnum = ACTIVE\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"The rate's value.\"\"\"\n  value: RateValueInput\n}\n\ninput MutationCreateReferencesForClassificationInput {\n  \"\"\"The references to be created for the classification.\"\"\"\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationCreateReferencesForOverrideInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationCreateReferencesForRateInput {\n  references: [CreateReferenceInput!]!\n}\n\ninput MutationDeleteReferencesFromClassificationInput {\n  \"\"\"The IDs of the references to be deleted from the classification.\"\"\"\n  referenceIds: [ID!]!\n}\n\ninput MutationDeleteReferencesFromOverrideInput {\n  referenceIds: [ID!]!\n}\n\ninput MutationDeleteReferencesFromRateInput {\n  referenceIds: [ID!]!\n}\n\ninput MutationRemoveListsFromClassificationInput {\n  \"\"\"The IDs of the lists to be removed from the classification.\"\"\"\n  listIds: [ID!]!\n}\n\ninput MutationRemoveListsFromOverrideInput {\n  listIds: [ID!]!\n}\n\ninput MutationRemoveRatesFromClassificationInput {\n  \"\"\"The IDs of the rates to be remove from the classification.\"\"\"\n  rateIds: [ID!]!\n}\n\ninput MutationRemoveRatesFromOverrideInput {\n  rateIds: [ID!]!\n}\n\ninput MutationRemoveSkusFromClassificationInput {\n  \"\"\"The IDs of the SKUs to be removed from the classification.\"\"\"\n  skuIds: [ID!]!\n}\n\ninput MutationRemoveSkusFromOverrideInput {\n  skuIds: [ID!]!\n}\n\ninput MutationRemoveSkusGroupsFromClassificationInput {\n  \"\"\"The IDs of the SKU groups to be removed from the classification.\"\"\"\n  skuGroupIds: [ID!]!\n}\n\ninput MutationRemoveSkusGroupsFromOverrideInput {\n  skuGroupIds: [ID!]!\n}\n\ninput MutationUpdateClassificationInput {\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"A label for display.\"\"\"\n  label: String\n\n  \"\"\"A unique human-friendly identifier.\"\"\"\n  name: String\n}\n\ninput MutationUpdateJurisdictionInput {\n  \"\"\"\n  The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.\n  \"\"\"\n  adminArea1: String\n\n  \"\"\"The city, town, or village. Smaller than `adminArea1`.\"\"\"\n  adminArea2: String\n\n  \"\"\"\n  The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.\n  \"\"\"\n  adminArea3: String\n\n  \"\"\"The neighborhood, ward, or district. Smaller than `adminArea3`.\"\"\"\n  adminArea4: String\n\n  \"\"\"\n  The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.\n  \"\"\"\n  countryCode: String\n\n  \"\"\"The postal code, which is the zip code or equivalent.\"\"\"\n  postalCode: String\n}\n\ninput MutationUpdateOverrideInput {\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"A custom rate to be applied by the override.\"\"\"\n  customRate: OverrideCustomRateUpdateInput\n\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"A label for display.\"\"\"\n  label: String\n\n  \"\"\"A unique human-friendly identifier.\"\"\"\n  name: String\n\n  \"\"\"The desired status.\"\"\"\n  status: OverrideStatusEnum\n\n  \"\"\"The ID of the target rate that this override references.\"\"\"\n  targetRateId: ID\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n}\n\ninput MutationUpdateRateInput {\n  \"\"\"The method to be used when applying the rate to a purchase amount.\"\"\"\n  calculationMethod: RateCalculationMethodEnum\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  createdAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"A human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"The ID of the jurisdiction in which this rate applies.\"\"\"\n  jurisdictionId: ID\n\n  \"\"\"A label for display.\"\"\"\n  label: String\n\n  \"\"\"A unique human-friendly identifier.\"\"\"\n  name: String\n\n  \"\"\"The desired status.\"\"\"\n  status: RateStatusEnum\n\n  \"\"\"WARNING: DO NOT USE.\"\"\"\n  updatedAt: DateTime @deprecated(reason: \"This field is deprecated and only used for Tax v1 to v2 migration syncs.\")\n\n  \"\"\"The rate's value.\"\"\"\n  value: RateValueInput\n}\n\nenum OrderByDirectionEnum {\n  ASC\n  DESC\n}\n\n\"\"\"\nA rule to override any other taxation criteria for the associated skus, groups, or lists.\n\"\"\"\ntype Override {\n  \"\"\"The data & time at which the override was last activated.\"\"\"\n  activatedAt: DateTime\n\n  \"\"\"The data & time at which the override was created.\"\"\"\n  createdAt: DateTime!\n  customRate: OverrideCustomRate\n\n  \"\"\"The human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID!\n\n  \"\"\"The label for display.\"\"\"\n  label: String!\n\n  \"\"\"The catalog lists to which the override applies.\"\"\"\n  lists(after: String, before: String, first: Int, last: Int): OverrideListsConnection\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield\"\"\"\n    namespace: String\n  ): OverrideMetafieldsConnection\n\n  \"\"\"The unique human-friendly identifier.\"\"\"\n  name: String!\n\n  \"\"\"The rates associated with the override.\"\"\"\n  rates(after: String, before: String, first: Int, last: Int, orderBy: RateOrderBy, status: RateStatusFilter): OverrideRatesConnection\n\n  \"\"\"A reference to a resource in an external service.\"\"\"\n  references(after: String, before: String, first: Int, last: Int, orderBy: ReferenceOrderByInput): OverrideReferencesConnection\n\n  \"\"\"The catalog SKU groups to which the override applies.\"\"\"\n  skuGroups(after: String, before: String, first: Int, last: Int): OverrideSkuGroupsConnection\n\n  \"\"\"The catalog SKUs to which the override applies.\"\"\"\n  skus(after: String, before: String, first: Int, last: Int): OverrideSkusConnection\n\n  \"\"\"The current status.\"\"\"\n  status: OverrideStatusEnum!\n\n  \"\"\"The rate that this override targets.\"\"\"\n  targetRate: Rate\n\n  \"\"\"The data & time at which the override was last updated.\"\"\"\n  updatedAt: DateTime!\n}\n\nenum OverrideCalculationMethodEnum {\n  ADDITIVE\n  INCLUSIVE\n}\n\n\"\"\"The custom rate to be applied by the override.\"\"\"\ntype OverrideCustomRate {\n  \"\"\"The method to be used when applying the override during calculation.\"\"\"\n  calculationMethod: OverrideCalculationMethodEnum!\n\n  \"\"\"The rate's value\"\"\"\n  value: RateValue!\n}\n\ninput OverrideCustomRateCreateInput {\n  \"\"\"\n  The method to be used when applying the custom rate to a purchase amount.\n  \"\"\"\n  calculationMethod: OverrideCalculationMethodEnum = ADDITIVE\n\n  \"\"\"The custom rate's value.\"\"\"\n  value: RateValueInput!\n}\n\ninput OverrideCustomRateUpdateInput {\n  \"\"\"\n  The method to be used when applying the custom rate to a purchase amount.\n  \"\"\"\n  calculationMethod: OverrideCalculationMethodEnum\n\n  \"\"\"The custom rate's value.\"\"\"\n  value: RateValueInput\n}\n\ninput OverrideIdFilter {\n  in: [ID!]\n}\n\ntype OverrideListsConnection {\n  edges: [OverrideListsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideListsConnectionEdge {\n  cursor: String!\n  node: CatalogList\n}\n\ntype OverrideMetafieldsConnection {\n  edges: [OverrideMetafieldsEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput OverrideOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ntype OverrideRatesConnection {\n  edges: [OverrideRatesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideRatesConnectionEdge {\n  cursor: String!\n  node: Rate\n}\n\ntype OverrideReferencesConnection {\n  edges: [OverrideReferencesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\ntype OverrideSkuGroupsConnection {\n  edges: [OverrideSkuGroupsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideSkuGroupsConnectionEdge {\n  cursor: String!\n  node: CatalogSKUGroup\n}\n\ntype OverrideSkusConnection {\n  edges: [OverrideSkusConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype OverrideSkusConnectionEdge {\n  cursor: String!\n  node: CatalogSKU\n}\n\nenum OverrideStatusEnum {\n  ACTIVE\n  INACTIVE\n}\n\ntype PageInfo {\n  endCursor: String\n  hasNextPage: Boolean!\n  hasPreviousPage: Boolean!\n  startCursor: String\n}\n\ntype Query {\n  \"\"\"Get a single classification.\"\"\"\n  classification(\n    \"\"\"The classification ID.\"\"\"\n    id: ID!\n  ): Classification\n\n  \"\"\"Get a collection of classifications.\"\"\"\n  classifications(after: String, before: String, first: Int, id: ClassificationIdFilter, last: Int, orderBy: ClassificationOrderBy): QueryClassificationsConnection\n\n  \"\"\"Get a single jurisdiction.\"\"\"\n  jurisdiction(\n    \"\"\"The jurisdiction ID.\"\"\"\n    id: ID!\n  ): Jurisdiction\n\n  \"\"\"Get a collection of jurisdictions.\"\"\"\n  jurisdictions(after: String, before: String, first: Int, id: JurisdictionIdFilter, last: Int, orderBy: JurisdictionOrderBy): QueryJurisdictionsConnection\n\n  \"\"\"Get a single override.\"\"\"\n  override(\n    \"\"\"The override ID.\"\"\"\n    id: ID!\n  ): Override\n\n  \"\"\"Get a collection of overrides.\"\"\"\n  overrides(after: String, before: String, first: Int, id: OverrideIdFilter, last: Int, orderBy: OverrideOrderBy, referenceValue: ReferenceValueFilter): QueryOverridesConnection\n\n  \"\"\"Get a single rate.\"\"\"\n  rate(\n    \"\"\"The rate ID.\"\"\"\n    id: ID!\n  ): Rate\n\n  \"\"\"Get a collection of rates.\"\"\"\n  rates(after: String, before: String, first: Int, id: RateIdFilter, last: Int, orderBy: RateOrderBy, referenceValue: ReferenceValueFilter, status: RateStatusFilter): QueryRatesConnection\n}\n\ntype QueryClassificationsConnection {\n  edges: [QueryClassificationsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype QueryClassificationsConnectionEdge {\n  cursor: String!\n  node: Classification\n}\n\ntype QueryJurisdictionsConnection {\n  edges: [QueryJurisdictionsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype QueryJurisdictionsConnectionEdge {\n  cursor: String!\n  node: Jurisdiction\n}\n\ntype QueryOverridesConnection {\n  edges: [QueryOverridesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype QueryOverridesConnectionEdge {\n  cursor: String!\n  node: Override\n}\n\ntype QueryRatesConnection {\n  edges: [QueryRatesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype QueryRatesConnectionEdge {\n  cursor: String!\n  node: Rate\n}\n\n\"\"\"An individual tax rate.\"\"\"\ntype Rate {\n  \"\"\"The data & time at which the rate was first activated.\"\"\"\n  activatedAt: DateTime\n\n  \"\"\"The method to be used when applying the rate to a purchase amount.\"\"\"\n  calculationMethod: RateCalculationMethodEnum!\n\n  \"\"\"The classifications associated with the rate.\"\"\"\n  classifications(after: String, before: String, first: Int, last: Int, orderBy: ClassificationOrderBy): RateClassificationsConnection\n\n  \"\"\"The data & time at which the rate was created.\"\"\"\n  createdAt: DateTime!\n\n  \"\"\"The human-friendly description.\"\"\"\n  description: String\n\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID!\n\n  \"\"\"The jurisdiction in which this rate applies.\"\"\"\n  jurisdiction: Jurisdiction\n\n  \"\"\"The label for display.\"\"\"\n  label: String!\n  metafields(\n    after: String\n    before: String\n    first: Int\n\n    \"\"\"The key of the metafield\"\"\"\n    key: String\n    last: Int\n\n    \"\"\"The namespace of the metafield\"\"\"\n    namespace: String\n  ): RateMetafieldsConnection\n\n  \"\"\"The unique human-friendly identifier.\"\"\"\n  name: String!\n\n  \"\"\"A reference to the resource in an external service.\"\"\"\n  references(after: String, before: String, first: Int, last: Int, orderBy: ReferenceOrderByInput): RateReferencesConnection\n\n  \"\"\"The current status.\"\"\"\n  status: RateStatusEnum!\n\n  \"\"\"The data & time at which the rate was last updated.\"\"\"\n  updatedAt: DateTime!\n\n  \"\"\"The rate's value\"\"\"\n  value: RateValue!\n}\n\n\"\"\"The rate value represented as a fixed money amount.\"\"\"\ntype RateAmount {\n  amount: SimpleMoney\n}\n\nenum RateCalculationMethodEnum {\n  ADDITIVE\n  INCLUSIVE\n}\n\ntype RateClassificationsConnection {\n  edges: [RateClassificationsConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype RateClassificationsConnectionEdge {\n  cursor: String!\n  node: Classification\n}\n\ninput RateIdFilter {\n  in: [ID!]\n}\n\ntype RateMetafieldsConnection {\n  edges: [RateMetafieldsEdge]\n  pageInfo: PageInfo!\n}\n\ntype RateMetafieldsEdge {\n  cursor: String!\n  node: Metafield\n}\n\ninput RateOrderBy {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  name: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\n\"\"\"The rate value represented as a percentage.\"\"\"\ntype RatePercentage {\n  \"\"\"The percentage applied by the rate, out of 100.\"\"\"\n  percentage: String!\n}\n\ntype RateReferencesConnection {\n  edges: [RateReferencesConnectionEdge]\n  pageInfo: PageInfo!\n}\n\ntype RateReferencesConnectionEdge {\n  cursor: String!\n  node: Reference\n}\n\nenum RateStatusEnum {\n  ACTIVE\n  INACTIVE\n}\n\ninput RateStatusFilter {\n  eq: RateStatusEnum\n  in: [RateStatusEnum!]\n}\n\nunion RateValue = RateAmount | RatePercentage\n\ninput RateValueInput {\n  \"\"\"\n  The rate value represented as a fixed money amount. Required if `percentage` is not provided.\n  \"\"\"\n  amount: SimpleMoneyInput\n\n  \"\"\"\n  The percentage applied by the rate, out of 100. Required if `amount` is not provided.\n  \"\"\"\n  percentage: String\n}\n\n\"\"\"A reference to the resource in an external service.\"\"\"\ntype Reference {\n  \"\"\"The globally-unique ID.\"\"\"\n  id: ID!\n\n  \"\"\"The origin of the reference.\"\"\"\n  origin: String!\n\n  \"\"\"The value of the reference.\"\"\"\n  value: String!\n}\n\ninput ReferenceOrderByInput {\n  createdAt: OrderByDirectionEnum\n  id: OrderByDirectionEnum\n  updatedAt: OrderByDirectionEnum\n}\n\ninput ReferenceValueFilter {\n  in: [String!]\n}\n\n\"\"\"\nThe currency and amount for a financial transaction, such as a balance or payment due. Use for value representations with default transactable-value precision.\n\"\"\"\ntype SimpleMoney {\n  \"\"\"A three-character ISO-4217 currency code.\"\"\"\n  currencyCode: String!\n\n  \"\"\"\n  The value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes.\n  \"\"\"\n  value: Float!\n}\n\ninput SimpleMoneyInput {\n  \"\"\"A three-character ISO-4217 currency code.\"\"\"\n  currencyCode: String!\n\n  \"\"\"\n  The value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes.\n  \"\"\"\n  value: Float!\n}\n\n\"\"\"Store object.\"\"\"\ntype Store {\n  \"\"\"The globally-unique ID of the Store.\"\"\"\n  id: ID!\n}\n\n\"\"\"An individual tax amount calculated.\"\"\"\ntype TaxAmount {\n  rate: CalculatedRate!\n  totalTaxAmount: TotalTaxAmount!\n}\n\n\"\"\"The total tax amount calculated.\"\"\"\ntype TotalTaxAmount {\n  currencyCode: String!\n  value: Float!\n}",
+        "types": [
+          {
+            "fields": [
+              {
+                "name": "calculationLine",
+                "type": "CalculationLine!"
+              },
+              {
+                "description": "The individual tax amounts for the rates that were applied to the line.",
+                "name": "taxAmounts",
+                "type": "[TaxAmount!]!"
+              },
+              {
+                "description": "The total money amount of tax calculated for the line.",
+                "name": "totalTaxAmount",
+                "type": "TotalTaxAmount!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculatedLine"
+          },
+          {
+            "fields": [
+              {
+                "description": "The method that was used to apply the rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "RateCalculationMethodEnum!"
+              },
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "description": "The label for display.",
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "description": "The unique human-friendly identifier.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The rate's value",
+                "name": "value",
+                "type": "CalculatedRateValue!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculatedRate"
+          },
+          {
+            "fields": [
+              {
+                "name": "amount",
+                "type": "SimpleMoney"
+              },
+              {
+                "name": "appliedAmount",
+                "type": "SimpleMoney"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculatedRateAmount"
+          },
+          {
+            "fields": [
+              {
+                "description": "The percentage applied by the rate, out of 100.",
+                "name": "appliedPercentage",
+                "type": "String!"
+              },
+              {
+                "description": "The percentage value of the rate, out of 100.",
+                "name": "percentage",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculatedRatePercentage"
+          },
+          {
+            "fields": [
+              {
+                "description": "The first line of the address. For example, number and street name.",
+                "name": "addressLine1",
+                "type": "String"
+              },
+              {
+                "description": "The second line of the address. For example, office suite or apartment number.",
+                "name": "addressLine2",
+                "type": "String"
+              },
+              {
+                "description": "The third line of the address, if needed.",
+                "name": "addressLine3",
+                "type": "String"
+              },
+              {
+                "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The city, town, or village. Smaller than `adminArea1`.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The neighborhood, ward, or district. Smaller than `adminArea3` or `subLocality`.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.",
+                "name": "countryCode",
+                "type": "String"
+              },
+              {
+                "description": "The postal code, which is the zip code or equivalent.",
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "CalculationAddressInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The client-defined ID for the line.",
+                "name": "id",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculationLine"
+          },
+          {
+            "fields": [
+              {
+                "description": "The ID or code for the item's classification.",
+                "name": "classification",
+                "type": "String"
+              },
+              {
+                "description": "The location to which the item is being sent. e.g. the customer's address. Overrides the top-level value if provided.",
+                "name": "destination",
+                "type": "CalculationLocationInput"
+              },
+              {
+                "description": "The client-defined ID for the line. This could be a UUID of the SKU, or a shipping method/package name.",
+                "name": "id",
+                "type": "String!"
+              },
+              {
+                "description": "The location from which the item is originating. Overrides the top-level value if provided.",
+                "name": "origin",
+                "type": "CalculationLocationInput"
+              },
+              {
+                "description": "The number of units being purchased.",
+                "name": "quantity",
+                "type": "Float"
+              },
+              {
+                "description": "The money amount for the total quantity being purchased.",
+                "name": "subtotalPrice",
+                "type": "SimpleMoneyInput!"
+              },
+              {
+                "name": "type",
+                "type": "CalculationLineType!"
+              },
+              {
+                "description": "The money amount for a single unit of the item being purchased.",
+                "name": "unitPrice",
+                "type": "SimpleMoneyInput"
+              }
+            ],
+            "kind": "input",
+            "name": "CalculationLineInput"
+          },
+          {
+            "kind": "enum",
+            "name": "CalculationLineType",
+            "values": [
+              "FEE",
+              "SHIPPING",
+              "SKU"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "description": "The location address.",
+                "name": "address",
+                "type": "CalculationLocationAddress!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculationLocation"
+          },
+          {
+            "fields": [
+              {
+                "description": "The first line of the address.",
+                "name": "addressLine1",
+                "type": "String"
+              },
+              {
+                "description": "The second line of the address.",
+                "name": "addressLine2",
+                "type": "String"
+              },
+              {
+                "description": "The third line of the address.",
+                "name": "addressLine3",
+                "type": "String"
+              },
+              {
+                "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The city, town, or village.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The sub-locality, suburb, neighborhood, or district.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The neighborhood, ward, or district.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The country code of the address.",
+                "name": "countryCode",
+                "type": "String!"
+              },
+              {
+                "description": "The postal code of the address.",
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculationLocationAddress"
+          },
+          {
+            "fields": [
+              {
+                "description": "The location address.",
+                "name": "address",
+                "type": "CalculationAddressInput"
+              }
+            ],
+            "kind": "input",
+            "name": "CalculationLocationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "lines",
+                "type": "[CalculatedLine!]!"
+              },
+              {
+                "description": "The individual tax amounts for the rates that were applied to the purchase. A combined summary of all of the rates that applied across all of the lines.",
+                "name": "taxAmounts",
+                "type": "[TaxAmount!]!"
+              },
+              {
+                "description": "The total money amount of tax calculated for the purchase. A sum of each individual line tax amount.",
+                "name": "totalTaxAmount",
+                "type": "TotalTaxAmount!"
+              }
+            ],
+            "kind": "object",
+            "name": "CalculationResult"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the list.",
+                "name": "id",
+                "type": "ID!"
+              }
+            ],
+            "kind": "object",
+            "name": "CatalogList"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the SKU.",
+                "name": "id",
+                "type": "ID!"
+              }
+            ],
+            "kind": "object",
+            "name": "CatalogSKU"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the SKU group.",
+                "name": "id",
+                "type": "ID!"
+              }
+            ],
+            "kind": "object",
+            "name": "CatalogSKUGroup"
+          },
+          {
+            "fields": [
+              {
+                "description": "The data & time at which the classification was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "The catalog lists to which the classification applies.",
+                "name": "lists",
+                "type": "ClassificationListsConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "ClassificationMetafieldsConnection"
+              },
+              {
+                "description": "The unique human-friendly identifier.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The rates associated with the classification.",
+                "name": "rates",
+                "type": "ClassificationRatesConnection"
+              },
+              {
+                "description": "A reference to the resource in an external service.",
+                "name": "references",
+                "type": "ClassificationReferencesConnection"
+              },
+              {
+                "description": "The catalog SKU groups to which the classification applies.",
+                "name": "skuGroups",
+                "type": "ClassificationSkuGroupsConnection"
+              },
+              {
+                "description": "The catalog SKUs to which the classification applies.",
+                "name": "skus",
+                "type": "ClassificationSkusConnection"
+              },
+              {
+                "description": "The data & time at which the classification was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "Classification"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[ID!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ClassificationIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationListsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationListsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogList"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationListsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "ClassificationOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationRatesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationRatesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Rate"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationRatesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationSkuGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationSkuGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogSKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationSkuGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[ClassificationSkusConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationSkusConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogSKU"
+              }
+            ],
+            "kind": "object",
+            "name": "ClassificationSkusConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "key",
+                "type": "String!"
+              },
+              {
+                "name": "namespace",
+                "type": "String!"
+              },
+              {
+                "name": "type",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateMetafieldInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The origin of the reference.",
+                "name": "origin",
+                "type": "String!"
+              },
+              {
+                "description": "The value of the reference.",
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "input",
+            "name": "CreateReferenceInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The city, town, or village.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The sub-locality, suburb, neighborhood, or district.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The neighborhood, ward, or district.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The country code of the address.",
+                "name": "countryCode",
+                "type": "String!"
+              },
+              {
+                "description": "The data & time at which the jurisdiction was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "name": "metafields",
+                "type": "JurisdictionMetafieldsConnection"
+              },
+              {
+                "description": "The postal code of the address.",
+                "name": "postalCode",
+                "type": "String"
+              },
+              {
+                "description": "The rates associated with the jurisdiction.",
+                "name": "rates",
+                "type": "JurisdictionRatesConnection"
+              },
+              {
+                "description": "The data & time at which the jurisdiction was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "Jurisdiction"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[ID!]"
+              }
+            ],
+            "kind": "input",
+            "name": "JurisdictionIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[JurisdictionMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "JurisdictionMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "JurisdictionMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "JurisdictionOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[JurisdictionRatesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "JurisdictionRatesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Rate"
+              }
+            ],
+            "kind": "object",
+            "name": "JurisdictionRatesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "String"
+              },
+              {
+                "name": "id",
+                "type": "ID"
+              },
+              {
+                "name": "key",
+                "type": "String"
+              },
+              {
+                "name": "namespace",
+                "type": "String"
+              },
+              {
+                "name": "resourceId",
+                "type": "ID"
+              },
+              {
+                "name": "type",
+                "type": "String"
+              },
+              {
+                "name": "updatedAt",
+                "type": "String"
+              },
+              {
+                "name": "value",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "Metafield"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the lists to be added to the classification.",
+                "name": "listIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddListsToClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddListsToOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the rates to be added to the classification.",
+                "name": "rateIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddRatesToClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "rateIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddRatesToOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkuGroupsToOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the SKU groups to be added to the classification.",
+                "name": "skuGroupIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkusGroupsToClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the SKUs to be added to the classification.",
+                "name": "skuIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkusToClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationAddSkusToOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "destination",
+                "type": "CalculationLocationInput"
+              },
+              {
+                "name": "lines",
+                "type": "[CalculationLineInput!]!"
+              },
+              {
+                "name": "origin",
+                "type": "CalculationLocationInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCalculateTaxesInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "Any metafields to be created and assigned to the new classification.",
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "description": "A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "Any references to be created and assigned to the new classification.",
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The city, town, or village. Smaller than `adminArea1`.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The neighborhood, ward, or district. Smaller than `adminArea3`.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.",
+                "name": "countryCode",
+                "type": "String!"
+              },
+              {
+                "description": "Any metafields to be created and assigned to the new jurisdiction.",
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "description": "The postal code, which is the zip code or equivalent.",
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateJurisdictionInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "A custom rate to be applied by the override.",
+                "name": "customRate",
+                "type": "OverrideCustomRateCreateInput"
+              },
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "Any metafields to be created and assigned to the new override.",
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "description": "A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "Any references to be created and assigned to the new override.",
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "description": "The desired status.",
+                "name": "status",
+                "type": "OverrideStatusEnum"
+              },
+              {
+                "description": "The ID of the target rate that this override references.",
+                "name": "targetRateId",
+                "type": "ID"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The method to be used when applying the rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "RateCalculationMethodEnum"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The ID of the jurisdiction in which this rate applies.",
+                "name": "jurisdictionId",
+                "type": "ID"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "Any metafields to be created and assigned to the new rate.",
+                "name": "metafields",
+                "type": "[CreateMetafieldInput!]"
+              },
+              {
+                "description": "A unique human-friendly identifier. If omitted, a name will be generated from the `label` value.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "Any references to be created and assigned to the new rate.",
+                "name": "references",
+                "type": "[CreateReferenceInput!]"
+              },
+              {
+                "description": "The desired status.",
+                "name": "status",
+                "type": "RateStatusEnum"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The rate's value.",
+                "name": "value",
+                "type": "RateValueInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateRateInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The references to be created for the classification.",
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateReferencesForClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateReferencesForOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "references",
+                "type": "[CreateReferenceInput!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationCreateReferencesForRateInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the references to be deleted from the classification.",
+                "name": "referenceIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationDeleteReferencesFromClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationDeleteReferencesFromOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "referenceIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationDeleteReferencesFromRateInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the lists to be removed from the classification.",
+                "name": "listIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveListsFromClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "listIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveListsFromOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the rates to be remove from the classification.",
+                "name": "rateIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveRatesFromClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "rateIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveRatesFromOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the SKUs to be removed from the classification.",
+                "name": "skuIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusFromClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusFromOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The IDs of the SKU groups to be removed from the classification.",
+                "name": "skuGroupIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusGroupsFromClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "skuGroupIds",
+                "type": "[ID!]!"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationRemoveSkusGroupsFromOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "description": "A unique human-friendly identifier.",
+                "name": "name",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateClassificationInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision; formatted for postal delivery.",
+                "name": "adminArea1",
+                "type": "String"
+              },
+              {
+                "description": "The city, town, or village. Smaller than `adminArea1`.",
+                "name": "adminArea2",
+                "type": "String"
+              },
+              {
+                "description": "The sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`.",
+                "name": "adminArea3",
+                "type": "String"
+              },
+              {
+                "description": "The neighborhood, ward, or district. Smaller than `adminArea3`.",
+                "name": "adminArea4",
+                "type": "String"
+              },
+              {
+                "description": "The [two-character ISO 3166-1 code](https://en.wikipedia.org/wiki/ISO_3166-1) that identifies the country or region.",
+                "name": "countryCode",
+                "type": "String"
+              },
+              {
+                "description": "The postal code, which is the zip code or equivalent.",
+                "name": "postalCode",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateJurisdictionInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "A custom rate to be applied by the override.",
+                "name": "customRate",
+                "type": "OverrideCustomRateUpdateInput"
+              },
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "description": "A unique human-friendly identifier.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The desired status.",
+                "name": "status",
+                "type": "OverrideStatusEnum"
+              },
+              {
+                "description": "The ID of the target rate that this override references.",
+                "name": "targetRateId",
+                "type": "ID"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateOverrideInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The method to be used when applying the rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "RateCalculationMethodEnum"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "createdAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "A human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The ID of the jurisdiction in which this rate applies.",
+                "name": "jurisdictionId",
+                "type": "ID"
+              },
+              {
+                "description": "A label for display.",
+                "name": "label",
+                "type": "String"
+              },
+              {
+                "description": "A unique human-friendly identifier.",
+                "name": "name",
+                "type": "String"
+              },
+              {
+                "description": "The desired status.",
+                "name": "status",
+                "type": "RateStatusEnum"
+              },
+              {
+                "description": "WARNING: DO NOT USE.",
+                "name": "updatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The rate's value.",
+                "name": "value",
+                "type": "RateValueInput"
+              }
+            ],
+            "kind": "input",
+            "name": "MutationUpdateRateInput"
+          },
+          {
+            "kind": "enum",
+            "name": "OrderByDirectionEnum",
+            "values": [
+              "ASC",
+              "DESC"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "description": "The data & time at which the override was last activated.",
+                "name": "activatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The data & time at which the override was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "name": "customRate",
+                "type": "OverrideCustomRate"
+              },
+              {
+                "description": "The human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "description": "The catalog lists to which the override applies.",
+                "name": "lists",
+                "type": "OverrideListsConnection"
+              },
+              {
+                "name": "metafields",
+                "type": "OverrideMetafieldsConnection"
+              },
+              {
+                "description": "The unique human-friendly identifier.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "The rates associated with the override.",
+                "name": "rates",
+                "type": "OverrideRatesConnection"
+              },
+              {
+                "description": "A reference to a resource in an external service.",
+                "name": "references",
+                "type": "OverrideReferencesConnection"
+              },
+              {
+                "description": "The catalog SKU groups to which the override applies.",
+                "name": "skuGroups",
+                "type": "OverrideSkuGroupsConnection"
+              },
+              {
+                "description": "The catalog SKUs to which the override applies.",
+                "name": "skus",
+                "type": "OverrideSkusConnection"
+              },
+              {
+                "description": "The current status.",
+                "name": "status",
+                "type": "OverrideStatusEnum!"
+              },
+              {
+                "description": "The rate that this override targets.",
+                "name": "targetRate",
+                "type": "Rate"
+              },
+              {
+                "description": "The data & time at which the override was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              }
+            ],
+            "kind": "object",
+            "name": "Override"
+          },
+          {
+            "kind": "enum",
+            "name": "OverrideCalculationMethodEnum",
+            "values": [
+              "ADDITIVE",
+              "INCLUSIVE"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "description": "The method to be used when applying the override during calculation.",
+                "name": "calculationMethod",
+                "type": "OverrideCalculationMethodEnum!"
+              },
+              {
+                "description": "The rate's value",
+                "name": "value",
+                "type": "RateValue!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideCustomRate"
+          },
+          {
+            "fields": [
+              {
+                "description": "The method to be used when applying the custom rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "OverrideCalculationMethodEnum"
+              },
+              {
+                "description": "The custom rate's value.",
+                "name": "value",
+                "type": "RateValueInput!"
+              }
+            ],
+            "kind": "input",
+            "name": "OverrideCustomRateCreateInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The method to be used when applying the custom rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "OverrideCalculationMethodEnum"
+              },
+              {
+                "description": "The custom rate's value.",
+                "name": "value",
+                "type": "RateValueInput"
+              }
+            ],
+            "kind": "input",
+            "name": "OverrideCustomRateUpdateInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[ID!]"
+              }
+            ],
+            "kind": "input",
+            "name": "OverrideIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideListsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideListsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogList"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideListsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "OverrideOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideRatesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideRatesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Rate"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideRatesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideReferencesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideSkuGroupsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideSkuGroupsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogSKUGroup"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideSkuGroupsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[OverrideSkusConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideSkusConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "CatalogSKU"
+              }
+            ],
+            "kind": "object",
+            "name": "OverrideSkusConnectionEdge"
+          },
+          {
+            "kind": "enum",
+            "name": "OverrideStatusEnum",
+            "values": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "name": "endCursor",
+                "type": "String"
+              },
+              {
+                "name": "hasNextPage",
+                "type": "Boolean!"
+              },
+              {
+                "name": "hasPreviousPage",
+                "type": "Boolean!"
+              },
+              {
+                "name": "startCursor",
+                "type": "String"
+              }
+            ],
+            "kind": "object",
+            "name": "PageInfo"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryClassificationsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryClassificationsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Classification"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryClassificationsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryJurisdictionsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryJurisdictionsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Jurisdiction"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryJurisdictionsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryOverridesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOverridesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Override"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryOverridesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[QueryRatesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryRatesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Rate"
+              }
+            ],
+            "kind": "object",
+            "name": "QueryRatesConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "description": "The data & time at which the rate was first activated.",
+                "name": "activatedAt",
+                "type": "DateTime"
+              },
+              {
+                "description": "The method to be used when applying the rate to a purchase amount.",
+                "name": "calculationMethod",
+                "type": "RateCalculationMethodEnum!"
+              },
+              {
+                "description": "The classifications associated with the rate.",
+                "name": "classifications",
+                "type": "RateClassificationsConnection"
+              },
+              {
+                "description": "The data & time at which the rate was created.",
+                "name": "createdAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The human-friendly description.",
+                "name": "description",
+                "type": "String"
+              },
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The jurisdiction in which this rate applies.",
+                "name": "jurisdiction",
+                "type": "Jurisdiction"
+              },
+              {
+                "description": "The label for display.",
+                "name": "label",
+                "type": "String!"
+              },
+              {
+                "name": "metafields",
+                "type": "RateMetafieldsConnection"
+              },
+              {
+                "description": "The unique human-friendly identifier.",
+                "name": "name",
+                "type": "String!"
+              },
+              {
+                "description": "A reference to the resource in an external service.",
+                "name": "references",
+                "type": "RateReferencesConnection"
+              },
+              {
+                "description": "The current status.",
+                "name": "status",
+                "type": "RateStatusEnum!"
+              },
+              {
+                "description": "The data & time at which the rate was last updated.",
+                "name": "updatedAt",
+                "type": "DateTime!"
+              },
+              {
+                "description": "The rate's value",
+                "name": "value",
+                "type": "RateValue!"
+              }
+            ],
+            "kind": "object",
+            "name": "Rate"
+          },
+          {
+            "fields": [
+              {
+                "name": "amount",
+                "type": "SimpleMoney"
+              }
+            ],
+            "kind": "object",
+            "name": "RateAmount"
+          },
+          {
+            "kind": "enum",
+            "name": "RateCalculationMethodEnum",
+            "values": [
+              "ADDITIVE",
+              "INCLUSIVE"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[RateClassificationsConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "RateClassificationsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Classification"
+              }
+            ],
+            "kind": "object",
+            "name": "RateClassificationsConnectionEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[ID!]"
+              }
+            ],
+            "kind": "input",
+            "name": "RateIdFilter"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[RateMetafieldsEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "RateMetafieldsConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Metafield"
+              }
+            ],
+            "kind": "object",
+            "name": "RateMetafieldsEdge"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "name",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "RateOrderBy"
+          },
+          {
+            "fields": [
+              {
+                "description": "The percentage applied by the rate, out of 100.",
+                "name": "percentage",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "RatePercentage"
+          },
+          {
+            "fields": [
+              {
+                "name": "edges",
+                "type": "[RateReferencesConnectionEdge]"
+              },
+              {
+                "name": "pageInfo",
+                "type": "PageInfo!"
+              }
+            ],
+            "kind": "object",
+            "name": "RateReferencesConnection"
+          },
+          {
+            "fields": [
+              {
+                "name": "cursor",
+                "type": "String!"
+              },
+              {
+                "name": "node",
+                "type": "Reference"
+              }
+            ],
+            "kind": "object",
+            "name": "RateReferencesConnectionEdge"
+          },
+          {
+            "kind": "enum",
+            "name": "RateStatusEnum",
+            "values": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          },
+          {
+            "fields": [
+              {
+                "name": "eq",
+                "type": "RateStatusEnum"
+              },
+              {
+                "name": "in",
+                "type": "[RateStatusEnum!]"
+              }
+            ],
+            "kind": "input",
+            "name": "RateStatusFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "The rate value represented as a fixed money amount. Required if `percentage` is not provided.",
+                "name": "amount",
+                "type": "SimpleMoneyInput"
+              },
+              {
+                "description": "The percentage applied by the rate, out of 100. Required if `amount` is not provided.",
+                "name": "percentage",
+                "type": "String"
+              }
+            ],
+            "kind": "input",
+            "name": "RateValueInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID.",
+                "name": "id",
+                "type": "ID!"
+              },
+              {
+                "description": "The origin of the reference.",
+                "name": "origin",
+                "type": "String!"
+              },
+              {
+                "description": "The value of the reference.",
+                "name": "value",
+                "type": "String!"
+              }
+            ],
+            "kind": "object",
+            "name": "Reference"
+          },
+          {
+            "fields": [
+              {
+                "name": "createdAt",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "id",
+                "type": "OrderByDirectionEnum"
+              },
+              {
+                "name": "updatedAt",
+                "type": "OrderByDirectionEnum"
+              }
+            ],
+            "kind": "input",
+            "name": "ReferenceOrderByInput"
+          },
+          {
+            "fields": [
+              {
+                "name": "in",
+                "type": "[String!]"
+              }
+            ],
+            "kind": "input",
+            "name": "ReferenceValueFilter"
+          },
+          {
+            "fields": [
+              {
+                "description": "A three-character ISO-4217 currency code.",
+                "name": "currencyCode",
+                "type": "String!"
+              },
+              {
+                "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes.",
+                "name": "value",
+                "type": "Float!"
+              }
+            ],
+            "kind": "object",
+            "name": "SimpleMoney"
+          },
+          {
+            "fields": [
+              {
+                "description": "A three-character ISO-4217 currency code.",
+                "name": "currencyCode",
+                "type": "String!"
+              },
+              {
+                "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional; or, a decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see ISO-4217 Currency Codes.",
+                "name": "value",
+                "type": "Float!"
+              }
+            ],
+            "kind": "input",
+            "name": "SimpleMoneyInput"
+          },
+          {
+            "fields": [
+              {
+                "description": "The globally-unique ID of the Store.",
+                "name": "id",
+                "type": "ID!"
+              }
+            ],
+            "kind": "object",
+            "name": "Store"
+          },
+          {
+            "fields": [
+              {
+                "name": "rate",
+                "type": "CalculatedRate!"
+              },
+              {
+                "name": "totalTaxAmount",
+                "type": "TotalTaxAmount!"
+              }
+            ],
+            "kind": "object",
+            "name": "TaxAmount"
+          },
+          {
+            "fields": [
+              {
+                "name": "currencyCode",
+                "type": "String!"
+              },
+              {
+                "name": "value",
+                "type": "Float!"
+              }
+            ],
+            "kind": "object",
+            "name": "TotalTaxAmount"
+          }
+        ]
       },
       "method": "POST",
       "operationId": "postTaxGraphql",

--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -3,10 +3,14 @@
 //! gateway host).
 
 use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
-use serde_json::{Map, Value, json};
+use serde_json::{Value, json};
 
-use super::catalog::{catalog, find_endpoint};
-use super::http::{graphql_errors, is_mutating_method, merge_required_scopes, split_header};
+use super::catalog::{
+    catalog, find_endpoint, graphql_operation_redirect_error, resolve_graphql_operation,
+};
+use super::http::{
+    is_mutating_method, merge_required_scopes, parsed_extra_headers, send_and_report,
+};
 
 #[derive(Debug, Clone, clap::Args)]
 struct CallArgs {
@@ -87,9 +91,13 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // path — accepting a bare operationId here would silently build
             // an invalid URL (e.g. `https://.../listFulfillments`).
             if !endpoint.starts_with('/') {
+                if resolve_graphql_operation(catalog(), endpoint).is_some() {
+                    return Err(graphql_operation_redirect_error(endpoint, "graphql call"));
+                }
                 return Err(crate::error::GddyError::validation(format!(
-                    "endpoint must be a URL path starting with '/', not {endpoint:?} — \
-                     use `api operation get {endpoint}` to find the concrete path"
+                    "endpoint must be a URL path starting with '/', or a GraphQL operation id \
+                     (see `api operation list --domain <domain>`), not {endpoint:?} — \
+                     use `api operation get {endpoint}` to find the concrete path or id"
                 ))
                 .into_cli_error());
             }
@@ -174,129 +182,27 @@ pub(super) fn command() -> RuntimeCommandSpec {
             }
 
             let client = crate::application::client::make_http_client();
-            let mut req = client
-                .request(parsed_method, &url)
-                .bearer_auth(&token)
-                .header("x-request-id", uuid::Uuid::new_v4().to_string());
-
-            // Apply user-supplied `--header KEY:VALUE` values (repeatable).
-            for h in &args.header {
-                let (key, val) = split_header(h).ok_or_else(|| {
-                    crate::error::GddyError::validation(format!(
-                        "invalid header '{h}': expected KEY:VALUE"
-                    ))
-                    .into_cli_error()
-                })?;
-                req = req.header(key, val);
-            }
-
-            if let Some(body) = request_body {
-                req = req.json(&body);
-            }
-
-            let request = req
-                .build()
-                .map_err(|e| crate::error::GddyError::validation(e.to_string()))?;
-            cli_engine::transport::debug_log_reqwest_request(&request);
-            let resp = client
-                .execute(request)
-                .await
-                .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
-
-            let status_code = resp.status();
-            let status_text = status_code.canonical_reason().unwrap_or("").to_owned();
-            let response_headers_raw = resp.headers().clone();
-            let include_headers = args.include;
-            let body_bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
-            cli_engine::transport::debug_log_reqwest_response(
-                status_code,
-                &response_headers_raw,
-                &body_bytes,
-            );
-
-            let status = status_code.as_u16();
-            let response_headers: Option<Map<String, Value>> = if include_headers {
-                Some(
-                    response_headers_raw
-                        .iter()
-                        .filter_map(|(k, v)| v.to_str().ok().map(|s| (k.to_string(), json!(s))))
-                        .collect(),
-                )
-            } else {
-                None
-            };
-
-            let body: Value = super::http::parse_response_body(&body_bytes);
+            let extra_headers = parsed_extra_headers(&args.header)?;
 
             // GraphQL endpoints return HTTP 200 even on failure, carrying the error
             // in a top-level `errors` array. Detect the GraphQL commerce surfaces by
             // path and surface those errors instead of reporting a false success.
             let is_graphql = endpoint.contains("graphql") || endpoint.contains("subgraph");
-            if is_graphql && let Some(errors) = graphql_errors(&body) {
-                return Err(crate::error::GddyError::from_graphql(
-                    format!(
-                        "GraphQL request returned {} error(s):\n{}",
-                        errors.len(),
-                        serde_json::to_string_pretty(&json!(errors)).unwrap_or_default(),
-                    ),
-                    "api",
-                )
-                .into());
-            }
 
-            // Scope step-up already ran up front (the token was requested with
-            // `required`). A 403 here means the granted token still lacks a
-            // required scope — surface it with a re-login hint.
-            if status == 403 && !required.is_empty() {
-                // `auth login --scope` is append-style (one value per flag), so
-                // repeat the flag rather than space-joining.
-                let login_hint = required
-                    .iter()
-                    .map(|s| format!("--scope {s}"))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                return Err(crate::error::GddyError::auth(format!(
-                    "403 Forbidden — the authorized token is missing required scope(s): {}. \
-                     Re-run `gddy auth login {login_hint}` and try again.",
-                    required.join(", "),
-                ))
-                .with_fix(format!("Run: gddy auth login {login_hint}"))
-                .into());
-            }
-
-            // Any other non-2xx is a failure, not a success envelope. Include the
-            // status line and (truncated) response body so the caller sees the detail
-            // instead of a success result that happens to carry an error payload.
-            if !(200..300).contains(&status) {
-                let detail: String = serde_json::to_string_pretty(&body)
-                    .unwrap_or_else(|_| body.to_string())
-                    .chars()
-                    .take(4000)
-                    .collect();
-                return Err(crate::error::GddyError::from_http(
-                    status,
-                    format!("{status_text}\n{detail}"),
-                    "api",
-                )
-                .into_cli_error());
-            }
-
-            // Identify the call and its outcome in the result envelope.
-            let mut result = json!({
-                "endpoint": endpoint,
-                "method": method,
-                "status": status,
-                "status_text": status_text,
-                "data": body,
-            });
-            if let Some(headers) = response_headers {
-                result["headers"] = Value::Object(headers);
-            }
-
-            Ok(CommandResult::new(result))
+            send_and_report(
+                &client,
+                parsed_method,
+                method,
+                &url,
+                &token,
+                &extra_headers,
+                request_body,
+                args.include,
+                is_graphql,
+                &required,
+                endpoint,
+            )
+            .await
         },
     )
 }

--- a/rust/src/api_explorer/catalog.rs
+++ b/rust/src/api_explorer/catalog.rs
@@ -62,6 +62,8 @@ pub(super) struct GraphqlArgument {
     #[serde(rename = "type")]
     pub(super) arg_type: String,
     pub(super) required: bool,
+    #[serde(default)]
+    pub(super) description: Option<String>,
     #[serde(default, rename = "defaultValue")]
     pub(super) default_value: Option<String>,
 }
@@ -73,11 +75,35 @@ pub(super) struct GraphqlOperation {
     #[serde(rename = "returnType")]
     pub(super) return_type: String,
     #[serde(default)]
+    pub(super) description: Option<String>,
+    #[serde(default)]
     pub(super) deprecated: bool,
     #[serde(default, rename = "deprecationReason")]
     pub(super) deprecation_reason: Option<String>,
     #[serde(default)]
     pub(super) args: Vec<GraphqlArgument>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GraphqlField {
+    pub(super) name: String,
+    #[serde(rename = "type")]
+    pub(super) field_type: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+}
+
+/// A named GraphQL object/input/enum type — used by `api graphql get`
+/// (resolving an operation's return type into its real field list) and `api
+/// graphql type get` (looking one up directly by name).
+#[derive(Debug, Deserialize)]
+pub(super) struct GraphqlType {
+    pub(super) name: String,
+    pub(super) kind: String,
+    #[serde(default)]
+    pub(super) fields: Vec<GraphqlField>,
+    #[serde(default)]
+    pub(super) values: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -87,6 +113,11 @@ pub(super) struct GraphqlSchema {
     #[serde(rename = "operationCount")]
     pub(super) operation_count: usize,
     pub(super) operations: Vec<GraphqlOperation>,
+    #[serde(default)]
+    pub(super) types: Vec<GraphqlType>,
+    /// The raw GraphQL SDL source verbatim — see `api graphql sdl get`.
+    #[serde(default)]
+    pub(super) sdl: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -346,6 +377,170 @@ pub(super) fn search_endpoints<'a>(
                 if matches { Some((domain, ep)) } else { None }
             })
         })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL operation ids and resolution
+// ---------------------------------------------------------------------------
+//
+// A GraphQL query/mutation field isn't its own catalog endpoint — it's
+// addressed as `<parentOperationId>::<query|mutation>::<fieldName>`, e.g.
+// `postTaxGraphql::query::classification`, resolved against the wrapper
+// endpoint's own `graphql.operations`. `api graphql get`/`api graphql call`
+// are this id's only real targets; `operation get`/`parameter list`/`api
+// call` redirect to them instead of rendering REST-shaped output for a
+// GraphQL operation (see `graphql_operation_redirect_error`).
+
+pub(super) fn graphql_operation_id(parent_operation_id: &str, kind: &str, name: &str) -> String {
+    format!("{parent_operation_id}::{kind}::{name}")
+}
+
+fn parse_graphql_op_id(id: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = id.splitn(3, "::");
+    let parent = parts.next()?;
+    let kind = parts.next()?;
+    let name = parts.next()?;
+    (!parent.is_empty() && !name.is_empty() && matches!(kind, "query" | "mutation"))
+        .then_some((parent, kind, name))
+}
+
+pub(super) struct GraphqlOpRef<'a> {
+    pub(super) domain: &'a Domain,
+    pub(super) parent: &'a Endpoint,
+    pub(super) op: &'a GraphqlOperation,
+}
+
+pub(super) fn resolve_graphql_operation<'a>(
+    catalog: &'a [Domain],
+    id: &str,
+) -> Option<GraphqlOpRef<'a>> {
+    let (parent_id, kind, name) = parse_graphql_op_id(id)?;
+    let (domain, parent) = find_endpoint_exact(catalog, parent_id, None)
+        .into_iter()
+        .next()?;
+    let op = parent
+        .graphql
+        .as_ref()?
+        .operations
+        .iter()
+        .find(|o| o.kind == kind && o.name == name)?;
+    Some(GraphqlOpRef { domain, parent, op })
+}
+
+/// Error for `operation get`/`parameter list`/`parameter get`/`call` given a
+/// GraphQL operation id — these commands render REST-shaped output that
+/// doesn't fit a GraphQL operation at all, so they redirect to the dedicated
+/// `api graphql` equivalent instead of trying to render anything.
+pub(super) fn graphql_operation_redirect_error(id: &str, next: &str) -> CliCoreError {
+    crate::error::GddyError::validation(format!(
+        "'{id}' is a GraphQL operation — use `gddy api {next} {id}` instead"
+    ))
+    .with_fix(format!("Run: gddy api {next} {id}"))
+    .into_cli_error()
+}
+
+/// Error for any `api graphql` command given an id that doesn't resolve to a
+/// real GraphQL operation — either malformed, or naming a domain/wrapper
+/// operation that exists but isn't itself addressable this way (e.g. the
+/// wrapper id `postTaxGraphql` rather than one of its operations).
+pub(super) fn graphql_operation_not_found_error(id: &str) -> CliCoreError {
+    crate::error::GddyError::not_found(format!(
+        "no GraphQL operation found for id '{id}' — expected \
+         <parentOperationId>::<query|mutation>::<fieldName>, e.g. \
+         postTaxGraphql::query::classification"
+    ))
+    .with_fix("Run: gddy api operation list --domain <domain>, or gddy api search <query>")
+    .into_cli_error()
+}
+
+/// Every GraphQL query/mutation field on `ep`'s schema, as a synthetic
+/// endpoint-list row addressed via [`graphql_operation_id`] — appended
+/// alongside the wrapper's own row by `operation_list_command`/
+/// `search_command` so a GraphQL operation is just as discoverable as a
+/// REST one.
+pub(super) fn graphql_sub_endpoint_rows(domain_name: Option<&str>, ep: &Endpoint) -> Vec<Value> {
+    let Some(schema) = ep.graphql.as_ref() else {
+        return Vec::new();
+    };
+    schema
+        .operations
+        .iter()
+        .map(|op| {
+            let mut row = serde_json::json!({
+                "operationId": graphql_operation_id(&ep.operation_id, &op.kind, &op.name),
+                "method": ep.method,
+                "path": ep.path,
+                "summary": op.description.clone().unwrap_or_else(|| format!("{} {}", op.kind, op.name)),
+                "scopes": ep.scopes,
+                "kind": op.kind,
+            });
+            if let Some(name) = domain_name {
+                row["domain"] = serde_json::json!(name);
+            }
+            row
+        })
+        .collect()
+}
+
+/// Strips GraphQL's Non-Null (`!`) and List (`[...]`) type modifiers down to
+/// the bare named type, e.g. `"[Widget!]!"` -> `"Widget"` — the name that
+/// `GraphqlType::name` and `coerce_graphql_arg`'s scalar match key off of.
+pub(super) fn graphql_base_type_name(type_str: &str) -> &str {
+    type_str.trim_matches(|c: char| matches!(c, '!' | '[' | ']'))
+}
+
+/// Looks up a named GraphQL type (object/input/enum) by its bare name
+/// against the domain schema `g` belongs to — used to resolve an operation's
+/// `returnType` string into its real field list. `type_str` may be a full
+/// GraphQL type string (e.g. `"[Widget!]!"`); only its base name is looked
+/// up (see [`graphql_base_type_name`]).
+pub(super) fn graphql_resolve_type<'a>(
+    g: &GraphqlOpRef<'a>,
+    type_str: &str,
+) -> Option<&'a GraphqlType> {
+    let base_name = graphql_base_type_name(type_str);
+    g.parent
+        .graphql
+        .as_ref()?
+        .types
+        .iter()
+        .find(|t| t.name == base_name)
+}
+
+/// Looks up a named GraphQL type (object/input/enum) by its bare name across
+/// every loaded GraphQL schema — the standalone counterpart to
+/// [`graphql_resolve_type`] for `api graphql type get`, which has no
+/// operation to scope the search to. First match wins; in practice GraphQL
+/// type names are already distinct per-subgraph.
+pub(super) fn find_graphql_type<'a>(catalog: &'a [Domain], name: &str) -> Option<&'a GraphqlType> {
+    catalog.iter().find_map(|d| {
+        d.endpoints
+            .iter()
+            .find_map(|ep| ep.graphql.as_ref()?.types.iter().find(|t| t.name == name))
+    })
+}
+
+/// Error for `api graphql type get` given a name that doesn't resolve to any
+/// known GraphQL object/input/enum.
+pub(super) fn graphql_type_not_found_error(name: &str) -> CliCoreError {
+    crate::error::GddyError::not_found(format!("no GraphQL type found named '{name}'"))
+        .with_fix(
+            "Run: gddy api graphql get <operationId> and check a field's Type column for the \
+             exact name to look up",
+        )
+        .into_cli_error()
+}
+
+/// Every valid `--arg` name for `g`'s call — the wrapper's own parameters
+/// plus the GraphQL field's own arguments — used in the "unknown --arg"
+/// validation error's suggestion list.
+pub(super) fn graphql_valid_arg_names(g: &GraphqlOpRef<'_>) -> Vec<String> {
+    g.parent
+        .parameters
+        .iter()
+        .filter_map(|p| p.get("name").and_then(Value::as_str).map(str::to_owned))
+        .chain(g.op.args.iter().map(|a| a.name.clone()))
         .collect()
 }
 

--- a/rust/src/api_explorer/catalog.rs
+++ b/rust/src/api_explorer/catalog.rs
@@ -508,21 +508,32 @@ pub(super) fn graphql_resolve_type<'a>(
         .find(|t| t.name == base_name)
 }
 
-/// Looks up a named GraphQL type (object/input/enum) by its bare name across
-/// every loaded GraphQL schema — the standalone counterpart to
-/// [`graphql_resolve_type`] for `api graphql type get`, which has no
-/// operation to scope the search to. First match wins; in practice GraphQL
-/// type names are already distinct per-subgraph.
-pub(super) fn find_graphql_type<'a>(catalog: &'a [Domain], name: &str) -> Option<&'a GraphqlType> {
-    catalog.iter().find_map(|d| {
-        d.endpoints
-            .iter()
-            .find_map(|ep| ep.graphql.as_ref()?.types.iter().find(|t| t.name == name))
-    })
+/// Every domain whose own GraphQL schema defines a type named `name` — the
+/// standalone counterpart to [`graphql_resolve_type`] for `api graphql type
+/// get`, which has no operation to scope the search to. A GraphQL type name
+/// is only unique *within* a single subgraph; two independently-authored
+/// domain schemas can (and do — e.g. `ReferenceValueFilter` on both `taxes`
+/// and `catalog-products`, with different fields) declare their own,
+/// unrelated type sharing a name. Callers must handle more than one hit
+/// rather than assume the first is the one the user meant.
+pub(super) fn find_graphql_types<'a>(
+    catalog: &'a [Domain],
+    name: &str,
+) -> Vec<(&'a Domain, &'a GraphqlType)> {
+    catalog
+        .iter()
+        .filter_map(|d| {
+            d.endpoints
+                .iter()
+                .find_map(|ep| ep.graphql.as_ref()?.types.iter().find(|t| t.name == name))
+                .map(|t| (d, t))
+        })
+        .collect()
 }
 
 /// Error for `api graphql type get` given a name that doesn't resolve to any
-/// known GraphQL object/input/enum.
+/// known GraphQL object/input/enum (in the requested domain, if `--domain`
+/// was given).
 pub(super) fn graphql_type_not_found_error(name: &str) -> CliCoreError {
     crate::error::GddyError::not_found(format!("no GraphQL type found named '{name}'"))
         .with_fix(
@@ -530,6 +541,22 @@ pub(super) fn graphql_type_not_found_error(name: &str) -> CliCoreError {
              exact name to look up",
         )
         .into_cli_error()
+}
+
+/// Error for `api graphql type get` when `name` resolves in more than one
+/// domain's GraphQL schema with no `--domain` given to disambiguate.
+pub(super) fn ambiguous_graphql_type_error(name: &str, domains: &[&str]) -> CliCoreError {
+    crate::error::GddyError::ambiguous(format!(
+        "'{name}' is defined by {} different domains ({}) with no guarantee they're the same \
+         shape — be more specific:",
+        domains.len(),
+        domains.join(", "),
+    ))
+    .with_fix(format!(
+        "Run: gddy api graphql type get {name} --domain <domain>, one of: {}",
+        domains.join(", "),
+    ))
+    .into_cli_error()
 }
 
 /// Every valid `--arg` name for `g`'s call — the wrapper's own parameters

--- a/rust/src/api_explorer/graphql/call.rs
+++ b/rust/src/api_explorer/graphql/call.rs
@@ -230,6 +230,9 @@ fn build_graphql_call(
             .filter(|a| variables.contains_key(&a.name))
             .map(|a| format!("{0}: ${0}", a.name))
             .collect();
+    if let Some(select) = args.select.as_deref() {
+        validate_selection_expr(select)?;
+    }
     let selection = build_selection(args.select.as_deref(), &g.op.return_type);
 
     let var_clause = if var_decls.is_empty() {
@@ -312,6 +315,34 @@ fn coerce_graphql_arg(
 /// real custom scalar with a capitalized name would be misclassified and
 /// rejected loudly by the server (not silently wrong), an acceptable
 /// tradeoff against forcing `--select` on every object-returning call.
+/// Rejects a `--select` value containing anything but comma/dot-separated
+/// GraphQL field names before it's concatenated into the synthesized query
+/// string. `build_selection_from_fields` does no escaping of its own — a
+/// segment carrying braces, colons, quotes, or `$` would inject arbitrary
+/// GraphQL syntax into the request (extra sibling fields, directives, or a
+/// broken selection set) rather than naming a nested field.
+fn validate_selection_expr(raw: &str) -> Result<(), cli_engine::CliCoreError> {
+    let is_valid_name = |segment: &str| {
+        let mut chars = segment.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    };
+    let all_valid = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+        .all(|field| field.split('.').all(is_valid_name));
+    if all_valid {
+        Ok(())
+    } else {
+        Err(crate::error::GddyError::validation(format!(
+            "invalid --select '{raw}': expected comma-separated, dot-nested GraphQL field names \
+             (e.g. 'id,name,address.city')"
+        ))
+        .into_cli_error())
+    }
+}
+
 fn build_selection(select: Option<&str>, return_type: &str) -> String {
     match select.map(str::trim).filter(|s| !s.is_empty()) {
         Some(fields) => build_selection_from_fields(fields),
@@ -496,6 +527,25 @@ mod tests {
             "path params substituted: {}",
             built.path
         );
+    }
+
+    #[test]
+    fn build_graphql_call_rejects_a_select_value_that_breaks_out_of_the_selection_set() {
+        let id = a_query_id();
+        let g = resolve_graphql_operation(catalog(), &id).expect("id resolves");
+        let mut args =
+            graphql_call_args_with(&id, vec![], Some("id } } mutation Evil { deleteEverything"));
+        for p in &g.parent.parameters {
+            if let Some(name) = p.get("name").and_then(serde_json::Value::as_str) {
+                args.arg.push(format!("{name}=placeholder"));
+            }
+        }
+        for a in &g.op.args {
+            args.arg.push(format!("{}=placeholder", a.name));
+        }
+        let err = build_graphql_call(&g, &args)
+            .expect_err("a --select value containing GraphQL syntax must be rejected");
+        assert!(err.to_string().contains("invalid --select"));
     }
 
     #[tokio::test]

--- a/rust/src/api_explorer/graphql/call.rs
+++ b/rust/src/api_explorer/graphql/call.rs
@@ -214,7 +214,7 @@ fn build_graphql_call(
     let mut variables = Map::new();
     for (name, value) in &variable_values {
         if let Some(a) = g.op.args.iter().find(|a| &a.name == name) {
-            variables.insert(name.clone(), coerce_graphql_arg(value, &a.arg_type));
+            variables.insert(name.clone(), coerce_graphql_arg(name, value, &a.arg_type)?);
         }
     }
 
@@ -265,18 +265,28 @@ fn build_graphql_call(
 
 /// Coerces a `--arg` raw CLI string into JSON, given the GraphQL type
 /// string it will be bound to as a query variable. A list type (any type
-/// string containing `[`) is always JSON-parsed, since scalar-style
-/// coercion would silently treat the whole raw string as one value instead
-/// of a list (e.g. `--arg ids='["a","b"]'`). A non-list custom type (input
-/// object or enum) is JSON-parsed first, falling back to a bare JSON
-/// string — covering `--arg input='{"name":"x"}'` and `--arg
-/// status=ACTIVE` (not valid JSON on its own, and a string is the right
-/// encoding either way).
-fn coerce_graphql_arg(raw: &str, gql_type: &str) -> Value {
+/// string containing `[`) must be a JSON array (e.g. `--arg
+/// ids='["a","b"]'`) — falling back to a bare JSON string like the scalar
+/// cases below would silently send the server a String where it expects a
+/// List, trading a clear CLI validation error for a confusing server-side
+/// type error. A non-list custom type (input object or enum) is JSON-parsed
+/// first, falling back to a bare JSON string — covering `--arg
+/// input='{"name":"x"}'` and `--arg status=ACTIVE` (not valid JSON on its
+/// own, and a string is the right encoding either way).
+fn coerce_graphql_arg(
+    name: &str,
+    raw: &str,
+    gql_type: &str,
+) -> Result<Value, cli_engine::CliCoreError> {
     if gql_type.contains('[') {
-        return serde_json::from_str(raw).unwrap_or_else(|_| json!(raw));
+        return serde_json::from_str(raw).map_err(|e| {
+            crate::error::GddyError::validation(format!(
+                "invalid --arg {name}={raw}: expected a JSON array for list type {gql_type} ({e})"
+            ))
+            .into_cli_error()
+        });
     }
-    match graphql_base_type_name(gql_type) {
+    Ok(match graphql_base_type_name(gql_type) {
         "Int" => raw
             .parse::<i64>()
             .map(Value::from)
@@ -291,7 +301,7 @@ fn coerce_graphql_arg(raw: &str, gql_type: &str) -> Value {
             .unwrap_or_else(|_| json!(raw)),
         "String" | "ID" => json!(raw),
         _ => serde_json::from_str(raw).unwrap_or_else(|_| json!(raw)),
-    }
+    })
 }
 
 /// Selection-set text for a GraphQL call's `--select` flag (or its
@@ -406,29 +416,47 @@ mod tests {
 
     #[test]
     fn coerce_graphql_arg_scalar_and_fallback_cases() {
-        assert_eq!(coerce_graphql_arg("5", "Int"), serde_json::json!(5));
-        assert_eq!(coerce_graphql_arg("5.5", "Float"), serde_json::json!(5.5));
         assert_eq!(
-            coerce_graphql_arg("true", "Boolean"),
+            coerce_graphql_arg("n", "5", "Int").expect("valid"),
+            serde_json::json!(5)
+        );
+        assert_eq!(
+            coerce_graphql_arg("n", "5.5", "Float").expect("valid"),
+            serde_json::json!(5.5)
+        );
+        assert_eq!(
+            coerce_graphql_arg("n", "true", "Boolean").expect("valid"),
             serde_json::json!(true)
         );
         assert_eq!(
-            coerce_graphql_arg("abc", "String!"),
+            coerce_graphql_arg("n", "abc", "String!").expect("valid"),
             serde_json::json!("abc")
         );
-        assert_eq!(coerce_graphql_arg("abc", "ID"), serde_json::json!("abc"));
         assert_eq!(
-            coerce_graphql_arg(r#"["a","b"]"#, "[String!]!"),
+            coerce_graphql_arg("n", "abc", "ID").expect("valid"),
+            serde_json::json!("abc")
+        );
+        assert_eq!(
+            coerce_graphql_arg("n", r#"["a","b"]"#, "[String!]!").expect("valid"),
             serde_json::json!(["a", "b"])
         );
         assert_eq!(
-            coerce_graphql_arg("ACTIVE", "StatusEnum"),
+            coerce_graphql_arg("n", "ACTIVE", "StatusEnum").expect("valid"),
             serde_json::json!("ACTIVE")
         );
         assert_eq!(
-            coerce_graphql_arg(r#"{"a":1}"#, "SomeInput"),
+            coerce_graphql_arg("n", r#"{"a":1}"#, "SomeInput").expect("valid"),
             serde_json::json!({"a": 1})
         );
+    }
+
+    #[test]
+    fn coerce_graphql_arg_rejects_a_non_json_list_value() {
+        let err = coerce_graphql_arg("ids", "not-json", "[String!]!")
+            .expect_err("a non-JSON-array value for a list type must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("ids"));
+        assert!(msg.contains("[String!]!"));
     }
 
     #[test]

--- a/rust/src/api_explorer/graphql/call.rs
+++ b/rust/src/api_explorer/graphql/call.rs
@@ -1,0 +1,531 @@
+//! `api graphql call`.
+
+use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
+use serde_json::{Map, Value, json};
+
+use super::super::catalog::{
+    GraphqlOpRef, catalog, graphql_base_type_name, graphql_operation_id,
+    graphql_operation_not_found_error, graphql_valid_arg_names, resolve_graphql_operation,
+};
+use super::super::http::{merge_required_scopes, parsed_extra_headers, send_and_report};
+
+#[derive(Debug, Clone, clap::Args)]
+struct GraphqlCallArgs {
+    /// GraphQL operation id (see `api operation list --domain <domain>` or `api search`).
+    #[arg(value_name = "ID")]
+    id: String,
+
+    /// GraphQL variable or wrapper call-requirement value (name=value,
+    /// repeatable) — see `api graphql get <id>` for valid names.
+    #[arg(long, value_name = "NAME=VALUE")]
+    arg: Vec<String>,
+
+    /// Response fields to select, comma-separated, dotted for nesting (e.g.
+    /// `id,name,address.city`). Defaults to `{ __typename }` for an
+    /// object-shaped return type, or no subselection for a scalar.
+    #[arg(long, value_name = "FIELDS")]
+    select: Option<String>,
+
+    /// Extra request headers.
+    #[arg(long, short = 'H', value_name = "KEY:VALUE")]
+    header: Vec<String>,
+
+    /// Include response headers in output.
+    #[arg(long, short = 'i')]
+    include: bool,
+
+    /// Additional required OAuth scope(s), merged with the operation's.
+    #[arg(long, short = 's', value_name = "SCOPE")]
+    scope: Vec<String>,
+}
+
+pub(super) fn command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed_with_context::<GraphqlCallArgs, _, _, _>(
+        CommandSpec::from_args::<GraphqlCallArgs>("call", "Call a GraphQL operation")
+            .with_long(
+                "Executes a GraphQL query or mutation by id (see `api operation list --domain \
+                 <domain>` or `api search`). Supply each of the operation's own arguments and \
+                 the wrapper's call requirements (both shown by `api graphql get <id>`) via \
+                 `--arg name=value`, repeatable — the CLI builds the actual GraphQL query text \
+                 and variables for you. Use `--select` to choose which response fields to get \
+                 back (comma-separated, dotted for nesting, e.g. `id,name,address.city`); \
+                 defaults to `{ __typename }` for an object-shaped return, or nothing for a \
+                 scalar. A mutation is short-circuited under the global `--dry-run` flag.",
+            )
+            .with_system("api")
+            .with_tier(Tier::Mutate)
+            .handles_dry_run(true)
+            .auth_optional(),
+        |ctx, args: GraphqlCallArgs| async move {
+            let id = args.id.as_str();
+            let g = resolve_graphql_operation(catalog(), id)
+                .ok_or_else(|| graphql_operation_not_found_error(id))?;
+
+            // A query is safe to actually execute under `--dry-run` (same
+            // treatment as GET/HEAD in `api call`'s raw-path flow); only a
+            // mutation short-circuits.
+            if ctx.dry_run() && g.op.kind == "mutation" {
+                return Ok(CommandResult::new(json!({
+                    "command": "api:graphql:call",
+                    "action": "dry-run: would execute",
+                    "operation": id,
+                }))
+                .with_dry_run());
+            }
+
+            let built = build_graphql_call(&g, &args)?;
+
+            let required = merge_required_scopes(args.scope.clone(), &g.parent.scopes);
+            let token = ctx.credential_with_scopes(&required).await?.token;
+            let base_url = crate::environments::resolve_catalog_base_url(
+                &g.domain.name,
+                &g.domain.base_url,
+                &ctx.middleware.env,
+            );
+            let url = format!("{base_url}{}", built.path);
+            let method: reqwest::Method = g.parent.method.parse().map_err(|_| {
+                crate::error::GddyError::validation(format!(
+                    "invalid HTTP method on catalog entry: {}",
+                    g.parent.method
+                ))
+                .into_cli_error()
+            })?;
+
+            let client = crate::application::client::make_http_client();
+            send_and_report(
+                &client,
+                method,
+                &g.parent.method,
+                &url,
+                &token,
+                &built.headers,
+                Some(built.body),
+                args.include,
+                true,
+                &required,
+                id,
+            )
+            .await
+        },
+    )
+}
+
+/// The pure (no I/O) result of synthesizing a GraphQL request from `--arg`/
+/// `--select`: the wrapper's path with path params substituted, the extra
+/// headers to send (wrapper header params plus any `--header` flags), and
+/// the `{query, variables}` request body.
+#[derive(Debug)]
+struct BuiltGraphqlCall {
+    path: String,
+    headers: Vec<(String, String)>,
+    body: Value,
+}
+
+/// Synthesizes a GraphQL request for `g` from `args.arg`/`args.select` —
+/// the pure core of `command`'s handler, split out so it can be exercised
+/// directly by tests without any auth/HTTP dependency.
+fn build_graphql_call(
+    g: &GraphqlOpRef<'_>,
+    args: &GraphqlCallArgs,
+) -> Result<BuiltGraphqlCall, cli_engine::CliCoreError> {
+    let synthetic_id = graphql_operation_id(&g.parent.operation_id, &g.op.kind, &g.op.name);
+
+    // Partition each `--arg NAME=VALUE`: a name matching one of the
+    // wrapper's own parameters (e.g. `storeId`, `x-store-id`) substitutes
+    // into the request; a name matching one of the GraphQL field's own args
+    // becomes a query variable; anything else is a validation error listing
+    // the valid names for this operation.
+    let mut wrapper_values: Vec<(String, String)> = Vec::new();
+    let mut variable_values: Vec<(String, String)> = Vec::new();
+    for raw in &args.arg {
+        let eq = raw.find('=').ok_or_else(|| {
+            crate::error::GddyError::validation(format!(
+                "invalid --arg '{raw}': expected name=value"
+            ))
+            .into_cli_error()
+        })?;
+        let name = &raw[..eq];
+        let value = raw[eq + 1..].to_owned();
+        if g.parent
+            .parameters
+            .iter()
+            .any(|p| p.get("name").and_then(Value::as_str) == Some(name))
+        {
+            wrapper_values.push((name.to_owned(), value));
+        } else if g.op.args.iter().any(|a| a.name == name) {
+            variable_values.push((name.to_owned(), value));
+        } else {
+            let valid = graphql_valid_arg_names(g);
+            return Err(crate::error::GddyError::validation(format!(
+                "unknown --arg '{name}' for {synthetic_id} — valid names: {}",
+                valid.join(", "),
+            ))
+            .into_cli_error());
+        }
+    }
+
+    // Validate every required wrapper parameter and required GraphQL arg
+    // got a value, batched into one error naming everything missing.
+    let mut missing: Vec<String> = Vec::new();
+    for p in &g.parent.parameters {
+        let Some(name) = p.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let required = p.get("required").and_then(Value::as_bool).unwrap_or(false);
+        if required && !wrapper_values.iter().any(|(n, _)| n == name) {
+            missing.push(name.to_owned());
+        }
+    }
+    for a in &g.op.args {
+        if a.required && !variable_values.iter().any(|(n, _)| n == &a.name) {
+            missing.push(a.name.clone());
+        }
+    }
+    if !missing.is_empty() {
+        return Err(crate::error::GddyError::validation(format!(
+            "missing required --arg value(s) for {synthetic_id}: {}",
+            missing.join(", "),
+        ))
+        .with_fix(format!("Run: gddy api graphql get {synthetic_id}"))
+        .into_cli_error());
+    }
+
+    // Substitute wrapper path parameters into the parent's path template;
+    // wrapper header parameters become request headers alongside any
+    // user-supplied `--header` flags.
+    let mut path = g.parent.path.clone();
+    let mut extra_headers = parsed_extra_headers(&args.header)?;
+    for (name, value) in &wrapper_values {
+        let location = g
+            .parent
+            .parameters
+            .iter()
+            .find(|p| p.get("name").and_then(Value::as_str) == Some(name.as_str()))
+            .and_then(|p| p.get("in").and_then(Value::as_str))
+            .unwrap_or("query");
+        match location {
+            "path" => path = path.replace(&format!("{{{name}}}"), value),
+            "header" => extra_headers.push((name.clone(), value.clone())),
+            _ => {}
+        }
+    }
+
+    // Coerce each GraphQL variable's raw CLI string per its declared type.
+    let mut variables = Map::new();
+    for (name, value) in &variable_values {
+        if let Some(a) = g.op.args.iter().find(|a| &a.name == name) {
+            variables.insert(name.clone(), coerce_graphql_arg(value, &a.arg_type));
+        }
+    }
+
+    let var_decls: Vec<String> =
+        g.op.args
+            .iter()
+            .filter(|a| variables.contains_key(&a.name))
+            .map(|a| format!("${}: {}", a.name, a.arg_type))
+            .collect();
+    let call_args: Vec<String> =
+        g.op.args
+            .iter()
+            .filter(|a| variables.contains_key(&a.name))
+            .map(|a| format!("{0}: ${0}", a.name))
+            .collect();
+    let selection = build_selection(args.select.as_deref(), &g.op.return_type);
+
+    let var_clause = if var_decls.is_empty() {
+        String::new()
+    } else {
+        format!("({})", var_decls.join(", "))
+    };
+    let args_clause = if call_args.is_empty() {
+        String::new()
+    } else {
+        format!("({})", call_args.join(", "))
+    };
+    let selection_clause = if selection.is_empty() {
+        String::new()
+    } else {
+        format!(" {{ {selection} }}")
+    };
+    let kind = g.op.kind.as_str();
+    let field = g.op.name.as_str();
+    let query = format!("{kind}{var_clause} {{ {field}{args_clause}{selection_clause} }}");
+
+    // `operationName` is deliberately omitted — optional per the wrapper's
+    // own schema, and an unverified allowlist/persisted-query risk on
+    // either subgraph makes always sending one unsafe to assume.
+    let body = json!({ "query": query, "variables": Value::Object(variables) });
+
+    Ok(BuiltGraphqlCall {
+        path,
+        headers: extra_headers,
+        body,
+    })
+}
+
+/// Coerces a `--arg` raw CLI string into JSON, given the GraphQL type
+/// string it will be bound to as a query variable. A list type (any type
+/// string containing `[`) is always JSON-parsed, since scalar-style
+/// coercion would silently treat the whole raw string as one value instead
+/// of a list (e.g. `--arg ids='["a","b"]'`). A non-list custom type (input
+/// object or enum) is JSON-parsed first, falling back to a bare JSON
+/// string — covering `--arg input='{"name":"x"}'` and `--arg
+/// status=ACTIVE` (not valid JSON on its own, and a string is the right
+/// encoding either way).
+fn coerce_graphql_arg(raw: &str, gql_type: &str) -> Value {
+    if gql_type.contains('[') {
+        return serde_json::from_str(raw).unwrap_or_else(|_| json!(raw));
+    }
+    match graphql_base_type_name(gql_type) {
+        "Int" => raw
+            .parse::<i64>()
+            .map(Value::from)
+            .unwrap_or_else(|_| json!(raw)),
+        "Float" => raw
+            .parse::<f64>()
+            .map(Value::from)
+            .unwrap_or_else(|_| json!(raw)),
+        "Boolean" => raw
+            .parse::<bool>()
+            .map(Value::from)
+            .unwrap_or_else(|_| json!(raw)),
+        "String" | "ID" => json!(raw),
+        _ => serde_json::from_str(raw).unwrap_or_else(|_| json!(raw)),
+    }
+}
+
+/// Selection-set text for a GraphQL call's `--select` flag (or its
+/// default): dotted paths in `select` nest into `{ }` blocks for sibling
+/// fields sharing a prefix (`"id,name,address.city"` -> `"id name address {
+/// city }"`). With no `--select` at all, defaults to `__typename` when
+/// `return_type`'s base name isn't one of the five built-in scalars — a
+/// real custom scalar with a capitalized name would be misclassified and
+/// rejected loudly by the server (not silently wrong), an acceptable
+/// tradeoff against forcing `--select` on every object-returning call.
+fn build_selection(select: Option<&str>, return_type: &str) -> String {
+    match select.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(fields) => build_selection_from_fields(fields),
+        None => {
+            let base = graphql_base_type_name(return_type);
+            if matches!(base, "Int" | "Float" | "String" | "Boolean" | "ID") {
+                String::new()
+            } else {
+                "__typename".to_owned()
+            }
+        }
+    }
+}
+
+/// Expands a comma-separated, dot-nested field list into GraphQL selection
+/// syntax, recursively grouping siblings that share a dotted prefix.
+fn build_selection_from_fields(fields: &str) -> String {
+    let mut groups: Vec<(&str, Vec<&str>)> = Vec::new();
+    for raw in fields.split(',') {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let (head, rest) = raw
+            .split_once('.')
+            .map_or((raw, None), |(h, r)| (h, Some(r)));
+        match groups.iter_mut().find(|(h, _)| *h == head) {
+            Some((_, subs)) => subs.extend(rest),
+            None => groups.push((head, rest.into_iter().collect())),
+        }
+    }
+    groups
+        .into_iter()
+        .map(|(head, subs)| {
+            if subs.is_empty() {
+                head.to_owned()
+            } else {
+                format!(
+                    "{head} {{ {} }}",
+                    build_selection_from_fields(&subs.join(","))
+                )
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use cli_engine::{Cli, CliConfig};
+
+    use super::super::super::catalog::{catalog, find_endpoint, resolve_graphql_operation};
+    use super::{GraphqlCallArgs, build_graphql_call, build_selection, coerce_graphql_arg};
+
+    fn graphql_cli() -> Cli {
+        Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(crate::api_explorer::module()),
+        )
+    }
+
+    fn graphql_call_args_with(id: &str, arg: Vec<&str>, select: Option<&str>) -> GraphqlCallArgs {
+        GraphqlCallArgs {
+            id: id.to_owned(),
+            arg: arg.into_iter().map(str::to_owned).collect(),
+            select: select.map(str::to_owned),
+            header: vec![],
+            include: false,
+            scope: vec![],
+        }
+    }
+
+    fn a_mutation_id() -> String {
+        let (_, ep) = find_endpoint(catalog(), "postTaxGraphql")
+            .expect("postTaxGraphql exists in the embedded taxes catalog");
+        let schema = ep
+            .graphql
+            .as_ref()
+            .expect("postTaxGraphql has a graphql schema");
+        let op = schema
+            .operations
+            .iter()
+            .find(|o| o.kind == "mutation")
+            .expect("taxes graphql schema has at least one mutation");
+        super::super::super::catalog::graphql_operation_id(&ep.operation_id, &op.kind, &op.name)
+    }
+
+    fn a_query_id() -> String {
+        let (_, ep) = find_endpoint(catalog(), "postTaxGraphql")
+            .expect("postTaxGraphql exists in the embedded taxes catalog");
+        let schema = ep
+            .graphql
+            .as_ref()
+            .expect("postTaxGraphql has a graphql schema");
+        let op = schema
+            .operations
+            .iter()
+            .find(|o| o.kind == "query")
+            .expect("taxes graphql schema has at least one query");
+        super::super::super::catalog::graphql_operation_id(&ep.operation_id, &op.kind, &op.name)
+    }
+
+    #[test]
+    fn coerce_graphql_arg_scalar_and_fallback_cases() {
+        assert_eq!(coerce_graphql_arg("5", "Int"), serde_json::json!(5));
+        assert_eq!(coerce_graphql_arg("5.5", "Float"), serde_json::json!(5.5));
+        assert_eq!(
+            coerce_graphql_arg("true", "Boolean"),
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            coerce_graphql_arg("abc", "String!"),
+            serde_json::json!("abc")
+        );
+        assert_eq!(coerce_graphql_arg("abc", "ID"), serde_json::json!("abc"));
+        assert_eq!(
+            coerce_graphql_arg(r#"["a","b"]"#, "[String!]!"),
+            serde_json::json!(["a", "b"])
+        );
+        assert_eq!(
+            coerce_graphql_arg("ACTIVE", "StatusEnum"),
+            serde_json::json!("ACTIVE")
+        );
+        assert_eq!(
+            coerce_graphql_arg(r#"{"a":1}"#, "SomeInput"),
+            serde_json::json!({"a": 1})
+        );
+    }
+
+    #[test]
+    fn build_selection_expands_dotted_paths_and_defaults_by_return_type_scalar_ness() {
+        assert_eq!(
+            build_selection(Some("id,name,address.city"), "[Widget!]!"),
+            "id name address { city }"
+        );
+        assert_eq!(build_selection(None, "String!"), "");
+        assert_eq!(build_selection(None, "[Widget!]!"), "__typename");
+    }
+
+    #[test]
+    fn build_graphql_call_synthesizes_exact_query_and_variables() {
+        let id = a_query_id();
+        let g = resolve_graphql_operation(catalog(), &id).expect("id resolves");
+        let mut args = graphql_call_args_with(&id, vec![], Some("__typename"));
+        // Fill in every required wrapper param + required op arg with a
+        // placeholder so this exercises synthesis, not validation.
+        for p in &g.parent.parameters {
+            if let Some(name) = p.get("name").and_then(serde_json::Value::as_str) {
+                args.arg.push(format!("{name}=placeholder"));
+            }
+        }
+        for a in &g.op.args {
+            args.arg.push(format!("{}=placeholder", a.name));
+        }
+        let built = build_graphql_call(&g, &args).expect("builds without error");
+        assert!(
+            built.body["query"]
+                .as_str()
+                .expect("query is a string")
+                .contains(&g.op.name)
+        );
+        assert!(
+            !built.path.contains('{'),
+            "path params substituted: {}",
+            built.path
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_call_dry_run_short_circuits_mutation_but_not_query() {
+        let mutation_id = a_mutation_id();
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "call",
+                &mutation_id,
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        assert!(output.rendered.contains("dry-run: would execute"));
+
+        // A query has nothing unsafe to preview, so it isn't short-circuited
+        // — it falls through to a real (auth-requiring, here failing) send.
+        let query_id = a_query_id();
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "call",
+                &query_id,
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            !output.rendered.contains("dry-run: would execute"),
+            "{}",
+            output.rendered
+        );
+    }
+
+    #[test]
+    fn build_graphql_call_missing_required_arg_is_validation_error() {
+        let id = a_query_id();
+        let g = resolve_graphql_operation(catalog(), &id).expect("id resolves");
+        let args = graphql_call_args_with(&id, vec![], None);
+        let err = build_graphql_call(&g, &args).expect_err("missing required args");
+        assert!(err.to_string().contains("missing required"), "{err}");
+    }
+
+    #[test]
+    fn build_graphql_call_unknown_arg_name_is_validation_error() {
+        let id = a_query_id();
+        let g = resolve_graphql_operation(catalog(), &id).expect("id resolves");
+        let args = graphql_call_args_with(&id, vec!["notARealArgName=x"], None);
+        let err = build_graphql_call(&g, &args).expect_err("unknown arg name");
+        assert!(err.to_string().contains("unknown --arg"), "{err}");
+    }
+}

--- a/rust/src/api_explorer/graphql/call.rs
+++ b/rust/src/api_explorer/graphql/call.rs
@@ -61,9 +61,15 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let g = resolve_graphql_operation(catalog(), id)
                 .ok_or_else(|| graphql_operation_not_found_error(id))?;
 
+            // Validate unconditionally, including under `--dry-run` (same
+            // rationale as `api call`'s method/endpoint checks) — otherwise
+            // missing/invalid `--arg`/`--select` would return a successful
+            // dry-run preview even though a real run would reject it here.
+            let built = build_graphql_call(&g, &args)?;
+
             // A query is safe to actually execute under `--dry-run` (same
             // treatment as GET/HEAD in `api call`'s raw-path flow); only a
-            // mutation short-circuits.
+            // mutation short-circuits, and only after the validation above.
             if ctx.dry_run() && g.op.kind == "mutation" {
                 return Ok(CommandResult::new(json!({
                     "command": "api:graphql:call",
@@ -72,8 +78,6 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 }))
                 .with_dry_run());
             }
-
-            let built = build_graphql_call(&g, &args)?;
 
             let required = merge_required_scopes(args.scope.clone(), &g.parent.scopes);
             let token = ctx.credential_with_scopes(&required).await?.token;
@@ -445,6 +449,25 @@ mod tests {
         super::super::super::catalog::graphql_operation_id(&ep.operation_id, &op.kind, &op.name)
     }
 
+    /// `--arg name=placeholder` for every one of `id`'s wrapper call
+    /// requirements and GraphQL args, so a test can invoke it without
+    /// tripping "missing required --arg" validation it isn't exercising.
+    fn placeholder_arg_flags(id: &str) -> Vec<String> {
+        let g = resolve_graphql_operation(catalog(), id).expect("id resolves");
+        let mut flags = Vec::new();
+        for p in &g.parent.parameters {
+            if let Some(name) = p.get("name").and_then(serde_json::Value::as_str) {
+                flags.push("--arg".to_owned());
+                flags.push(format!("{name}=placeholder"));
+            }
+        }
+        for a in &g.op.args {
+            flags.push("--arg".to_owned());
+            flags.push(format!("{}=placeholder", a.name));
+        }
+        flags
+    }
+
     #[test]
     fn coerce_graphql_arg_scalar_and_fallback_cases() {
         assert_eq!(
@@ -551,6 +574,49 @@ mod tests {
     #[tokio::test]
     async fn graphql_call_dry_run_short_circuits_mutation_but_not_query() {
         let mutation_id = a_mutation_id();
+        let mut cmd: Vec<String> = ["gddy", "api", "graphql", "call", &mutation_id]
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        cmd.extend(placeholder_arg_flags(&mutation_id));
+        cmd.extend(
+            ["--dry-run", "--output", "json"]
+                .into_iter()
+                .map(str::to_owned),
+        );
+        let output = graphql_cli().run(cmd).await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        assert!(output.rendered.contains("dry-run: would execute"));
+
+        // A query has nothing unsafe to preview, so it isn't short-circuited
+        // — it falls through to a real (auth-requiring, here failing) send.
+        let query_id = a_query_id();
+        let mut cmd: Vec<String> = ["gddy", "api", "graphql", "call", &query_id]
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        cmd.extend(placeholder_arg_flags(&query_id));
+        cmd.extend(
+            ["--dry-run", "--output", "json"]
+                .into_iter()
+                .map(str::to_owned),
+        );
+        let output = graphql_cli().run(cmd).await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            !output.rendered.contains("dry-run: would execute"),
+            "{}",
+            output.rendered
+        );
+    }
+
+    /// Regression for PR #200 review feedback: a dry-run mutation call must
+    /// fail on missing/invalid `--arg` the same way a real call would,
+    /// instead of returning a successful "would execute" preview that then
+    /// fails as soon as `--dry-run` is dropped.
+    #[tokio::test]
+    async fn graphql_call_dry_run_still_validates_missing_required_args() {
+        let mutation_id = a_mutation_id();
         let output = graphql_cli()
             .run([
                 "gddy",
@@ -563,27 +629,14 @@ mod tests {
                 "json",
             ])
             .await;
-        assert_eq!(output.exit_code, 0, "{}", output.rendered);
-        assert!(output.rendered.contains("dry-run: would execute"));
-
-        // A query has nothing unsafe to preview, so it isn't short-circuited
-        // — it falls through to a real (auth-requiring, here failing) send.
-        let query_id = a_query_id();
-        let output = graphql_cli()
-            .run([
-                "gddy",
-                "api",
-                "graphql",
-                "call",
-                &query_id,
-                "--dry-run",
-                "--output",
-                "json",
-            ])
-            .await;
         assert_ne!(output.exit_code, 0, "{}", output.rendered);
         assert!(
             !output.rendered.contains("dry-run: would execute"),
+            "{}",
+            output.rendered
+        );
+        assert!(
+            output.rendered.contains("missing required"),
             "{}",
             output.rendered
         );

--- a/rust/src/api_explorer/graphql/get.rs
+++ b/rust/src/api_explorer/graphql/get.rs
@@ -1,0 +1,257 @@
+//! `api graphql get`.
+
+use cli_engine::{
+    CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+};
+use serde_json::{Value, json};
+
+use crate::next_action::next_action;
+use crate::output_schema::output_schema;
+
+use super::super::catalog::{
+    catalog, graphql_operation_id, graphql_operation_not_found_error, graphql_resolve_type,
+    resolve_graphql_operation,
+};
+use super::super::schema_tree::describe_schema;
+
+// A GraphQL operation
+output_schema!(ApiGraphqlOperation {
+    "domain": "string";
+    "operationId": "string";
+    "kind": "string";
+    "name": "string";
+    "summary": "string", optional;
+    "description": "string", optional;
+    "deprecated": "bool";
+    "deprecationReason": "string", optional;
+    "returnType": "string";
+    "returnFields": "[]object", optional;
+    "callRequirements": "[]object";
+    "arguments": "[]object";
+    "scopes": "[]string";
+});
+
+#[derive(Debug, Clone, clap::Args)]
+struct GraphqlGetArgs {
+    /// GraphQL operation id (see `api operation list --domain <domain>` or `api search`).
+    #[arg(value_name = "ID")]
+    id: String,
+}
+
+pub(super) fn command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed::<GraphqlGetArgs, _, _, _>(
+        CommandSpec::from_args::<GraphqlGetArgs>("get", "Show a GraphQL operation's own shape")
+            .with_long(
+                "Shows a GraphQL operation's details. \"Call Requirements\" \
+                lists what the wrapper endpoint that proxies this operation \
+                needs to route and authenticate the request. \"Arguments\" lists \
+                 the operation's GraphQL inputs. Use `api graphql call <id>` to \
+                 execute it.",
+            )
+            .with_system("api")
+            .with_tier(Tier::Read)
+            .no_auth(true)
+            .with_output_schema::<ApiGraphqlOperation>()
+            .with_view(vec![
+                TableColumn::new("domain", "Domain"),
+                TableColumn::new("operationId", "Operation ID"),
+                TableColumn::new("kind", "Kind"),
+                TableColumn::new("summary", "Summary"),
+                TableColumn::new("returnType", "Return Type"),
+                TableColumn::new("returnFields", "Return Fields").nested(vec![
+                    TableColumn::new("name", "Name"),
+                    TableColumn::new("type", "Type"),
+                    TableColumn::new("description", "Description"),
+                ]),
+                TableColumn::new("callRequirements", "Call Requirements").nested(vec![
+                    TableColumn::new("name", "Name"),
+                    TableColumn::new("in", "In"),
+                    TableColumn::new("required", "Required"),
+                    TableColumn::new("type", "Type"),
+                    TableColumn::new("description", "Description"),
+                ]),
+                TableColumn::new("arguments", "Arguments").nested(vec![
+                    TableColumn::new("name", "Name"),
+                    TableColumn::new("required", "Required"),
+                    TableColumn::new("type", "Type"),
+                    TableColumn::new("description", "Description"),
+                ]),
+            ]),
+        |_cred, args: GraphqlGetArgs| async move {
+            let id = args.id.as_str();
+            let g = resolve_graphql_operation(catalog(), id)
+                .ok_or_else(|| graphql_operation_not_found_error(id))?;
+
+            // Most return types resolve to an object/input with real fields;
+            // a bare enum return (no known operation does this today, but
+            // the schema allows it) has no `fields` at all — its "shape" is
+            // its set of allowed values instead.
+            let return_fields = graphql_resolve_type(&g, &g.op.return_type).map(|t| {
+                if t.kind == "enum" {
+                    t.values
+                        .iter()
+                        .map(|v| json!({"name": v, "type": "enum value"}))
+                        .collect::<Vec<_>>()
+                } else {
+                    t.fields
+                        .iter()
+                        .map(|f| {
+                            json!({"name": f.name, "type": f.field_type, "description": f.description})
+                        })
+                        .collect::<Vec<_>>()
+                }
+            });
+
+            let call_requirements: Vec<Value> = g
+                .parent
+                .parameters
+                .iter()
+                .filter_map(|p| {
+                    let obj = p.as_object()?;
+                    let name = obj.get("name")?.as_str()?.to_owned();
+                    let location = obj
+                        .get("in")
+                        .and_then(Value::as_str)
+                        .unwrap_or("query")
+                        .to_owned();
+                    let required = obj
+                        .get("required")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    let (scalar_type, _) = describe_schema(obj.get("schema"), &g.domain.defs);
+                    let description = obj
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                    Some(json!({
+                        "name": name,
+                        "in": location,
+                        "required": required,
+                        "type": scalar_type,
+                        "description": description,
+                    }))
+                })
+                .collect();
+
+            let arguments: Vec<Value> =
+                g.op.args
+                    .iter()
+                    .map(|a| {
+                        json!({
+                            "name": a.name,
+                            "type": a.arg_type,
+                            "required": a.required,
+                            "description": a.description,
+                            "defaultValue": a.default_value,
+                        })
+                    })
+                    .collect();
+
+            let synthetic_id = graphql_operation_id(&g.parent.operation_id, &g.op.kind, &g.op.name);
+            let has_return_fields = return_fields.is_some();
+
+            let mut next_actions = vec![next_action(
+                format!("api graphql call {synthetic_id} --arg name=value"),
+                "Make an authenticated call to this operation",
+            )];
+            // Only worth suggesting when the return type actually resolved
+            // to something with fields to drill into — a caller with a
+            // plain-scalar return type has nowhere further to go.
+            if has_return_fields {
+                next_actions.push(
+                    next_action(
+                        "api graphql type get <TypeName>",
+                        "See a nested type's own fields — pass any Return Fields Type value \
+                         that isn't a plain scalar (e.g. ClassificationListsConnection)",
+                    )
+                    .with_param("TypeName", NextActionParam::required()),
+                );
+            }
+
+            Ok(CommandResult::new(json!({
+                "domain": g.domain.name,
+                "operationId": synthetic_id,
+                "kind": g.op.kind,
+                "name": g.op.name,
+                "summary": g
+                    .op
+                    .description
+                    .clone()
+                    .unwrap_or_else(|| format!("{} {}", g.op.kind, g.op.name)),
+                "description": g.op.description,
+                "deprecated": g.op.deprecated,
+                "deprecationReason": g.op.deprecation_reason,
+                "returnType": g.op.return_type,
+                "returnFields": return_fields,
+                "callRequirements": call_requirements,
+                "arguments": arguments,
+                "scopes": g.parent.scopes,
+            }))
+            .with_next_actions(next_actions))
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use cli_engine::{Cli, CliConfig};
+    use serde_json::Value;
+
+    fn graphql_cli() -> Cli {
+        Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(crate::api_explorer::module()),
+        )
+    }
+
+    fn find_a_graphql_operation_id() -> String {
+        // Any real query/mutation on the taxes domain — walk the catalog
+        // directly rather than hardcoding a name that upstream spec drift
+        // could rename out from under this test.
+        let (_, ep) = super::super::super::catalog::find_endpoint(
+            super::super::super::catalog::catalog(),
+            "postTaxGraphql",
+        )
+        .expect("postTaxGraphql exists in the embedded taxes catalog");
+        let schema = ep
+            .graphql
+            .as_ref()
+            .expect("postTaxGraphql has a graphql schema");
+        let op = schema
+            .operations
+            .first()
+            .expect("taxes graphql schema has at least one operation");
+        super::super::super::catalog::graphql_operation_id(&ep.operation_id, &op.kind, &op.name)
+    }
+
+    #[tokio::test]
+    async fn graphql_get_returns_kind_return_shape_and_split_requirements_vs_arguments() {
+        let id = find_a_graphql_operation_id();
+        let output = graphql_cli()
+            .run(["gddy", "api", "graphql", "get", &id, "--output", "json"])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        let rendered: Value = serde_json::from_str(&output.rendered).expect("valid json");
+        let data = &rendered["data"];
+        assert!(data["kind"].as_str().is_some());
+        assert!(data.get("method").is_none(), "no REST fields: {data}");
+        assert!(data.get("path").is_none(), "no REST fields: {data}");
+        assert!(data.get("responses").is_none(), "no REST fields: {data}");
+    }
+
+    #[tokio::test]
+    async fn graphql_get_unknown_id_is_not_found() {
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "get",
+                "postTaxGraphql::query::notARealField",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+    }
+}

--- a/rust/src/api_explorer/graphql/mod.rs
+++ b/rust/src/api_explorer/graphql/mod.rs
@@ -19,10 +19,10 @@ pub(super) fn group() -> RuntimeGroupSpec {
     RuntimeGroupSpec::new(
         GroupSpec::new("graphql", "Inspect and call individual GraphQL operations").with_long(
             "Some API domains are backed by GraphQL rather than REST — \
-            `api operation list  --domain <domain>` and `api search` tag each \
+            `api operation list --domain <domain>` and `api search` tag each \
             of their addressable query/mutation fields with a `kind`. Use \
             `api graphql get <id>` for that operation's details and \
-            `api graphql call <id>` to execute it — `api  operation get`/\
+            `api graphql call <id>` to execute it — `api operation get`/\
             `api call` redirect here for a GraphQL operation id, since their \
              REST-shaped output doesn't fit a GraphQL operation.",
         ),

--- a/rust/src/api_explorer/graphql/mod.rs
+++ b/rust/src/api_explorer/graphql/mod.rs
@@ -1,0 +1,34 @@
+//! `api graphql` — inspect and call individual GraphQL operations.
+//!
+//! Some API domains (e.g. `taxes`, `catalog-products`) are backed by
+//! GraphQL rather than plain REST — `api operation list --domain <domain>`
+//! and `api search` tag each of their addressable query/mutation fields
+//! with a `kind`. This group is their own dedicated command surface: `api
+//! operation get`/`api parameter list`/`api call` redirect here for a
+//! GraphQL operation id, since their REST-shaped output doesn't fit a
+//! GraphQL operation at all (see `super::catalog::graphql_operation_redirect_error`).
+
+use cli_engine::{GroupSpec, RuntimeGroupSpec};
+
+mod call;
+mod get;
+mod sdl;
+mod type_cmd;
+
+pub(super) fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(
+        GroupSpec::new("graphql", "Inspect and call individual GraphQL operations").with_long(
+            "Some API domains are backed by GraphQL rather than REST — \
+            `api operation list  --domain <domain>` and `api search` tag each \
+            of their addressable query/mutation fields with a `kind`. Use \
+            `api graphql get <id>` for that operation's details and \
+            `api graphql call <id>` to execute it — `api  operation get`/\
+            `api call` redirect here for a GraphQL operation id, since their \
+             REST-shaped output doesn't fit a GraphQL operation.",
+        ),
+    )
+    .with_command(get::command())
+    .with_command(call::command())
+    .with_group(type_cmd::group())
+    .with_group(sdl::group())
+}

--- a/rust/src/api_explorer/graphql/sdl.rs
+++ b/rust/src/api_explorer/graphql/sdl.rs
@@ -1,0 +1,117 @@
+//! `api graphql sdl get` — a nested group with a single leaf, kept in one
+//! flat file rather than its own subdirectory (see `docs/code-structure.md`).
+
+use cli_engine::{
+    CommandResult, CommandSpec, GroupSpec, RuntimeCommandSpec, RuntimeGroupSpec, Tier,
+};
+use serde_json::json;
+
+use super::super::catalog::{catalog, resolve_operation};
+
+#[derive(Debug, Clone, clap::Args)]
+struct GraphqlSdlGetArgs {
+    /// The GraphQL domain's wrapper operation ID, not an individual
+    /// query/mutation id.
+    #[arg(value_name = "OPERATION")]
+    operation: String,
+}
+
+fn get_command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed::<GraphqlSdlGetArgs, _, _, _>(
+        CommandSpec::from_args::<GraphqlSdlGetArgs>(
+            "get",
+            "Show a GraphQL domain's actual schema (SDL) text",
+        )
+        .with_long(
+            "Prints the GraphQL Schema Definition Language source for a GraphQL \
+            domain. Useful for feeding into other GraphQL tooling or for \
+            answering any question this catalog's own summary doesn't happen to \
+            capture. Pass the wrapper operation id for the domain (e.g. \
+            `postTaxGraphql`), not an individual query/mutation id.",
+        )
+        .with_system("api")
+        .with_tier(Tier::Read)
+        .no_auth(true)
+        .raw_output(true),
+        |_cred, args: GraphqlSdlGetArgs| async move {
+            let operation = args.operation.as_str();
+            let (_, ep) = resolve_operation(catalog(), operation, None)?;
+            let schema = ep.graphql.as_ref().ok_or_else(|| {
+                crate::error::GddyError::validation(format!(
+                    "'{operation}' has no GraphQL schema attached — pass a domain's wrapper \
+                     operation id instead, e.g. postTaxGraphql"
+                ))
+                .into_cli_error()
+            })?;
+            Ok(CommandResult::new(json!(schema.sdl)))
+        },
+    )
+}
+
+pub(super) fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(GroupSpec::new(
+        "sdl",
+        "Get a GraphQL domain's actual schema text, verbatim",
+    ))
+    .with_command(get_command())
+}
+
+#[cfg(test)]
+mod tests {
+    use cli_engine::{Cli, CliConfig};
+
+    fn graphql_cli() -> Cli {
+        Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(crate::api_explorer::module()),
+        )
+    }
+
+    #[tokio::test]
+    async fn graphql_sdl_get_always_prints_raw_text_by_default() {
+        let output = graphql_cli()
+            .run(["gddy", "api", "graphql", "sdl", "get", "postTaxGraphql"])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            output.rendered.contains("type ") || output.rendered.contains("schema"),
+            "expected raw SDL text, got: {}",
+            output.rendered
+        );
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&output.rendered).is_err(),
+            "expected raw text, not JSON: {}",
+            output.rendered
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_sdl_get_ignores_an_explicit_output_json_flag() {
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "sdl",
+                "get",
+                "postTaxGraphql",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&output.rendered).is_err(),
+            "expected raw text even with --output json, got: {}",
+            output.rendered
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_sdl_get_rejects_an_operation_with_no_graphql_schema() {
+        let output = graphql_cli()
+            .run(["gddy", "api", "graphql", "sdl", "get", "listFulfillments"])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+    }
+}

--- a/rust/src/api_explorer/graphql/type_cmd.rs
+++ b/rust/src/api_explorer/graphql/type_cmd.rs
@@ -9,7 +9,9 @@ use serde_json::json;
 
 use crate::output_schema::output_schema;
 
-use super::super::catalog::{catalog, find_graphql_type, graphql_type_not_found_error};
+use super::super::catalog::{
+    ambiguous_graphql_type_error, catalog, find_graphql_types, graphql_type_not_found_error,
+};
 
 output_schema!(ApiGraphqlType {
     "name": "string";
@@ -23,6 +25,11 @@ struct GraphqlTypeGetArgs {
     /// GraphQL type name (see a field's `Type` column in `api graphql get`).
     #[arg(value_name = "NAME")]
     name: String,
+
+    /// Domain to look up the type in, when the name is defined by more than
+    /// one domain's GraphQL schema (see `api domain list`).
+    #[arg(long, value_name = "DOMAIN")]
+    domain: Option<String>,
 }
 
 fn get_command() -> RuntimeCommandSpec {
@@ -54,8 +61,23 @@ fn get_command() -> RuntimeCommandSpec {
         ]),
         |_cred, args: GraphqlTypeGetArgs| async move {
             let name = args.name.as_str();
-            let t = find_graphql_type(catalog(), name)
-                .ok_or_else(|| graphql_type_not_found_error(name))?;
+            let matches = find_graphql_types(catalog(), name);
+            let t = match args.domain.as_deref() {
+                Some(domain) => matches
+                    .iter()
+                    .find(|(d, _)| d.name == domain)
+                    .map(|(_, t)| *t)
+                    .ok_or_else(|| graphql_type_not_found_error(name))?,
+                None => match matches.as_slice() {
+                    [] => return Err(graphql_type_not_found_error(name)),
+                    [(_, t)] => *t,
+                    hits => {
+                        let domains: Vec<&str> =
+                            hits.iter().map(|(d, _)| d.name.as_str()).collect();
+                        return Err(ambiguous_graphql_type_error(name, &domains));
+                    }
+                },
+            };
 
             let fields = (!t.fields.is_empty()).then(|| {
                 t.fields
@@ -138,6 +160,8 @@ mod tests {
                 "type",
                 "get",
                 &object_name,
+                "--domain",
+                "taxes",
                 "--output",
                 "json",
             ])
@@ -157,7 +181,8 @@ mod tests {
         let (_, enum_name) = an_object_and_enum_type_name();
         let output = graphql_cli()
             .run([
-                "gddy", "api", "graphql", "type", "get", &enum_name, "--output", "json",
+                "gddy", "api", "graphql", "type", "get", &enum_name, "--domain", "taxes",
+                "--output", "json",
             ])
             .await;
         assert_eq!(output.exit_code, 0, "{}", output.rendered);
@@ -168,6 +193,84 @@ mod tests {
                 .expect("values array")
                 .is_empty()
         );
+    }
+
+    /// Regression for a name collision caught in PR #200 review: `taxes`
+    /// and `catalog-products` each declare their own, differently-shaped
+    /// `ReferenceValueFilter` input type. Without `--domain`, that must be
+    /// an ambiguous-match error rather than silently returning whichever
+    /// domain happens to sort first — and each `--domain` value must return
+    /// that domain's own fields, not the other's.
+    #[tokio::test]
+    async fn graphql_type_get_disambiguates_a_name_shared_by_two_domains() {
+        let ambiguous = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "type",
+                "get",
+                "ReferenceValueFilter",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(ambiguous.exit_code, 0, "{}", ambiguous.rendered);
+        assert!(ambiguous.rendered.contains("taxes"));
+        assert!(ambiguous.rendered.contains("catalog-products"));
+
+        let taxes = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "type",
+                "get",
+                "ReferenceValueFilter",
+                "--domain",
+                "taxes",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(taxes.exit_code, 0, "{}", taxes.rendered);
+        let taxes_fields: Value = serde_json::from_str(&taxes.rendered).expect("valid json");
+        let taxes_field_names: Vec<&str> = taxes_fields["data"]["fields"]
+            .as_array()
+            .expect("fields array")
+            .iter()
+            .map(|f| f["name"].as_str().expect("field name"))
+            .collect();
+        assert_eq!(taxes_field_names, ["in"]);
+
+        let catalog_products = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "type",
+                "get",
+                "ReferenceValueFilter",
+                "--domain",
+                "catalog-products",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(
+            catalog_products.exit_code, 0,
+            "{}",
+            catalog_products.rendered
+        );
+        let cp_fields: Value =
+            serde_json::from_str(&catalog_products.rendered).expect("valid json");
+        let cp_field_names: Vec<&str> = cp_fields["data"]["fields"]
+            .as_array()
+            .expect("fields array")
+            .iter()
+            .map(|f| f["name"].as_str().expect("field name"))
+            .collect();
+        assert_eq!(cp_field_names, ["eq", "in"]);
     }
 
     #[tokio::test]

--- a/rust/src/api_explorer/graphql/type_cmd.rs
+++ b/rust/src/api_explorer/graphql/type_cmd.rs
@@ -1,0 +1,189 @@
+//! `api graphql type get` — a nested group with a single leaf, kept in one
+//! flat file rather than its own subdirectory (see `docs/code-structure.md`).
+//! Named `type_cmd` rather than `type` since `type` is a Rust keyword.
+
+use cli_engine::{
+    CommandResult, CommandSpec, GroupSpec, RuntimeCommandSpec, RuntimeGroupSpec, TableColumn, Tier,
+};
+use serde_json::json;
+
+use crate::output_schema::output_schema;
+
+use super::super::catalog::{catalog, find_graphql_type, graphql_type_not_found_error};
+
+output_schema!(ApiGraphqlType {
+    "name": "string";
+    "kind": "string";
+    "fields": "[]object", optional;
+    "values": "[]string", optional;
+});
+
+#[derive(Debug, Clone, clap::Args)]
+struct GraphqlTypeGetArgs {
+    /// GraphQL type name (see a field's `Type` column in `api graphql get`).
+    #[arg(value_name = "NAME")]
+    name: String,
+}
+
+fn get_command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed::<GraphqlTypeGetArgs, _, _, _>(
+        CommandSpec::from_args::<GraphqlTypeGetArgs>(
+            "get",
+            "Show a named GraphQL type's fields or values",
+        )
+        .with_long(
+            "Looks up a GraphQL object, input, or enum type by name and shows its full field \
+             list (or, for an enum, its allowed values) — never truncated. Use this to drill \
+             into a field whose `Type` column in `api graphql get` isn't a plain scalar (e.g. \
+             `ClassificationListsConnection`), one hop at a time, until you reach the fields \
+             you want to pass to `--select`.",
+        )
+        .with_system("api")
+        .with_tier(Tier::Read)
+        .no_auth(true)
+        .with_output_schema::<ApiGraphqlType>()
+        .with_view(vec![
+            TableColumn::new("name", "Name"),
+            TableColumn::new("kind", "Kind"),
+            TableColumn::new("fields", "Fields").nested(vec![
+                TableColumn::new("name", "Name"),
+                TableColumn::new("type", "Type"),
+                TableColumn::new("description", "Description"),
+            ]),
+            TableColumn::new("values", "Values"),
+        ]),
+        |_cred, args: GraphqlTypeGetArgs| async move {
+            let name = args.name.as_str();
+            let t = find_graphql_type(catalog(), name)
+                .ok_or_else(|| graphql_type_not_found_error(name))?;
+
+            let fields = (!t.fields.is_empty()).then(|| {
+                t.fields
+                    .iter()
+                    .map(|f| {
+                        json!({"name": f.name, "type": f.field_type, "description": f.description})
+                    })
+                    .collect::<Vec<_>>()
+            });
+            let values = (!t.values.is_empty()).then(|| t.values.clone());
+
+            Ok(CommandResult::new(json!({
+                "name": t.name,
+                "kind": t.kind,
+                "fields": fields,
+                "values": values,
+            })))
+        },
+    )
+}
+
+pub(super) fn group() -> RuntimeGroupSpec {
+    RuntimeGroupSpec::new(GroupSpec::new(
+        "type",
+        "Look up a named GraphQL object, input, or enum type",
+    ))
+    .with_command(get_command())
+}
+
+#[cfg(test)]
+mod tests {
+    use cli_engine::{Cli, CliConfig};
+    use serde_json::Value;
+
+    fn graphql_cli() -> Cli {
+        Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(crate::api_explorer::module()),
+        )
+    }
+
+    /// Finds a named object/input type with at least one field, and a named
+    /// enum type, on the taxes GraphQL schema — used instead of hardcoding
+    /// type names an upstream spec change could rename.
+    fn an_object_and_enum_type_name() -> (String, String) {
+        let (_, ep) = super::super::super::catalog::find_endpoint(
+            super::super::super::catalog::catalog(),
+            "postTaxGraphql",
+        )
+        .expect("postTaxGraphql exists in the embedded taxes catalog");
+        let schema = ep
+            .graphql
+            .as_ref()
+            .expect("postTaxGraphql has a graphql schema");
+        let object_name = schema
+            .types
+            .iter()
+            .find(|t| t.kind != "enum" && !t.fields.is_empty())
+            .expect("taxes graphql schema has an object/input type with fields")
+            .name
+            .clone();
+        let enum_name = schema
+            .types
+            .iter()
+            .find(|t| t.kind == "enum" && !t.values.is_empty())
+            .expect("taxes graphql schema has an enum type with values")
+            .name
+            .clone();
+        (object_name, enum_name)
+    }
+
+    #[tokio::test]
+    async fn graphql_type_get_returns_fields_for_an_object_type() {
+        let (object_name, _) = an_object_and_enum_type_name();
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "type",
+                "get",
+                &object_name,
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        let rendered: Value = serde_json::from_str(&output.rendered).expect("valid json");
+        assert!(
+            !rendered["data"]["fields"]
+                .as_array()
+                .expect("fields array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_type_get_returns_values_for_an_enum_type() {
+        let (_, enum_name) = an_object_and_enum_type_name();
+        let output = graphql_cli()
+            .run([
+                "gddy", "api", "graphql", "type", "get", &enum_name, "--output", "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        let rendered: Value = serde_json::from_str(&output.rendered).expect("valid json");
+        assert!(
+            !rendered["data"]["values"]
+                .as_array()
+                .expect("values array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_type_get_unknown_name_is_not_found() {
+        let output = graphql_cli()
+            .run([
+                "gddy",
+                "api",
+                "graphql",
+                "type",
+                "get",
+                "NotARealGraphqlType",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+    }
+}

--- a/rust/src/api_explorer/guides/api-explorer.md
+++ b/rust/src/api_explorer/guides/api-explorer.md
@@ -130,7 +130,7 @@ The CLI builds the GraphQL query text and `variables` object for you, sends it t
 By default the response selects just `{ __typename }` for an object-shaped return type (or nothing at all for a plain scalar). To ask for specific fields, use `--select`, comma-separated and dot-nested for fields on a nested object:
 
 ```
-gddy api graphql call postTaxGraphql::query::classification --arg id=<id> --select id,name,rate.percentage
+gddy api graphql call postTaxGraphql::query::classification --arg storeId=<uuid> --arg x-store-id=<uuid> --arg id=<id> --select id,name,rate.percentage
 ```
 
 ### Finding out what's selectable

--- a/rust/src/api_explorer/guides/api-explorer.md
+++ b/rust/src/api_explorer/guides/api-explorer.md
@@ -108,13 +108,13 @@ Before running anything that changes data, preview it with the global `--dry-run
 
 Some domains are backed by GraphQL rather than plain REST. In the catalog they still show up as one wrapper operation (`postTaxGraphql`, `postCatalogGraphql`) that accepts a generic `{query, variables}` body — but every GraphQL query and mutation that wrapper proxies to is also individually addressable.
 
-A GraphQL operations have their own dedicated set of commands. Run this to show a GraphQL operation's details:
+GraphQL operations have their own dedicated set of commands. Run this to show a GraphQL operation's details:
 
 ```
 gddy api graphql get <id>
 ```
 
-A GraphQL operation contains: 
+A GraphQL operation contains:
 
 - **Call Requirements** — what the underlying wrapper endpoint needs to route and authenticate the request (e.g. path parameters and HTTP headers). These are transport plumbing, not GraphQL semantics.
 - **Arguments** — the GraphQL operation's own inputs.

--- a/rust/src/api_explorer/guides/api-explorer.md
+++ b/rust/src/api_explorer/guides/api-explorer.md
@@ -104,6 +104,73 @@ gddy api call <path> --method POST --file body.json
 
 Before running anything that changes data, preview it with the global `--dry-run` flag — it short-circuits before sending the request for any method that mutates state (a plain `GET`/`HEAD` still runs for real under `--dry-run`, since there's nothing unsafe to preview there).
 
+## GraphQL operations
+
+Some domains are backed by GraphQL rather than plain REST. In the catalog they still show up as one wrapper operation (`postTaxGraphql`, `postCatalogGraphql`) that accepts a generic `{query, variables}` body — but every GraphQL query and mutation that wrapper proxies to is also individually addressable.
+
+A GraphQL operations have their own dedicated set of commands. Run this to show a GraphQL operation's details:
+
+```
+gddy api graphql get <id>
+```
+
+A GraphQL operation contains: 
+
+- **Call Requirements** — what the underlying wrapper endpoint needs to route and authenticate the request (e.g. path parameters and HTTP headers). These are transport plumbing, not GraphQL semantics.
+- **Arguments** — the GraphQL operation's own inputs.
+
+Supply both of these with `--arg name=value` (repeatable).
+
+```
+gddy api graphql call postTaxGraphql::query::classification --arg storeId=<uuid> --arg x-store-id=<uuid> --arg id=<id>
+```
+
+The CLI builds the GraphQL query text and `variables` object for you, sends it to the HTTP wrapper, and reports the response or errors.
+
+By default the response selects just `{ __typename }` for an object-shaped return type (or nothing at all for a plain scalar). To ask for specific fields, use `--select`, comma-separated and dot-nested for fields on a nested object:
+
+```
+gddy api graphql call postTaxGraphql::query::classification --arg id=<id> --select id,name,rate.percentage
+```
+
+### Finding out what's selectable
+
+`gddy api graphql get <id>` lists the operation's **Return Type** and its **Return Fields** — one level deep. If a field's `Type` column is a plain scalar (`String`, `Int`, `ID`, ...) that's the whole story; if it's something else (e.g. `ClassificationListsConnection`), look that name up to see *its* fields:
+
+```
+gddy api graphql type get <TypeName>
+```
+
+which shows the same kind of field list (or, for an enum, the allowed values) for that type on its own, independent of any operation. Repeat with whatever type name shows up next — `edges` might be a `[SomethingEdge]`, look up `SomethingEdge`, find a `node` field, look up its type, and so on — until every segment of your `--select` path resolves to a real field.
+
+A `mutation` operation is short-circuited under the global `--dry-run` flag the same way any other mutating call is; a `query` operation still runs for real, since there's nothing unsafe to preview.
+
+### Getting the whole schema at once
+
+Drilling one type at a time is the right flow for shaping a specific `--select`. If you want the actual GraphQL specification instead — the real SDL text, not a JSON reconstruction of it — ask for it directly:
+
+```
+gddy api graphql sdl get postTaxGraphql
+```
+
+This prints the `.graphql` schema source. Pass the domain's wrapper operation id (`postTaxGraphql`, `postCatalogGraphql`), not an individual query/mutation id.
+
+Unlike every other command here, this one prints the SDL as plain text.
+
+```
+gddy api graphql sdl get postTaxGraphql > schema.graphql
+```
+
+If you'd rather have a structured, JSON-native dump instead of the raw SDL text — every operation and every type, with full field/arg detail and descriptions, already broken into our summary shape — that's available too:
+
+```
+gddy api operation get postTaxGraphql --output json
+```
+
+The result's `graphql` field has it all: `operations` and `types`. This is the same data `api graphql get`/`api graphql type get` read from, just all at once instead of one hop at a time — useful if you want to script against the JSON shape rather than parse GraphQL SDL yourself.
+
+The wrapper operation itself (`postTaxGraphql`, `postCatalogGraphql`) keeps working exactly as before under the regular REST commands, if you'd rather hand-write the GraphQL query text yourself — `gddy api call postTaxGraphql --body '{"query": "...", "variables": {...}}'` is unaffected by any of the above.
+
 ## Quick reference
 
 | Command | Purpose |
@@ -111,8 +178,12 @@ Before running anything that changes data, preview it with the global `--dry-run
 | `api domain list` | List every API domain |
 | `api operation list --domain <domain>` | List operations in a domain |
 | `api search <query>` | Full-text search across every domain |
-| `api operation get <operationId>` | Full detail for one operation |
-| `api parameter list/get --operation <id>` | An operation's parameters |
-| `api response list/get --operation <id>` | An operation's responses |
+| `api operation get <operationId>` | Full detail for one REST operation |
+| `api parameter list/get --operation <id>` | A REST operation's parameters |
+| `api response list/get --operation <id>` | A REST operation's responses |
 | `api schema get <id>` | Full structure of a schema |
-| `api call <path> --method <method>` | Make an authenticated request |
+| `api call <path> --method <method>` | Make an authenticated REST request |
+| `api graphql get <id>` | Full detail for one GraphQL operation |
+| `api graphql call <id> --arg name=value` | Call a GraphQL operation |
+| `api graphql type get <TypeName>` | Fields/values of a named GraphQL type |
+| `api graphql sdl get <wrapperOperationId>` | The actual GraphQL schema (SDL) text, verbatim |

--- a/rust/src/api_explorer/guides/api-explorer.md
+++ b/rust/src/api_explorer/guides/api-explorer.md
@@ -143,6 +143,8 @@ gddy api graphql type get <TypeName>
 
 which shows the same kind of field list (or, for an enum, the allowed values) for that type on its own, independent of any operation. Repeat with whatever type name shows up next — `edges` might be a `[SomethingEdge]`, look up `SomethingEdge`, find a `node` field, look up its type, and so on — until every segment of your `--select` path resolves to a real field.
 
+A GraphQL type name is only unique within its own domain's schema — two domains can each declare an unrelated type sharing a name (e.g. `ReferenceValueFilter` on both `taxes` and `catalog-products`). When that happens, `api graphql type get <TypeName>` errors out listing every domain that defines it; add `--domain <domain>` to pick one.
+
 A `mutation` operation is short-circuited under the global `--dry-run` flag the same way any other mutating call is; a `query` operation still runs for real, since there's nothing unsafe to preview.
 
 ### Getting the whole schema at once

--- a/rust/src/api_explorer/guides/api-explorer.md
+++ b/rust/src/api_explorer/guides/api-explorer.md
@@ -169,7 +169,7 @@ gddy api operation get postTaxGraphql --output json
 
 The result's `graphql` field has it all: `operations` and `types`. This is the same data `api graphql get`/`api graphql type get` read from, just all at once instead of one hop at a time — useful if you want to script against the JSON shape rather than parse GraphQL SDL yourself.
 
-The wrapper operation itself (`postTaxGraphql`, `postCatalogGraphql`) keeps working exactly as before under the regular REST commands, if you'd rather hand-write the GraphQL query text yourself — `gddy api call postTaxGraphql --body '{"query": "...", "variables": {...}}'` is unaffected by any of the above.
+The wrapper operation itself (`postTaxGraphql`, `postCatalogGraphql`) keeps working exactly as before under the regular REST commands, if you'd rather hand-write the GraphQL query text yourself. `api call` takes a concrete path, not an operationId — grab it from `fullPath` in `api operation get postTaxGraphql`'s output — so it looks like `gddy api call /v2/commerce/stores/<storeId>/tax-subgraph --body '{"query": "...", "variables": {...}}'`, unaffected by any of the above.
 
 ## Quick reference
 

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -9,9 +9,14 @@ use serde_json::{Map, Value, json};
 
 /// Split a `--header` value of the form `KEY:VALUE` into trimmed parts.
 /// Splits on the first colon only, so values may themselves contain colons
-/// (e.g. a URL). Returns None when there is no colon.
+/// (e.g. a URL). Returns None when there is no colon or the key is empty
+/// (e.g. `":value"`) — reqwest rejects an empty header name with a less
+/// actionable "invalid header name" error than the caller's own
+/// `expected KEY:VALUE` validation.
 pub(super) fn split_header(raw: &str) -> Option<(&str, &str)> {
-    raw.split_once(':').map(|(k, v)| (k.trim(), v.trim()))
+    let (k, v) = raw.split_once(':')?;
+    let k = k.trim();
+    (!k.is_empty()).then(|| (k, v.trim()))
 }
 
 /// Whether an HTTP method mutates server state, for `--dry-run` gating.
@@ -284,6 +289,12 @@ mod tests {
             Some(("Location", "https://x/y"))
         );
         assert_eq!(split_header("no-colon"), None);
+    }
+
+    #[test]
+    fn split_header_rejects_an_empty_key() {
+        assert_eq!(split_header(":value"), None);
+        assert_eq!(split_header("  :value"), None);
     }
 
     #[test]

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -222,11 +222,12 @@ pub(super) async fn send_and_report(
 
 #[cfg(test)]
 mod tests {
+    use httpmock::MockServer;
     use serde_json::json;
 
     use super::{
         graphql_errors, is_mutating_method, merge_required_scopes, parse_response_body,
-        split_header,
+        send_and_report, split_header,
     };
     use crate::api_explorer::catalog::{catalog, find_endpoint};
 
@@ -322,5 +323,101 @@ mod tests {
         assert!(is_mutating_method("PUT"));
         assert!(is_mutating_method("PATCH"));
         assert!(is_mutating_method("DELETE"));
+    }
+
+    #[tokio::test]
+    async fn send_and_report_surfaces_graphql_errors_from_a_200_response() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/graphql");
+                then.status(200)
+                    .json_body(json!({"data": null, "errors": [{"message": "boom"}]}));
+            })
+            .await;
+
+        let err = send_and_report(
+            &reqwest::Client::new(),
+            reqwest::Method::POST,
+            "POST",
+            &format!("{}/graphql", server.base_url()),
+            "test-token",
+            &[],
+            None,
+            false,
+            true,
+            &[],
+            "postTaxGraphql",
+        )
+        .await
+        .expect_err("a top-level GraphQL errors array must fail even on HTTP 200");
+
+        assert!(err.to_string().contains("GraphQL request returned 1 error"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn send_and_report_reports_missing_scopes_on_403() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/thing");
+                then.status(403);
+            })
+            .await;
+
+        let err = send_and_report(
+            &reqwest::Client::new(),
+            reqwest::Method::GET,
+            "GET",
+            &format!("{}/thing", server.base_url()),
+            "test-token",
+            &[],
+            None,
+            false,
+            false,
+            &v(&["commerce.order:write"]),
+            "getThing",
+        )
+        .await
+        .expect_err("403 with a required scope must fail with a re-login hint");
+
+        let msg = err.to_string();
+        assert!(msg.contains("403 Forbidden"));
+        assert!(msg.contains("commerce.order:write"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn send_and_report_truncates_a_long_non_2xx_body() {
+        let server = MockServer::start_async().await;
+        let long_detail = "x".repeat(10_000);
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/thing");
+                then.status(500).json_body(json!({"detail": long_detail}));
+            })
+            .await;
+
+        let err = send_and_report(
+            &reqwest::Client::new(),
+            reqwest::Method::GET,
+            "GET",
+            &format!("{}/thing", server.base_url()),
+            "test-token",
+            &[],
+            None,
+            false,
+            false,
+            &[],
+            "getThing",
+        )
+        .await
+        .expect_err("a non-2xx status must fail");
+
+        let msg = err.to_string();
+        assert!(msg.len() < 5_000, "expected the body to be truncated");
+        assert!(!msg.contains(&"x".repeat(10_000)));
+        mock.assert_async().await;
     }
 }

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -1,8 +1,11 @@
-//! Small, pure helpers used only by `api call` (see `super::call`): header
-//! parsing, mutating-method detection for `--dry-run` gating, response-body
-//! parsing, GraphQL error extraction, and OAuth scope merging.
+//! Small, pure helpers plus the shared HTTP transport tail used by `api
+//! call` (see `super::call`) and `api graphql call` (see
+//! `super::graphql::call`): header parsing, mutating-method detection for
+//! `--dry-run` gating, response-body parsing, GraphQL error extraction, and
+//! OAuth scope merging.
 
-use serde_json::{Value, json};
+use cli_engine::CommandResult;
+use serde_json::{Map, Value, json};
 
 /// Split a `--header` value of the form `KEY:VALUE` into trimmed parts.
 /// Splits on the first colon only, so values may themselves contain colons
@@ -57,6 +60,159 @@ pub(super) fn merge_required_scopes(
         }
     }
     required
+}
+
+/// Parses repeatable `--header KEY:VALUE` flags into a validated list.
+pub(super) fn parsed_extra_headers(
+    raw: &[String],
+) -> Result<Vec<(String, String)>, cli_engine::CliCoreError> {
+    raw.iter()
+        .map(|h| {
+            split_header(h)
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .ok_or_else(|| {
+                    crate::error::GddyError::validation(format!(
+                        "invalid header '{h}': expected KEY:VALUE"
+                    ))
+                    .into_cli_error()
+                })
+        })
+        .collect()
+}
+
+/// Sends a fully-built request and reports the result as a `CommandResult`
+/// — shared by `call_command`'s raw-path flow and
+/// `graphql::call::call_command`'s synthesized flow, since both need the
+/// same status/GraphQL-error/403/non-2xx handling once the request itself
+/// differs (raw path + user body vs. synthesized GraphQL query + variables).
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn send_and_report(
+    client: &reqwest::Client,
+    parsed_method: reqwest::Method,
+    method: &str,
+    url: &str,
+    token: &str,
+    extra_headers: &[(String, String)],
+    request_body: Option<Value>,
+    include_headers: bool,
+    is_graphql: bool,
+    required: &[String],
+    endpoint: &str,
+) -> Result<CommandResult, cli_engine::CliCoreError> {
+    let mut req = client
+        .request(parsed_method, url)
+        .bearer_auth(token)
+        .header("x-request-id", uuid::Uuid::new_v4().to_string());
+
+    for (key, val) in extra_headers {
+        req = req.header(key, val);
+    }
+
+    if let Some(body) = request_body {
+        req = req.json(&body);
+    }
+
+    let request = req
+        .build()
+        .map_err(|e| crate::error::GddyError::validation(e.to_string()))?;
+    cli_engine::transport::debug_log_reqwest_request(&request);
+    let resp = client
+        .execute(request)
+        .await
+        .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
+
+    let status_code = resp.status();
+    let status_text = status_code.canonical_reason().unwrap_or("").to_owned();
+    let response_headers_raw = resp.headers().clone();
+    let body_bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| crate::error::GddyError::network(e.to_string()))?;
+    cli_engine::transport::debug_log_reqwest_response(
+        status_code,
+        &response_headers_raw,
+        &body_bytes,
+    );
+
+    let status = status_code.as_u16();
+    let response_headers: Option<Map<String, Value>> = if include_headers {
+        Some(
+            response_headers_raw
+                .iter()
+                .filter_map(|(k, v)| v.to_str().ok().map(|s| (k.to_string(), json!(s))))
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    let body: Value = parse_response_body(&body_bytes);
+
+    // GraphQL endpoints return HTTP 200 even on failure, carrying the error
+    // in a top-level `errors` array.
+    if is_graphql && let Some(errors) = graphql_errors(&body) {
+        return Err(crate::error::GddyError::from_graphql(
+            format!(
+                "GraphQL request returned {} error(s):\n{}",
+                errors.len(),
+                serde_json::to_string_pretty(&json!(errors)).unwrap_or_default(),
+            ),
+            "api",
+        )
+        .into());
+    }
+
+    // Scope step-up already ran up front (the token was requested with
+    // `required`). A 403 here means the granted token still lacks a
+    // required scope — surface it with a re-login hint.
+    if status == 403 && !required.is_empty() {
+        // `auth login --scope` is append-style (one value per flag), so
+        // repeat the flag rather than space-joining.
+        let login_hint = required
+            .iter()
+            .map(|s| format!("--scope {s}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        return Err(crate::error::GddyError::auth(format!(
+            "403 Forbidden — the authorized token is missing required scope(s): {}. \
+             Re-run `gddy auth login {login_hint}` and try again.",
+            required.join(", "),
+        ))
+        .with_fix(format!("Run: gddy auth login {login_hint}"))
+        .into());
+    }
+
+    // Any other non-2xx is a failure, not a success envelope. Include the
+    // status line and (truncated) response body so the caller sees the
+    // detail instead of a success result that happens to carry an error
+    // payload.
+    if !(200..300).contains(&status) {
+        let detail: String = serde_json::to_string_pretty(&body)
+            .unwrap_or_else(|_| body.to_string())
+            .chars()
+            .take(4000)
+            .collect();
+        return Err(crate::error::GddyError::from_http(
+            status,
+            format!("{status_text}\n{detail}"),
+            "api",
+        )
+        .into_cli_error());
+    }
+
+    // Identify the call and its outcome in the result envelope.
+    let mut result = json!({
+        "endpoint": endpoint,
+        "method": method,
+        "status": status,
+        "status_text": status_text,
+        "data": body,
+    });
+    if let Some(headers) = response_headers {
+        result["headers"] = Value::Object(headers);
+    }
+
+    Ok(CommandResult::new(result))
 }
 
 #[cfg(test)]

--- a/rust/src/api_explorer/mod.rs
+++ b/rust/src/api_explorer/mod.rs
@@ -5,6 +5,7 @@ use cli_engine::{GroupSpec, Module, RuntimeGroupSpec};
 mod call;
 mod catalog;
 mod domain_cmd;
+mod graphql;
 mod http;
 mod operation;
 mod parameter;
@@ -73,6 +74,7 @@ pub fn module() -> Module {
             ))
             .with_command(schema_cmd::get_command()),
         )
+        .with_group(graphql::group())
         .with_command(search::command())
         .with_command(call::command())
     })

--- a/rust/src/api_explorer/operation.rs
+++ b/rust/src/api_explorer/operation.rs
@@ -9,8 +9,10 @@ use crate::next_action::{next_action, required_value};
 use crate::output_schema::output_schema;
 use crate::summary::Summary;
 
-use super::catalog::catalog;
-use super::catalog::resolve_operation;
+use super::catalog::{
+    catalog, graphql_operation_redirect_error, graphql_sub_endpoint_rows,
+    resolve_graphql_operation, resolve_operation,
+};
 use super::summary::{
     OPERATION_CHILD_LIST_DEFAULT_LIMIT, response_rows, summarize_graphql_schema,
     summarize_parameters,
@@ -25,6 +27,10 @@ output_schema!(ApiDomainEndpoint {
     "summary": "string", optional;
     "scopes": "[]string";
     "graphqlOperations": "number", optional;
+    // Present only on a synthetic row for one addressable GraphQL
+    // query/mutation (`<parentOperationId>::<query|mutation>::<name>`) —
+    // `"query"` or `"mutation"`. Absent for a real REST/wrapper row.
+    "kind": "string", optional;
 });
 
 output_schema!(ApiOperation {
@@ -77,7 +83,7 @@ pub(super) fn list_command() -> RuntimeCommandSpec {
                     .with_fix("Run: gddy api domain list")
                     .into_cli_error()
                 })?;
-            let endpoints: Vec<Value> = domain
+            let mut endpoints: Vec<Value> = domain
                 .endpoints
                 .iter()
                 .map(|ep| {
@@ -91,13 +97,44 @@ pub(super) fn list_command() -> RuntimeCommandSpec {
                     })
                 })
                 .collect();
-            Ok(CommandResult::new(json!(endpoints)).with_next_actions(vec![
+            // Every GraphQL query/mutation field is just as addressable as a
+            // REST operation — surface it as its own row alongside the
+            // wrapper's, tagged with `kind` so the two are easy to tell
+            // apart at a glance.
+            let graphql_wrappers: Vec<&str> = domain
+                .endpoints
+                .iter()
+                .filter(|ep| ep.graphql.is_some())
+                .map(|ep| ep.operation_id.as_str())
+                .collect();
+            for ep in &domain.endpoints {
+                endpoints.extend(graphql_sub_endpoint_rows(None, ep));
+            }
+
+            let mut next_actions = vec![
                 next_action(
                     "api operation get <operation>",
                     "Get full details for an operation",
                 )
                 .with_param("operation", NextActionParam::required()),
-            ]))
+            ];
+            if !graphql_wrappers.is_empty() {
+                next_actions.push(
+                    next_action(
+                        "api graphql get <operation>",
+                        "See a GraphQL operation's own shape (arguments and real return type)",
+                    )
+                    .with_param("operation", NextActionParam::required()),
+                );
+                for wrapper in &graphql_wrappers {
+                    next_actions.push(next_action(
+                        format!("api graphql sdl get {wrapper}"),
+                        format!("See {wrapper}'s actual GraphQL schema (SDL) text, verbatim"),
+                    ));
+                }
+            }
+
+            Ok(CommandResult::new(json!(endpoints)).with_next_actions(next_actions))
         },
     )
 }
@@ -154,6 +191,15 @@ pub(super) fn get_command() -> RuntimeCommandSpec {
             let query = args.operation.as_str();
             let method_filter = args.method.map(|m| m.to_uppercase());
             let catalog = catalog();
+
+            // A GraphQL operation id (`<parent>::<kind>::<name>`) isn't a
+            // valid `operation get` target at all — it has its own
+            // dedicated command (`api graphql get`) with an output shape
+            // that doesn't try to fit GraphQL semantics into REST-operation
+            // columns.
+            if resolve_graphql_operation(catalog, query).is_some() {
+                return Err(graphql_operation_redirect_error(query, "graphql get"));
+            }
 
             // Exact operationId/path/template match (optionally narrowed by
             // --method) first; a miss falls back to fuzzy substring search,
@@ -868,13 +914,16 @@ mod tests {
         let rendered: serde_json::Value =
             serde_json::from_str(&output.rendered).expect("valid json");
         let data = &rendered["data"];
-        assert_eq!(data["graphql"]["operationCount"], json!(149));
+        let operation_count = data["graphql"]["operationCount"]
+            .as_u64()
+            .expect("operationCount is a number");
+        assert!(operation_count > 100, "{operation_count}");
         assert_eq!(
             data["graphql"]["operations"]
                 .as_array()
                 .expect("operations array")
-                .len(),
-            149
+                .len() as u64,
+            operation_count
         );
     }
 }

--- a/rust/src/api_explorer/parameter.rs
+++ b/rust/src/api_explorer/parameter.rs
@@ -8,7 +8,9 @@ use serde_json::json;
 
 use crate::next_action::{next_action, required_value};
 
-use super::catalog::{catalog, resolve_operation};
+use super::catalog::{
+    catalog, graphql_operation_redirect_error, resolve_graphql_operation, resolve_operation,
+};
 use super::summary::{
     OPERATION_CHILD_LIST_DEFAULT_LIMIT, OPERATION_CHILD_LIST_MAX_LIMIT, summarize_parameters,
     to_json,
@@ -47,6 +49,9 @@ pub(super) fn list_command() -> RuntimeCommandSpec {
         |_cred, args: ParameterListArgs| async move {
             let operation = args.operation.as_str();
             let catalog = catalog();
+            if resolve_graphql_operation(catalog, operation).is_some() {
+                return Err(graphql_operation_redirect_error(operation, "graphql get"));
+            }
             let (domain, ep) = resolve_operation(catalog, operation, None)?;
             let all = summarize_parameters(ep, &domain.defs);
             let next_actions = vec![
@@ -91,6 +96,9 @@ pub(super) fn get_command() -> RuntimeCommandSpec {
             let name = args.name.as_str();
             let operation = args.operation.as_str();
             let catalog = catalog();
+            if resolve_graphql_operation(catalog, operation).is_some() {
+                return Err(graphql_operation_redirect_error(operation, "graphql get"));
+            }
             let (domain, ep) = resolve_operation(catalog, operation, None)?;
             let row = summarize_parameters(ep, &domain.defs)
                 .into_iter()

--- a/rust/src/api_explorer/search.rs
+++ b/rust/src/api_explorer/search.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use crate::next_action::next_action;
 use crate::output_schema::output_schema;
 
-use super::catalog::{catalog, search_endpoints};
+use super::catalog::{catalog, graphql_sub_endpoint_rows, search_endpoints};
 
 output_schema!(ApiEndpoint {
     "domain": "string";
@@ -18,6 +18,9 @@ output_schema!(ApiEndpoint {
     "summary": "string", optional;
     "scopes": "[]string";
     "graphqlOperations": "number", optional;
+    // See `ApiDomainEndpoint`'s `kind` field in `operation.rs` — present
+    // only on a synthetic row for one addressable GraphQL query/mutation.
+    "kind": "string", optional;
 });
 
 #[derive(Debug, Clone, clap::Args)]
@@ -50,7 +53,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
             if hits.is_empty() {
                 return Ok(CommandResult::new(json!([])));
             }
-            let results: Vec<Value> = hits
+            let mut results: Vec<Value> = hits
                 .iter()
                 .map(|(domain, ep)| {
                     json!({
@@ -64,13 +67,55 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     })
                 })
                 .collect();
-            Ok(CommandResult::new(json!(results)).with_next_actions(vec![
+            // A matched GraphQL wrapper's own query/mutation fields are
+            // just as addressable as any REST operation — surface whichever
+            // of them also match the search term as their own rows.
+            let query_lower = args.query.to_lowercase();
+            for (domain, ep) in &hits {
+                for row in graphql_sub_endpoint_rows(Some(&domain.name), ep) {
+                    let matches = row
+                        .get("operationId")
+                        .and_then(Value::as_str)
+                        .is_some_and(|s| s.to_lowercase().contains(&query_lower))
+                        || row
+                            .get("summary")
+                            .and_then(Value::as_str)
+                            .is_some_and(|s| s.to_lowercase().contains(&query_lower));
+                    if matches {
+                        results.push(row);
+                    }
+                }
+            }
+
+            let mut next_actions = vec![
                 next_action(
                     "api operation get <operation>",
                     "Get full details for a result",
                 )
                 .with_param("operation", NextActionParam::required()),
-            ]))
+            ];
+            let graphql_wrappers: Vec<&str> = {
+                let mut wrappers: Vec<&str> = results
+                    .iter()
+                    .filter(|r| r.get("kind").is_some())
+                    .filter_map(|r| r.get("operationId").and_then(Value::as_str))
+                    .filter_map(|id| id.split_once("::").map(|(wrapper, _)| wrapper))
+                    .collect();
+                wrappers.sort_unstable();
+                wrappers.dedup();
+                wrappers
+            };
+            if !graphql_wrappers.is_empty() {
+                next_actions.push(
+                    next_action(
+                        "api graphql get <operation>",
+                        "See a GraphQL result's own shape (arguments and real return type)",
+                    )
+                    .with_param("operation", NextActionParam::required()),
+                );
+            }
+
+            Ok(CommandResult::new(json!(results)).with_next_actions(next_actions))
         },
     )
 }

--- a/rust/src/api_explorer/summary.rs
+++ b/rust/src/api_explorer/summary.rs
@@ -279,14 +279,32 @@ pub(super) fn summarize_graphql_schema(graphql: &GraphqlSchema) -> Value {
                 "name": op.name,
                 "kind": op.kind,
                 "returnType": op.return_type,
+                "description": op.description,
                 "deprecated": op.deprecated,
                 "deprecationReason": op.deprecation_reason,
                 "args": op.args.iter().map(|a| json!({
                     "name": a.name,
                     "type": a.arg_type,
                     "required": a.required,
+                    "description": a.description,
                     "defaultValue": a.default_value,
                 })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let types: Vec<Value> = graphql
+        .types
+        .iter()
+        .map(|t| {
+            json!({
+                "name": t.name,
+                "kind": t.kind,
+                "fields": t.fields.iter().map(|f| json!({
+                    "name": f.name,
+                    "type": f.field_type,
+                    "description": f.description,
+                })).collect::<Vec<_>>(),
+                "values": t.values,
             })
         })
         .collect();
@@ -296,6 +314,8 @@ pub(super) fn summarize_graphql_schema(graphql: &GraphqlSchema) -> Value {
         "queryCount": query_count,
         "mutationCount": mutation_count,
         "operations": operations,
+        "typeCount": types.len(),
+        "types": types,
     })
 }
 
@@ -312,6 +332,7 @@ mod tests {
                 name: format!("op{i}"),
                 kind: if i % 2 == 0 { "query" } else { "mutation" }.to_owned(),
                 return_type: "String".to_owned(),
+                description: None,
                 deprecated: false,
                 deprecation_reason: None,
                 args: vec![],
@@ -325,6 +346,8 @@ mod tests {
             schema_ref: "./schema.graphql".to_owned(),
             operation_count: 25,
             operations: make_graphql_operations(25),
+            types: vec![],
+            sdl: String::new(),
         };
         let summary = summarize_graphql_schema(&schema);
         assert_eq!(summary["operationCount"], json!(25));
@@ -348,22 +371,70 @@ mod tests {
                 name: "widgets".to_owned(),
                 kind: "query".to_owned(),
                 return_type: "[Widget]".to_owned(),
+                description: Some("Lists widgets.".to_owned()),
                 deprecated: true,
                 deprecation_reason: Some("use widgetsV2".to_owned()),
                 args: vec![GraphqlArgument {
                     name: "id".to_owned(),
                     arg_type: "String!".to_owned(),
                     required: true,
+                    description: Some("The widget id.".to_owned()),
                     default_value: None,
                 }],
             }],
+            types: vec![],
+            sdl: String::new(),
         };
         let summary = summarize_graphql_schema(&schema);
         assert_eq!(summary["operations"][0]["name"], json!("widgets"));
         assert_eq!(summary["operations"][0]["deprecated"], json!(true));
         assert_eq!(
+            summary["operations"][0]["description"],
+            json!("Lists widgets.")
+        );
+        assert_eq!(
             summary["operations"][0]["args"][0]["type"],
             json!("String!")
         );
+        assert_eq!(
+            summary["operations"][0]["args"][0]["description"],
+            json!("The widget id.")
+        );
+        assert_eq!(summary["typeCount"], json!(0));
+    }
+
+    #[test]
+    fn summarize_graphql_schema_carries_type_detail() {
+        use super::super::catalog::{GraphqlField, GraphqlType};
+
+        let schema = GraphqlSchema {
+            schema_ref: "./schema.graphql".to_owned(),
+            operation_count: 0,
+            operations: vec![],
+            types: vec![
+                GraphqlType {
+                    name: "Widget".to_owned(),
+                    kind: "object".to_owned(),
+                    fields: vec![GraphqlField {
+                        name: "id".to_owned(),
+                        field_type: "ID!".to_owned(),
+                        description: Some("The widget id.".to_owned()),
+                    }],
+                    values: vec![],
+                },
+                GraphqlType {
+                    name: "WidgetStatus".to_owned(),
+                    kind: "enum".to_owned(),
+                    fields: vec![],
+                    values: vec!["ACTIVE".to_owned(), "RETIRED".to_owned()],
+                },
+            ],
+            sdl: "type Widget { id: ID! }".to_owned(),
+        };
+        let summary = summarize_graphql_schema(&schema);
+        assert_eq!(summary["typeCount"], json!(2));
+        assert_eq!(summary["types"][0]["name"], json!("Widget"));
+        assert_eq!(summary["types"][0]["fields"][0]["name"], json!("id"));
+        assert_eq!(summary["types"][1]["values"], json!(["ACTIVE", "RETIRED"]));
     }
 }

--- a/rust/tools/generate-api-catalog/Cargo.toml
+++ b/rust/tools/generate-api-catalog/Cargo.toml
@@ -6,9 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1"
+async-graphql-parser = "7"
+async-graphql-value = "7"
 base64 = "0.22.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-graphql-parser = "0.4"
 indexmap = "2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/tools/generate-api-catalog/src/graphql.rs
+++ b/rust/tools/generate-api-catalog/src/graphql.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, path::Path};
 
 use anyhow::{Context, Result};
+use async_graphql_parser::types::{
+    FieldDefinition, InputValueDefinition, ServiceDocument, TypeKind, TypeSystemDefinition,
+};
+use async_graphql_value::ConstValue;
 use serde::Serialize;
 
 use crate::github::SpecSource;
@@ -10,7 +14,7 @@ use crate::openapi::{CatalogDomain, CatalogEndpoint, CatalogResponse};
 // GraphQL output types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct CatalogGraphqlArgument {
     pub(crate) name: String,
     #[serde(rename = "type")]
@@ -22,7 +26,7 @@ pub(crate) struct CatalogGraphqlArgument {
     pub(crate) default_value: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct CatalogGraphqlOperation {
     pub(crate) name: String,
     pub(crate) kind: String,
@@ -36,13 +40,40 @@ pub(crate) struct CatalogGraphqlOperation {
     pub(crate) args: Vec<CatalogGraphqlArgument>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct CatalogGraphqlField {
+    pub(crate) name: String,
+    #[serde(rename = "type")]
+    pub(crate) field_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+}
+
+/// A named GraphQL object/input/enum type, captured so `api graphql get`/
+/// `api graphql type get` can resolve an operation's return type (or any
+/// nested field's type) into its real field list instead of a bare name.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct CatalogGraphqlType {
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) fields: Vec<CatalogGraphqlField>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
 pub(crate) struct CatalogGraphqlSchema {
     #[serde(rename = "schemaRef")]
     pub(crate) schema_ref: String,
     #[serde(rename = "operationCount")]
     pub(crate) operation_count: usize,
     pub(crate) operations: Vec<CatalogGraphqlOperation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) types: Vec<CatalogGraphqlType>,
+    /// The raw GraphQL SDL source verbatim — see `api graphql sdl get`.
+    #[serde(default)]
+    pub(crate) sdl: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -57,91 +88,95 @@ pub(crate) fn load_graphql_schema(
     let src = std::fs::read_to_string(path)
         .with_context(|| format!("cannot read GraphQL schema {}", path.display()))?;
 
-    let operations = parse_graphql_operations(&src).unwrap_or_else(|e| {
+    let (operations, types) = parse_graphql_document(&src).unwrap_or_else(|e| {
         eprintln!(
             "WARNING: failed to parse GraphQL schema {}: {e}",
             path.display()
         );
-        Vec::new()
+        (Vec::new(), Vec::new())
     });
 
     Ok(CatalogGraphqlSchema {
         schema_ref: schema_ref.to_owned(),
         operation_count: operations.len(),
         operations,
+        types,
+        sdl: src,
     })
 }
 
-fn parse_graphql_operations(source: &str) -> Result<Vec<CatalogGraphqlOperation>> {
-    use graphql_parser::schema::{Definition, TypeDefinition};
-
-    let doc = graphql_parser::parse_schema::<String>(source)
+/// Parses `source` with `async-graphql-parser` — chosen over the older
+/// `graphql-parser` crate specifically because it natively understands
+/// Apollo Federation's `extend schema @link(...)` directive, which several
+/// upstream subgraph schemas use and `graphql-parser` cannot parse at all.
+fn parse_graphql_document(
+    source: &str,
+) -> Result<(Vec<CatalogGraphqlOperation>, Vec<CatalogGraphqlType>)> {
+    let doc: ServiceDocument = async_graphql_parser::parse_schema(source)
         .map_err(|e| anyhow::anyhow!("GraphQL parse error: {e}"))?;
 
     let mut operations: Vec<CatalogGraphqlOperation> = Vec::new();
+    let mut types: Vec<CatalogGraphqlType> = Vec::new();
 
     for def in &doc.definitions {
-        let type_def = match def {
-            Definition::TypeDefinition(td) => td,
-            _ => continue,
+        let TypeSystemDefinition::Type(pos_td) = def else {
+            continue;
         };
-        let obj = match type_def {
-            TypeDefinition::Object(o) => o,
-            _ => continue,
-        };
-        let kind = match obj.name.as_str() {
-            "Query" => "query",
-            "Mutation" => "mutation",
-            _ => continue,
-        };
+        let td = &pos_td.node;
 
-        for field in &obj.fields {
-            let deprecated = field.directives.iter().any(|d| d.name == "deprecated");
-            let deprecation_reason = field
-                .directives
-                .iter()
-                .find(|d| d.name == "deprecated")
-                .and_then(|d| d.arguments.iter().find(|(k, _)| k == "reason"))
-                .and_then(|(_, v)| {
-                    if let graphql_parser::query::Value::String(s) = v {
-                        Some(s.clone())
-                    } else {
-                        None
-                    }
-                });
-
-            let args: Vec<CatalogGraphqlArgument> = field
-                .arguments
-                .iter()
-                .map(|arg| {
-                    let type_str = graphql_type_to_string(&arg.value_type);
-                    let required =
-                        matches!(arg.value_type, graphql_parser::schema::Type::NonNullType(_))
-                            && arg.default_value.is_none();
-                    let default_value = arg.default_value.as_ref().map(|v| format!("{v}"));
-                    CatalogGraphqlArgument {
-                        name: arg.name.clone(),
-                        arg_type: type_str,
-                        required,
-                        description: arg.description.clone(),
-                        default_value,
-                    }
-                })
-                .collect();
-
-            operations.push(CatalogGraphqlOperation {
-                name: field.name.clone(),
-                kind: kind.to_owned(),
-                return_type: graphql_type_to_string(&field.field_type),
-                description: field.description.clone(),
-                deprecated,
-                deprecation_reason,
-                args,
-            });
+        match &td.kind {
+            TypeKind::Object(obj) => match td.name.node.as_str() {
+                "Query" => operations.extend(
+                    obj.fields
+                        .iter()
+                        .map(|f| operation_from_field("query", &f.node)),
+                ),
+                "Mutation" => operations.extend(
+                    obj.fields
+                        .iter()
+                        .map(|f| operation_from_field("mutation", &f.node)),
+                ),
+                name => types.push(CatalogGraphqlType {
+                    name: name.to_owned(),
+                    kind: "object".to_owned(),
+                    fields: obj
+                        .fields
+                        .iter()
+                        .map(|f| field_from_definition(&f.node))
+                        .collect(),
+                    values: Vec::new(),
+                }),
+            },
+            TypeKind::InputObject(io) => types.push(CatalogGraphqlType {
+                name: td.name.node.to_string(),
+                kind: "input".to_owned(),
+                fields: io
+                    .fields
+                    .iter()
+                    .map(|f| input_field_from_definition(&f.node))
+                    .collect(),
+                values: Vec::new(),
+            }),
+            TypeKind::Enum(en) => types.push(CatalogGraphqlType {
+                name: td.name.node.to_string(),
+                kind: "enum".to_owned(),
+                fields: Vec::new(),
+                values: en
+                    .values
+                    .iter()
+                    .map(|v| v.node.value.node.to_string())
+                    .collect(),
+            }),
+            // Interfaces, unions, and scalars aren't modeled by `api
+            // graphql type get` (there's no field/value list to drill
+            // into for a bare scalar, and interface/union member
+            // resolution isn't something a CLI call needs) — skipped.
+            TypeKind::Interface(_) | TypeKind::Union(_) | TypeKind::Scalar => {}
         }
     }
 
-    // Sort: queries before mutations, then alphabetical
+    // Sort: queries before mutations, then alphabetical — matches the
+    // original TypeScript CLI's ordering.
     operations.sort_by(|a, b| {
         if a.kind == b.kind {
             a.name.cmp(&b.name)
@@ -151,21 +186,67 @@ fn parse_graphql_operations(source: &str) -> Result<Vec<CatalogGraphqlOperation>
             std::cmp::Ordering::Greater
         }
     });
+    types.sort_by(|a, b| a.name.cmp(&b.name));
 
-    Ok(operations)
+    Ok((operations, types))
 }
 
-fn graphql_type_to_string<'a, T: graphql_parser::query::Text<'a>>(
-    t: &graphql_parser::schema::Type<'a, T>,
-) -> String
-where
-    T::Value: std::fmt::Display,
-{
-    use graphql_parser::schema::Type;
-    match t {
-        Type::NamedType(name) => name.as_ref().to_string(),
-        Type::NonNullType(inner) => format!("{}!", graphql_type_to_string(inner.as_ref())),
-        Type::ListType(inner) => format!("[{}]", graphql_type_to_string(inner.as_ref())),
+fn operation_from_field(kind: &str, field: &FieldDefinition) -> CatalogGraphqlOperation {
+    let deprecated_directive = field
+        .directives
+        .iter()
+        .find(|d| d.node.name.node.as_str() == "deprecated");
+    let deprecation_reason = deprecated_directive.and_then(|d| {
+        d.node
+            .arguments
+            .iter()
+            .find(|(name, _)| name.node.as_str() == "reason")
+            .and_then(|(_, v)| match &v.node {
+                ConstValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+    });
+
+    let args: Vec<CatalogGraphqlArgument> = field
+        .arguments
+        .iter()
+        .map(|a| {
+            let a = &a.node;
+            let required = !a.ty.node.nullable && a.default_value.is_none();
+            CatalogGraphqlArgument {
+                name: a.name.node.to_string(),
+                arg_type: a.ty.node.to_string(),
+                required,
+                description: a.description.as_ref().map(|d| d.node.clone()),
+                default_value: a.default_value.as_ref().map(|v| v.node.to_string()),
+            }
+        })
+        .collect();
+
+    CatalogGraphqlOperation {
+        name: field.name.node.to_string(),
+        kind: kind.to_owned(),
+        return_type: field.ty.node.to_string(),
+        description: field.description.as_ref().map(|d| d.node.clone()),
+        deprecated: deprecated_directive.is_some(),
+        deprecation_reason,
+        args,
+    }
+}
+
+fn field_from_definition(field: &FieldDefinition) -> CatalogGraphqlField {
+    CatalogGraphqlField {
+        name: field.name.node.to_string(),
+        field_type: field.ty.node.to_string(),
+        description: field.description.as_ref().map(|d| d.node.clone()),
+    }
+}
+
+fn input_field_from_definition(field: &InputValueDefinition) -> CatalogGraphqlField {
+    CatalogGraphqlField {
+        name: field.name.node.to_string(),
+        field_type: field.ty.node.to_string(),
+        description: field.description.as_ref().map(|d| d.node.clone()),
     }
 }
 
@@ -187,6 +268,8 @@ pub(crate) fn synthesize_graphql_domain(
                 schema_ref: "./schema.graphql".to_owned(),
                 operation_count: 0,
                 operations: Vec::new(),
+                types: Vec::new(),
+                sdl: String::new(),
             }
         });
 

--- a/rust/tools/generate-api-catalog/src/openapi.rs
+++ b/rust/tools/generate-api-catalog/src/openapi.rs
@@ -3,9 +3,7 @@ use std::{collections::HashMap, path::Path};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::graphql::{
-    CatalogGraphqlArgument, CatalogGraphqlOperation, CatalogGraphqlSchema, load_graphql_schema,
-};
+use crate::graphql::{CatalogGraphqlSchema, load_graphql_schema};
 
 const HTTP_METHODS: &[&str] = &[
     "get", "post", "put", "patch", "delete", "options", "head", "trace",
@@ -360,67 +358,16 @@ fn process_operation(
             let resolved = spec_dir.join(schema_ref);
             let cache_key = resolved.to_string_lossy().into_owned();
             if let Some(cached) = graphql_cache.get(&cache_key) {
-                // Return a clone with original schema_ref
+                // Return a clone with the original (per-operation) schema_ref
+                // — everything else is identical to the cached parse.
                 Some(CatalogGraphqlSchema {
                     schema_ref: schema_ref.to_owned(),
-                    operation_count: cached.operation_count,
-                    operations: cached
-                        .operations
-                        .iter()
-                        .map(|op| CatalogGraphqlOperation {
-                            name: op.name.clone(),
-                            kind: op.kind.clone(),
-                            return_type: op.return_type.clone(),
-                            description: op.description.clone(),
-                            deprecated: op.deprecated,
-                            deprecation_reason: op.deprecation_reason.clone(),
-                            args: op
-                                .args
-                                .iter()
-                                .map(|a| CatalogGraphqlArgument {
-                                    name: a.name.clone(),
-                                    arg_type: a.arg_type.clone(),
-                                    required: a.required,
-                                    description: a.description.clone(),
-                                    default_value: a.default_value.clone(),
-                                })
-                                .collect(),
-                        })
-                        .collect(),
+                    ..cached.clone()
                 })
             } else {
                 match load_graphql_schema(&resolved, schema_ref, common_types_dir) {
                     Ok(gql) => {
-                        graphql_cache.insert(
-                            cache_key,
-                            CatalogGraphqlSchema {
-                                schema_ref: gql.schema_ref.clone(),
-                                operation_count: gql.operation_count,
-                                operations: gql
-                                    .operations
-                                    .iter()
-                                    .map(|op| CatalogGraphqlOperation {
-                                        name: op.name.clone(),
-                                        kind: op.kind.clone(),
-                                        return_type: op.return_type.clone(),
-                                        description: op.description.clone(),
-                                        deprecated: op.deprecated,
-                                        deprecation_reason: op.deprecation_reason.clone(),
-                                        args: op
-                                            .args
-                                            .iter()
-                                            .map(|a| CatalogGraphqlArgument {
-                                                name: a.name.clone(),
-                                                arg_type: a.arg_type.clone(),
-                                                required: a.required,
-                                                description: a.description.clone(),
-                                                default_value: a.default_value.clone(),
-                                            })
-                                            .collect(),
-                                    })
-                                    .collect(),
-                            },
-                        );
+                        graphql_cache.insert(cache_key, gql.clone());
                         Some(gql)
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary
- Some API domains (e.g. `taxes`, `catalog-products`) are backed by GraphQL rather than plain REST.
- `api operation list --domain <domain>` and `api search` now tag each addressable query/mutation field with a `kind`.
- New `api graphql` command group gives GraphQL operations their own surface: `get`, `call`, `type`, and `sdl` subcommands — since REST-shaped commands (`api operation get`, `api call`) don't fit a GraphQL operation.
- `api operation get`/`api call` redirect to the new group when pointed at a GraphQL operation id.
- Regenerated `catalog-products` and `taxes` API catalog schemas to include GraphQL operation metadata.

### Refined during review
- `--select` on `api graphql call` is now validated as comma/dot-separated GraphQL field names before being concatenated into the synthesized query — an unvalidated value could otherwise inject arbitrary GraphQL syntax into the request.
- A list-typed `--arg` value that isn't valid JSON is now a validation error instead of silently being sent as a JSON string (which the server would reject with a confusing type error).
- `--header KEY:VALUE` now rejects an empty key (e.g. `:value`) up front with the CLI's own validation error, rather than letting reqwest fail later with a less-actionable message.
- Added test coverage for the shared HTTP status/GraphQL-error/403/non-2xx handling in `send_and_report`.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (577 passed)
- [x] `cargo fmt --check`
- [x] `./rust/scripts/check-module-size.sh`
- [x] Verified `--select` injection payloads and empty header keys are rejected with clear validation errors (manual + regression tests)
- [ ] Manual smoke test of `gddy api graphql get/call/type/sdl` against a live GraphQL-backed domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)