### PR TITLE
fix(release): draft releases until assets are attached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,8 +143,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # release-please creates the release as a draft (see
+          # release-please-config.json). A draft is never served as "latest",
+          # so `releases/latest/download/...` keeps resolving to the previous,
+          # fully-populated release until we publish below — closing the window
+          # where the one-liner would 404 on assets (including install.sh
+          # itself) that haven't finished uploading yet.
           TAG="${{ needs.release-please.outputs.tag_name }}"
           if [ -z "$TAG" ]; then
+            # Fallback for the workflow_dispatch publish_only retry path, which
+            # skips release-please and therefore has no tag_name output. Drafts
+            # are included in `gh release list` by default, so this still finds
+            # the pending draft release.
             TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
           fi
           gh release upload "$TAG" \
@@ -154,3 +164,8 @@ jobs:
             install.sh \
             install.ps1 \
             --clobber
+          # Publish only now that every asset is attached. Marking it latest
+          # flips the `releases/latest` pointer atomically to a release that is
+          # already complete. If build/attach fail, the release stays a draft
+          # and is never exposed to users — re-run via the publish_only input.
+          gh release edit "$TAG" --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,18 +143,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # release-please creates the release as a draft (see
-          # release-please-config.json). A draft is never served as "latest",
-          # so `releases/latest/download/...` keeps resolving to the previous,
-          # fully-populated release until we publish below — closing the window
-          # where the one-liner would 404 on assets (including install.sh
-          # itself) that haven't finished uploading yet.
+          # Release is a draft (release-please-config.json) so `latest` never
+          # points at it until every asset is attached — avoids a 404 window.
           TAG="${{ needs.release-please.outputs.tag_name }}"
           if [ -z "$TAG" ]; then
-            # Fallback for the workflow_dispatch publish_only retry path, which
-            # skips release-please and therefore has no tag_name output. Drafts
-            # are included in `gh release list` by default, so this still finds
-            # the pending draft release.
+            # publish_only retry path has no tag_name; drafts are listed here.
             TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
           fi
           gh release upload "$TAG" \
@@ -164,8 +157,5 @@ jobs:
             install.sh \
             install.ps1 \
             --clobber
-          # Publish only now that every asset is attached. Marking it latest
-          # flips the `releases/latest` pointer atomically to a release that is
-          # already complete. If build/attach fail, the release stays a draft
-          # and is never exposed to users — re-run via the publish_only input.
+          # Publish only now assets are complete; stays a draft if build fails.
           gh release edit "$TAG" --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,14 @@ jobs:
           # points at it until every asset is attached — avoids a 404 window.
           TAG="${{ needs.release-please.outputs.tag_name }}"
           if [ -z "$TAG" ]; then
-            # publish_only retry path has no tag_name; drafts are listed here.
-            TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
+            # publish_only retry path has no tag_name: pick the newest *draft*
+            # only (never a published release) and fail fast if none exists.
+            TAG="$(gh release list --limit 30 --json tagName,isDraft \
+              --jq 'map(select(.isDraft)) | .[0].tagName // empty')"
+            if [ -z "$TAG" ]; then
+              echo "No draft release found to publish." >&2
+              exit 1
+            fi
           fi
           gh release upload "$TAG" \
             dist/gddy-*.tar.gz \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
     "rust": {
       "release-type": "rust",
       "component": "gddy",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "draft": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes a race where `curl -fsSL https://github.com/godaddy/cli/releases/latest/download/install.sh | bash` returns **404** during a release.

`release-please` published each GitHub Release as **non-draft immediately** on merge, so `releases/latest/download/…` began redirecting to the new tag *before* the `build` + `attach` jobs finished. For that multi-minute window, every asset URL 404'd — including `install.sh` itself, which the one-liner fetches — so a fresh install could hard-fail. This was hit live during the `v0.2.4` release.

## Fix

- **`release-please-config.json`** — set `"draft": true` on the `rust` package so each Release is created as a draft.
- **`.github/workflows/release.yml`** — after `gh release upload …`, publish with `gh release edit "$TAG" --draft=false --latest`, i.e. only once all assets are attached.

## How draft releases close the race

Per GitHub's docs on [creating a release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release):

> If you're ready to publicize your release, click **Publish release**. To work on the release later, click **Save draft**.

A **draft release is not public and is never served as `latest`** — GitHub only resolves `releases/latest/download/…` to *published* releases. So while the new draft is being built and its assets uploaded, the `latest` pointer keeps resolving to the previous, fully-populated release (a brief "installs previous version", never a 404). Publishing with `--draft=false --latest` then flips the pointer atomically to a release that is already complete.

Fail-safe bonus: if `build`/`attach` fail, the release stays a draft and is never exposed to users. Re-run the upload/publish via the existing `publish_only` `workflow_dispatch` input.

## Test plan

- [x] `release-please-config.json` is valid JSON; `release.yml` parses as YAML.
- [ ] On the next release, confirm the Release appears as **Draft** during `build`, flips to **Latest** only after `attach`, and the install one-liner never 404s mid-release.