### PR TITLE
fix(platform): list apps across all App Registry statuses

### DIFF
--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -9,13 +9,8 @@ const USER_AGENT: &str = concat!("godaddy-cli/", env!("CARGO_PKG_VERSION"));
 ///
 /// The `applications` query defaults to ACTIVE-only when `status` is omitted, so
 /// callers that want every app must pass an explicit `status.in` containing these.
-pub const APPLICATION_STATUSES: &[&str] = &[
-    "ACTIVE",
-    "ARCHIVED",
-    "BLOCKED",
-    "INACTIVE",
-    "VERIFYING",
-];
+pub const APPLICATION_STATUSES: &[&str] =
+    &["ACTIVE", "ARCHIVED", "BLOCKED", "INACTIVE", "VERIFYING"];
 
 /// Builds a reqwest Client with the standard GoDaddy CLI User-Agent.
 pub fn make_http_client() -> Client {

--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -5,6 +5,18 @@ use serde_json::{Value, json};
 const GRAPHQL_PATH: &str = "/v1/apps/app-registry-subgraph";
 const USER_AGENT: &str = concat!("godaddy-cli/", env!("CARGO_PKG_VERSION"));
 
+/// App Registry `ApplicationStatus` enum values (see app-registry-api GraphQL schema).
+///
+/// The `applications` query defaults to ACTIVE-only when `status` is omitted, so
+/// callers that want every app must pass an explicit `status.in` containing these.
+pub const APPLICATION_STATUSES: &[&str] = &[
+    "ACTIVE",
+    "ARCHIVED",
+    "BLOCKED",
+    "INACTIVE",
+    "VERIFYING",
+];
+
 /// Builds a reqwest Client with the standard GoDaddy CLI User-Agent.
 pub fn make_http_client() -> Client {
     Client::builder()
@@ -132,11 +144,18 @@ impl ApplicationClient {
         Ok(payload["data"].clone())
     }
 
+    /// Lists applications across every App Registry status.
+    ///
+    /// Always sends an explicit `status.in` of [`APPLICATION_STATUSES`]. Omitting
+    /// the GraphQL `status` argument is *not* equivalent: the API defaults to
+    /// ACTIVE-only.
     pub async fn list_applications(&self) -> Result<Value, ClientError> {
-        let data = self.query(json!({
-            "query": "query ApplicationsList { applications { edges { node { id label name description status url proxyUrl } } } }"
-        }))
-        .await?;
+        let data = self
+            .query(json!({
+                "query": "query ApplicationsList($status: ApplicationStatusFilter) { applications(status: $status) { edges { node { id label name description status url proxyUrl } } } }",
+                "variables": { "status": { "in": APPLICATION_STATUSES } }
+            }))
+            .await?;
         let nodes: Vec<Value> = data["applications"]["edges"]
             .as_array()
             .map(|edges| {
@@ -408,6 +427,42 @@ mod tests {
         let err = api_url_for_env("definitely-not-a-real-env-xyz")
             .expect_err("unknown env must not resolve");
         assert!(err.to_string().contains("definitely-not-a-real-env-xyz"));
+    }
+
+    #[tokio::test]
+    async fn list_applications_sends_all_app_registry_statuses() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .header("authorization", "Bearer test-token")
+                    .is_true(|req| {
+                        let body = req.body_string();
+                        body.contains("ApplicationsList")
+                            && body.contains(r#""in":["ACTIVE","ARCHIVED","BLOCKED","INACTIVE","VERIFYING"]"#)
+                    });
+                then.status(200).json_body(json!({
+                    "data": {
+                        "applications": {
+                            "edges": [
+                                { "node": { "id": "a1", "name": "active-app", "status": "ACTIVE" } },
+                                { "node": { "id": "a2", "name": "inactive-app", "status": "INACTIVE" } }
+                            ]
+                        }
+                    }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .list_applications()
+            .await
+            .expect("list applications");
+
+        mock.assert_async().await;
+        assert_eq!(data.as_array().expect("array").len(), 2);
+        assert_eq!(data[1]["status"], "INACTIVE");
     }
 
     #[tokio::test]

--- a/rust/src/application/commands/list.rs
+++ b/rust/src/application/commands/list.rs
@@ -12,8 +12,9 @@ pub(super) fn command() -> RuntimeCommandSpec {
         CommandSpec::new("list", "List all applications")
             .with_long(
                 "List all GoDaddy developer-platform applications visible to \
-                the current account. Use `gddy platform app info --name <name>` \
-                to fetch full details for a single application.",
+                the current account, across every App Registry status. Use \
+                `gddy platform app info --name <name>` to fetch full details \
+                for a single application.",
             )
             .with_system("applications")
             .with_tier(Tier::Read)
@@ -49,6 +50,7 @@ mod tests {
     use cli_engine::{Cli, CliConfig, PaginationConfig, Stage};
 
     use super::command;
+    use crate::application::client::APPLICATION_STATUSES;
 
     #[test]
     fn command_opts_into_pagination_with_no_default_and_a_max_limit() {
@@ -58,6 +60,14 @@ mod tests {
                 max_limit: 200,
                 ..Default::default()
             })
+        );
+    }
+
+    #[test]
+    fn application_statuses_match_app_registry_enum() {
+        assert_eq!(
+            APPLICATION_STATUSES,
+            ["ACTIVE", "ARCHIVED", "BLOCKED", "INACTIVE", "VERIFYING"]
         );
     }
 


### PR DESCRIPTION
## Summary
- `gddy platform app list` now sends an explicit App Registry `status.in` for every `ApplicationStatus` (`ACTIVE`, `ARCHIVED`, `BLOCKED`, `INACTIVE`, `VERIFYING`).
- Fixes ACTIVE-only results caused by the API defaulting when `status` is omitted.

## Test plan
- [ ] `cargo test --lib application::commands::list application::client::tests::list_applications`
- [ ] `cargo run -- platform app list --env dev` returns non-ACTIVE apps when present
- [ ] Confirm help text mentions listing across every App Registry status

Jira: [DEVX-837](https://godaddy-corp.atlassian.net/browse/DEVX-837)