### PR TITLE
feat(api-explorer): support `api call` by operation id with parameter substitution

### DIFF
--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -103,8 +103,13 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // via the exact/template `locate_by_path`, or a bare operation id
             // via `resolve_operation`.
             let (matched, mut path) = if endpoint.starts_with('/') {
+                // Catalog paths never carry a query string — strip one off
+                // before matching so a literal path like `/v1/foo?limit=10`
+                // still resolves, while `path` (used for the request URL and
+                // for `existing_query_param_names`) keeps it.
+                let path_only = endpoint.split_once('?').map_or(endpoint, |(p, _)| p);
                 (
-                    locate_by_path(catalog(), endpoint, method)?,
+                    locate_by_path(catalog(), path_only, method)?,
                     endpoint.to_owned(),
                 )
             } else {
@@ -272,6 +277,21 @@ fn partition_call_params(
             ep.parameters
                 .iter()
                 .find(|p| p.get("name").and_then(Value::as_str) == Some(name))
+                .or_else(|| {
+                    // HTTP header names are case-insensitive (RFC 9110), so
+                    // e.g. `--param idempotency-key=...` should still match
+                    // a declared `Idempotency-Key` header/cookie parameter,
+                    // even though path/query names are exact-case.
+                    ep.parameters.iter().find(|p| {
+                        matches!(
+                            p.get("in").and_then(Value::as_str),
+                            Some("header" | "cookie")
+                        ) && p
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .is_some_and(|n| n.eq_ignore_ascii_case(name))
+                    })
+                })
                 .and_then(|p| p.get("in").and_then(Value::as_str))
         });
         match location {
@@ -328,7 +348,9 @@ fn validate_required_params(
                 Some("query") => {
                     parts.query.iter().any(|(n, _)| n == name) || existing_query.contains(&name)
                 }
-                Some("header" | "cookie") => headers.iter().any(|(n, _)| n == name),
+                Some("header" | "cookie") => {
+                    headers.iter().any(|(n, _)| n.eq_ignore_ascii_case(name))
+                }
                 _ => true,
             };
             (!satisfied).then_some(name)
@@ -604,6 +626,45 @@ mod tests {
         );
     }
 
+    /// A literal path with its own `?...` query string still resolves via
+    /// `locate_by_path` (which strips it before matching against templated
+    /// catalog paths) — an unmatched fallback would silently skip
+    /// required-value validation, so this exercises the regression by
+    /// confirming a still-missing required header is still caught.
+    #[tokio::test]
+    async fn call_dry_run_literal_path_with_query_string_still_resolves() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(super::super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "/v3/domains/domain-names/example.com/nameservers?foo=bar",
+                "--method",
+                "PUT",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            output
+                .rendered
+                .contains("missing required --param value(s)"),
+            "{}",
+            output.rendered
+        );
+        assert!(
+            output.rendered.contains("Idempotency-Key"),
+            "{}",
+            output.rendered
+        );
+    }
+
     /// An unmatched literal path has no schema to route `--param` against, so
     /// every value falls through to the body — same permissiveness as
     /// `--field`, and the same thing that happens for an unrecognized
@@ -671,6 +732,31 @@ mod tests {
             vec![("x-trace-id".to_owned(), "t1".to_owned())]
         );
         assert_eq!(parts.body, vec![("note".to_owned(), "hello".to_owned())]);
+    }
+
+    /// HTTP header names are case-insensitive (RFC 9110) — a `--param` with
+    /// different casing than the declared header parameter must still route
+    /// to `header`, not fall through to the body.
+    #[test]
+    fn partition_call_params_routes_a_header_case_insensitively() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "PUT",
+                "path": "/things",
+                "summary": "",
+                "parameters": [
+                    {"name": "Idempotency-Key", "in": "header", "required": true}
+                ]
+            }"#,
+        );
+        let parts = partition_call_params(Some(&ep), &["idempotency-key=abc".to_owned()])
+            .expect("valid args");
+        assert!(parts.body.is_empty(), "must not fall through to the body");
+        assert_eq!(
+            parts.header,
+            vec![("idempotency-key".to_owned(), "abc".to_owned())]
+        );
     }
 
     /// No matched endpoint (e.g. an unmatched literal path) means no
@@ -789,6 +875,27 @@ mod tests {
         let headers = vec![("Idempotency-Key".to_owned(), "abc".to_owned())];
         validate_required_params(&ep, "/things", &PartitionedParams::default(), &headers)
             .expect("Idempotency-Key was supplied via a plain --header flag");
+    }
+
+    /// Header names are case-insensitive (RFC 9110) — a required
+    /// `Idempotency-Key` is satisfied by a differently-cased `--header`
+    /// entry too, not just an exact-case match.
+    #[test]
+    fn validate_required_params_header_satisfied_case_insensitively() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "PUT",
+                "path": "/things",
+                "summary": "",
+                "parameters": [
+                    {"name": "Idempotency-Key", "in": "header", "required": true}
+                ]
+            }"#,
+        );
+        let headers = vec![("idempotency-key".to_owned(), "abc".to_owned())];
+        validate_required_params(&ep, "/things", &PartitionedParams::default(), &headers)
+            .expect("differently-cased header name still satisfies the requirement");
     }
 
     #[test]

--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -10,7 +10,8 @@ use super::catalog::{
     resolve_operation,
 };
 use super::http::{
-    is_mutating_method, merge_required_scopes, parsed_extra_headers, send_and_report, split_kv,
+    encode_path_segment, is_mutating_method, merge_required_scopes, parsed_extra_headers,
+    send_and_report, split_kv,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -368,21 +369,6 @@ fn validate_required_params(
     .into_cli_error())
 }
 
-/// Percent-encodes `value` for safe use as a single, literal path segment —
-/// unlike a bare path percent-encode, `/` and `%` are escaped too (via
-/// `Url::path_segments_mut().push`, which treats its argument as one opaque
-/// segment, never a sub-path), so a `--param` value can't inject an extra
-/// path segment or otherwise corrupt the URL's structure. Uses `url`
-/// (already a dependency) rather than adding `percent-encoding` directly,
-/// since `url` doesn't re-export it publicly.
-fn encode_path_segment(value: &str) -> String {
-    let mut url = url::Url::parse("http://x").expect("valid base URL");
-    url.path_segments_mut()
-        .expect("http URL always has path segments")
-        .push(value);
-    url.path()[1..].to_owned()
-}
-
 /// Appends `query` to `url` as URL-encoded query-string pairs. A no-op (and
 /// no parse attempt) when `query` is empty, so an unmatched/query-param-free
 /// call never risks failing on an otherwise-valid `url`.
@@ -407,8 +393,7 @@ mod tests {
     use cli_engine::{Cli, CliConfig};
 
     use super::{
-        Endpoint, PartitionedParams, append_query, encode_path_segment, partition_call_params,
-        validate_required_params,
+        Endpoint, PartitionedParams, append_query, partition_call_params, validate_required_params,
     };
 
     /// `call` opted into handler-driven `--dry-run` so a GET/HEAD can execute
@@ -912,30 +897,6 @@ mod tests {
         let headers = vec![("idempotency-key".to_owned(), "abc".to_owned())];
         validate_required_params(&ep, "/things", &PartitionedParams::default(), &headers)
             .expect("differently-cased header name still satisfies the requirement");
-    }
-
-    #[test]
-    fn encode_path_segment_passes_through_a_plain_value() {
-        assert_eq!(encode_path_segment("abc123"), "abc123");
-    }
-
-    /// `/` must be escaped (not treated as a segment separator) — otherwise
-    /// a `--param` value could inject an extra path segment into the URL.
-    #[test]
-    fn encode_path_segment_escapes_a_slash() {
-        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
-    }
-
-    /// A literal `%` must itself be escaped, or a crafted value like
-    /// `%2e%2e` could smuggle a pre-encoded traversal sequence through.
-    #[test]
-    fn encode_path_segment_escapes_a_percent() {
-        assert_eq!(encode_path_segment("100%"), "100%25");
-    }
-
-    #[test]
-    fn encode_path_segment_escapes_a_space() {
-        assert_eq!(encode_path_segment("a b"), "a%20b");
     }
 
     #[test]

--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -131,7 +131,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
             // fail even in a dry run, not return a fake preview.
             let parts = partition_call_params(ep_opt, &args.param)?;
             for (name, value) in &parts.path {
-                path = path.replace(&format!("{{{name}}}"), value);
+                path = path.replace(&format!("{{{name}}}"), &encode_path_segment(value));
             }
             let mut extra_headers = parsed_extra_headers(&args.header)?;
             extra_headers.extend(parts.header.iter().cloned());
@@ -368,6 +368,21 @@ fn validate_required_params(
     .into_cli_error())
 }
 
+/// Percent-encodes `value` for safe use as a single, literal path segment —
+/// unlike a bare path percent-encode, `/` and `%` are escaped too (via
+/// `Url::path_segments_mut().push`, which treats its argument as one opaque
+/// segment, never a sub-path), so a `--param` value can't inject an extra
+/// path segment or otherwise corrupt the URL's structure. Uses `url`
+/// (already a dependency) rather than adding `percent-encoding` directly,
+/// since `url` doesn't re-export it publicly.
+fn encode_path_segment(value: &str) -> String {
+    let mut url = url::Url::parse("http://x").expect("valid base URL");
+    url.path_segments_mut()
+        .expect("http URL always has path segments")
+        .push(value);
+    url.path()[1..].to_owned()
+}
+
 /// Appends `query` to `url` as URL-encoded query-string pairs. A no-op (and
 /// no parse attempt) when `query` is empty, so an unmatched/query-param-free
 /// call never risks failing on an otherwise-valid `url`.
@@ -392,7 +407,8 @@ mod tests {
     use cli_engine::{Cli, CliConfig};
 
     use super::{
-        Endpoint, PartitionedParams, append_query, partition_call_params, validate_required_params,
+        Endpoint, PartitionedParams, append_query, encode_path_segment, partition_call_params,
+        validate_required_params,
     };
 
     /// `call` opted into handler-driven `--dry-run` so a GET/HEAD can execute
@@ -896,6 +912,30 @@ mod tests {
         let headers = vec![("idempotency-key".to_owned(), "abc".to_owned())];
         validate_required_params(&ep, "/things", &PartitionedParams::default(), &headers)
             .expect("differently-cased header name still satisfies the requirement");
+    }
+
+    #[test]
+    fn encode_path_segment_passes_through_a_plain_value() {
+        assert_eq!(encode_path_segment("abc123"), "abc123");
+    }
+
+    /// `/` must be escaped (not treated as a segment separator) — otherwise
+    /// a `--param` value could inject an extra path segment into the URL.
+    #[test]
+    fn encode_path_segment_escapes_a_slash() {
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+    }
+
+    /// A literal `%` must itself be escaped, or a crafted value like
+    /// `%2e%2e` could smuggle a pre-encoded traversal sequence through.
+    #[test]
+    fn encode_path_segment_escapes_a_percent() {
+        assert_eq!(encode_path_segment("100%"), "100%25");
+    }
+
+    #[test]
+    fn encode_path_segment_escapes_a_space() {
+        assert_eq!(encode_path_segment("a b"), "a%20b");
     }
 
     #[test]

--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -100,7 +100,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
             })?;
 
             // Locate the (Domain, Endpoint) match, if any — a literal path
-            // via the exact/template `locate_by_path`, or a bare operation id 
+            // via the exact/template `locate_by_path`, or a bare operation id
             // via `resolve_operation`.
             let (matched, mut path) = if endpoint.starts_with('/') {
                 (

--- a/rust/src/api_explorer/call.rs
+++ b/rust/src/api_explorer/call.rs
@@ -2,14 +2,15 @@
 //! the embedded catalog (or an unmatched path, falling back to the generic
 //! gateway host).
 
-use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
+use cli_engine::{CliCoreError, CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
 use serde_json::{Value, json};
 
 use super::catalog::{
-    catalog, find_endpoint, graphql_operation_redirect_error, resolve_graphql_operation,
+    Endpoint, catalog, graphql_operation_redirect_error, locate_by_path, resolve_graphql_operation,
+    resolve_operation,
 };
 use super::http::{
-    is_mutating_method, merge_required_scopes, parsed_extra_headers, send_and_report,
+    is_mutating_method, merge_required_scopes, parsed_extra_headers, send_and_report, split_kv,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -34,6 +35,13 @@ struct CallArgs {
     #[arg(long, short = 'F', value_name = "PATH")]
     file: Option<String>,
 
+    /// Operation parameter (name=value, repeatable) — path, query, header,
+    /// or body value, routed by the resolved operation's declared
+    /// parameter locations (unrecognized names become body fields, like
+    /// --field).
+    #[arg(long, value_name = "NAME=VALUE")]
+    param: Vec<String>,
+
     /// Extra request headers.
     #[arg(long, short = 'H', value_name = "KEY:VALUE")]
     header: Vec<String>,
@@ -54,15 +62,22 @@ pub(super) fn command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_typed_with_context::<CallArgs, _, _, _>(
         CommandSpec::from_args::<CallArgs>("call", "Make an authenticated API request")
             .with_long(
-                "Executes an authenticated HTTP request against any GoDaddy API endpoint. \
-                 Supply the request body as raw JSON (`--body '{...}'`), as individual \
-                 fields (`--field key=value`, repeatable), or from a JSON file \
-                 (`--file body.json`); `--file` takes precedence over `--body`, \
-                 and `--field` values are merged on top of either. Use the global \
-                 `--expr`/`--filter` flags (JMESPath) to extract or filter \
-                 response data, and `--include` to see response headers \
-                 alongside the body. Use `api operation get <operationId>` \
-                 to inspect required parameters and scopes.",
+                "Executes an authenticated HTTP request against any GoDaddy API \
+                endpoint. ENDPOINT may be a literal path (e.g. \
+                /v1/commerce/stores/{storeId}/orders) or an operation id (see \
+                `api operation list --domain <domain>` or `api search`). Once \
+                the endpoint is located, `--param name=value` (repeatable) \
+                supplies its path, query, header, and body values, routed based \
+                on declared parameters; `api operation get <operationId>` shows \
+                which names are required. A value already present in a literal \
+                path (a filled-in placeholder, or an existing ?name=value) \
+                counts as already supplied. Supply the request body as raw JSON \
+                (`--body '{...}'`), as individual fields (`--field key=value`, \
+                repeatable), or from a JSON file (`--file body.json`); `--file` \
+                takes precedence over `--body`, and `--field`/`--param` values are \
+                merged on top of either. Use the global `--expr`/`--filter` \
+                flags (JMESPath) to extract or filter response data, and \
+                `--include` to see response headers alongside the body.",
             )
             .with_system("api")
             .with_tier(Tier::Mutate)
@@ -84,22 +99,39 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     .into_cli_error()
             })?;
 
-            // Validate unconditionally, including under `--dry-run` (same
-            // rationale as the method check above). `find_endpoint` below can
-            // match a raw operationId, but the request URL is always built
-            // from this literal `endpoint` string, not the matched catalog
-            // path — accepting a bare operationId here would silently build
-            // an invalid URL (e.g. `https://.../listFulfillments`).
-            if !endpoint.starts_with('/') {
+            // Locate the (Domain, Endpoint) match, if any — a literal path
+            // via the exact/template `locate_by_path`, or a bare operation id 
+            // via `resolve_operation`.
+            let (matched, mut path) = if endpoint.starts_with('/') {
+                (
+                    locate_by_path(catalog(), endpoint, method)?,
+                    endpoint.to_owned(),
+                )
+            } else {
                 if resolve_graphql_operation(catalog(), endpoint).is_some() {
                     return Err(graphql_operation_redirect_error(endpoint, "graphql call"));
                 }
-                return Err(crate::error::GddyError::validation(format!(
-                    "endpoint must be a URL path starting with '/', or a GraphQL operation id \
-                     (see `api operation list --domain <domain>`), not {endpoint:?} — \
-                     use `api operation get {endpoint}` to find the concrete path or id"
-                ))
-                .into_cli_error());
+                let (domain, ep) = resolve_operation(catalog(), endpoint, None)?;
+                (Some((domain, ep)), ep.path.clone())
+            };
+            let ep_opt = matched.map(|(_, ep)| ep);
+
+            // Process: partition `--param` by the matched endpoint's declared
+            // parameter locations (unmatched -> body, same as --field),
+            // substitute path params, and validate every declared-required
+            // parameter is satisfied — by `--param`, by `--header`, or already
+            // present literally in ENDPOINT. Unconditional, including under
+            // `--dry-run` (same rationale as the method check above): a bad
+            // `--param`/`--header` or an unresolvable/ambiguous locate must
+            // fail even in a dry run, not return a fake preview.
+            let parts = partition_call_params(ep_opt, &args.param)?;
+            for (name, value) in &parts.path {
+                path = path.replace(&format!("{{{name}}}"), value);
+            }
+            let mut extra_headers = parsed_extra_headers(&args.header)?;
+            extra_headers.extend(parts.header.iter().cloned());
+            if let Some(ep) = ep_opt {
+                validate_required_params(ep, &path, &parts, &extra_headers)?;
             }
 
             // `--dry-run` is statically tagged `Tier::Mutate` since the method
@@ -112,15 +144,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
                     "action": "dry-run: would execute",
                     "method": method,
                     "endpoint": endpoint,
+                    "path": path,
                 }))
                 .with_dry_run());
             }
-
-            // Best-effort match against the embedded catalog: a concrete request
-            // path may not match a templated catalog path, in which case scopes
-            // fall back to just --scope and the base URL falls back to the
-            // generic gateway host.
-            let matched = find_endpoint(catalog(), endpoint);
 
             // Required scopes = explicit --scope flags, plus the matched
             // endpoint's declared scopes. These drive OAuth scope step-up at
@@ -138,7 +165,8 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 ),
                 None => crate::application::client::api_url_for_env(&ctx.middleware.env)?,
             };
-            let url = format!("{base_url}{endpoint}");
+            let url = format!("{base_url}{path}");
+            let url = append_query(&url, &parts.query)?;
 
             // Build request body: -F file > -d body, then merge -f fields on top
             let mut request_body: Option<Value> = None;
@@ -164,30 +192,34 @@ pub(super) fn command() -> RuntimeCommandSpec {
             }
 
             let fields = &args.field;
-            if !fields.is_empty() {
+            if !fields.is_empty() || !parts.body.is_empty() {
                 let body = request_body.get_or_insert_with(|| json!({}));
                 for s in fields {
-                    let eq = s.find('=').ok_or_else(|| {
+                    let (key, val) = split_kv(s).ok_or_else(|| {
                         crate::error::GddyError::validation(format!(
                             "invalid field format '{s}': expected key=value"
                         ))
                         .into_cli_error()
                     })?;
-                    let key = s[..eq].to_owned();
-                    let val = s[eq + 1..].to_owned();
                     if let Some(obj) = body.as_object_mut() {
-                        obj.insert(key, json!(val));
+                        obj.insert(key.to_owned(), json!(val));
+                    }
+                }
+                // `--param` body values are merged on top of `--field`, so a
+                // repeated key resolves in `--param`'s favor.
+                for (key, val) in &parts.body {
+                    if let Some(obj) = body.as_object_mut() {
+                        obj.insert(key.clone(), json!(val));
                     }
                 }
             }
 
             let client = crate::application::client::make_http_client();
-            let extra_headers = parsed_extra_headers(&args.header)?;
 
             // GraphQL endpoints return HTTP 200 even on failure, carrying the error
             // in a top-level `errors` array. Detect the GraphQL commerce surfaces by
             // path and surface those errors instead of reporting a false success.
-            let is_graphql = endpoint.contains("graphql") || endpoint.contains("subgraph");
+            let is_graphql = path.contains("graphql") || path.contains("subgraph");
 
             send_and_report(
                 &client,
@@ -207,9 +239,139 @@ pub(super) fn command() -> RuntimeCommandSpec {
     )
 }
 
+/// `--param name=value` pairs partitioned by where they belong in the request,
+/// per the resolved operation's declared parameters.
+#[derive(Debug, Default, PartialEq)]
+struct PartitionedParams {
+    path: Vec<(String, String)>,
+    query: Vec<(String, String)>,
+    header: Vec<(String, String)>,
+    body: Vec<(String, String)>,
+}
+
+/// Parses `--param NAME=VALUE` and routes each by `ep`'s declared parameter
+/// locations — mode-agnostic: `ep` is `None` for an unmatched literal path,
+/// in which case every value becomes a body field, same as `--field`. A
+/// name matching nothing declared also becomes a body field — REST
+/// `requestBody` properties aren't enumerated the way `ep.parameters` is, so
+/// (like `--field`) there's no reliable way to distinguish "body field" from
+/// "typo" by name alone.
+fn partition_call_params(
+    ep: Option<&Endpoint>,
+    param: &[String],
+) -> Result<PartitionedParams, CliCoreError> {
+    let mut parts = PartitionedParams::default();
+    for raw in param {
+        let (name, value) = split_kv(raw).ok_or_else(|| {
+            crate::error::GddyError::validation(format!(
+                "invalid --param '{raw}': expected name=value"
+            ))
+            .into_cli_error()
+        })?;
+        let location = ep.and_then(|ep| {
+            ep.parameters
+                .iter()
+                .find(|p| p.get("name").and_then(Value::as_str) == Some(name))
+                .and_then(|p| p.get("in").and_then(Value::as_str))
+        });
+        match location {
+            Some("path") => parts.path.push((name.to_owned(), value.to_owned())),
+            Some("query") => parts.query.push((name.to_owned(), value.to_owned())),
+            Some("header" | "cookie") => parts.header.push((name.to_owned(), value.to_owned())),
+            _ => parts.body.push((name.to_owned(), value.to_owned())),
+        }
+    }
+    Ok(parts)
+}
+
+/// Query parameter names already present in a literal path's own `?...`
+/// suffix (e.g. `/v1/foo?limit=10`) — the literal-path analog of a path
+/// template's `{name}` placeholder already being filled in with a concrete
+/// value: the caller has already supplied it, so required-value validation
+/// shouldn't ask for it again via `--param`.
+fn existing_query_param_names(path: &str) -> Vec<&str> {
+    let Some((_, query)) = path.split_once('?') else {
+        return Vec::new();
+    };
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| pair.split('=').next().unwrap_or(pair))
+        .collect()
+}
+
+/// Every parameter `ep` declares required (any location) must be satisfied
+/// by something — a routed `--param` value; for `path`, its `{name}`
+/// placeholder no longer being present in `path` (substituted by `--param`,
+/// or the caller already passed a literal path with the value filled in);
+/// for `query`, the name already present in `path`'s own `?...` suffix; for
+/// `header`/`cookie`, a matching entry in `headers` (from `--header` or a
+/// routed `--param`). Batches every unsatisfied name into one error, mirroring
+/// `build_graphql_call`'s missing-required check (`graphql/call.rs`). Body
+/// location isn't enforced — same as `--field` never validating the body
+/// against a schema.
+fn validate_required_params(
+    ep: &Endpoint,
+    path: &str,
+    parts: &PartitionedParams,
+    headers: &[(String, String)],
+) -> Result<(), CliCoreError> {
+    let existing_query = existing_query_param_names(path);
+    let missing: Vec<&str> = ep
+        .parameters
+        .iter()
+        .filter(|p| p.get("required").and_then(Value::as_bool).unwrap_or(false))
+        .filter_map(|p| {
+            let name = p.get("name").and_then(Value::as_str)?;
+            let satisfied = match p.get("in").and_then(Value::as_str) {
+                Some("path") => !path.contains(&format!("{{{name}}}")),
+                Some("query") => {
+                    parts.query.iter().any(|(n, _)| n == name) || existing_query.contains(&name)
+                }
+                Some("header" | "cookie") => headers.iter().any(|(n, _)| n == name),
+                _ => true,
+            };
+            (!satisfied).then_some(name)
+        })
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(crate::error::GddyError::validation(format!(
+        "missing required --param value(s) for {}: {}",
+        ep.operation_id,
+        missing.join(", "),
+    ))
+    .with_fix(format!("Run: gddy api operation get {}", ep.operation_id))
+    .into_cli_error())
+}
+
+/// Appends `query` to `url` as URL-encoded query-string pairs. A no-op (and
+/// no parse attempt) when `query` is empty, so an unmatched/query-param-free
+/// call never risks failing on an otherwise-valid `url`.
+fn append_query(url: &str, query: &[(String, String)]) -> Result<String, CliCoreError> {
+    if query.is_empty() {
+        return Ok(url.to_owned());
+    }
+    let mut parsed = url::Url::parse(url).map_err(|e| {
+        crate::error::GddyError::validation(format!("invalid URL '{url}': {e}")).into_cli_error()
+    })?;
+    {
+        let mut qp = parsed.query_pairs_mut();
+        for (k, v) in query {
+            qp.append_pair(k, v);
+        }
+    }
+    Ok(parsed.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use cli_engine::{Cli, CliConfig};
+
+    use super::{
+        Endpoint, PartitionedParams, append_query, partition_call_params, validate_required_params,
+    };
 
     /// `call` opted into handler-driven `--dry-run` so a GET/HEAD can execute
     /// for real under `--dry-run` — but it still requires `Required` auth
@@ -302,12 +464,11 @@ mod tests {
         );
     }
 
-    /// A bare operationId (no leading '/') must be rejected rather than
-    /// silently built into an invalid request URL — `find_endpoint` can match
-    /// it for scope lookup, but the URL is always built from the literal
-    /// `endpoint` string, not the matched catalog path.
+    /// A bare operation id with no catalog match must be rejected with a
+    /// clear not-found error from `resolve_operation`, not silently built
+    /// into an invalid request URL.
     #[tokio::test]
-    async fn call_rejects_an_endpoint_without_a_leading_slash() {
+    async fn call_rejects_an_unresolvable_operation_id() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
                 .with_module(super::super::module()),
@@ -317,7 +478,7 @@ mod tests {
                 "gddy",
                 "api",
                 "call",
-                "listFulfillments",
+                "totallyMadeUpOperationId",
                 "--dry-run",
                 "--output",
                 "json",
@@ -325,9 +486,329 @@ mod tests {
             .await;
         assert_ne!(output.exit_code, 0, "{}", output.rendered);
         assert!(
-            output.rendered.contains("must be a URL path starting with"),
+            output.rendered.contains("no operation found matching"),
             "{}",
             output.rendered
         );
+    }
+
+    /// A bare operation id resolves via `resolve_operation`, substituting
+    /// its declared path and header parameters from `--param` — exercised via
+    /// a mutating method so it's safe to run under `--dry-run` without a
+    /// token, and the preview reports the resolved concrete path.
+    #[tokio::test]
+    async fn call_dry_run_resolves_operation_id_and_substitutes_params() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(super::super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "updateNameservers",
+                "--method",
+                "PUT",
+                "--param",
+                "domain-name=example.com",
+                "--param",
+                "Idempotency-Key=11111111-1111-1111-1111-111111111111",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        let rendered: serde_json::Value =
+            serde_json::from_str(&output.rendered).expect("valid json");
+        assert_eq!(
+            rendered["data"]["path"], "/v3/domains/domain-names/example.com/nameservers",
+            "{}",
+            output.rendered
+        );
+    }
+
+    /// Missing a required `--param` for a resolved operation id (here a
+    /// required header, not a path param) is a validation error naming it,
+    /// not a live request attempt.
+    #[tokio::test]
+    async fn call_rejects_a_resolved_operation_missing_a_required_param() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(super::super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "updateNameservers",
+                "--method",
+                "PUT",
+                "--param",
+                "domain-name=example.com",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_ne!(output.exit_code, 0, "{}", output.rendered);
+        assert!(
+            output
+                .rendered
+                .contains("missing required --param value(s)"),
+            "{}",
+            output.rendered
+        );
+        assert!(
+            output.rendered.contains("Idempotency-Key"),
+            "{}",
+            output.rendered
+        );
+    }
+
+    /// A literal path processes identically to the same operation located
+    /// by id: it resolves via `locate_by_path`, the header `--param` routes
+    /// the same way, and the preview reports the same resolved `path` —
+    /// except the path parameter needs no `--param` at all, since the literal
+    /// path already has it filled in.
+    #[tokio::test]
+    async fn call_dry_run_literal_path_processes_the_same_as_operation_id() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(super::super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "/v3/domains/domain-names/example.com/nameservers",
+                "--method",
+                "PUT",
+                "--param",
+                "Idempotency-Key=11111111-1111-1111-1111-111111111111",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+        let rendered: serde_json::Value =
+            serde_json::from_str(&output.rendered).expect("valid json");
+        assert_eq!(
+            rendered["data"]["path"], "/v3/domains/domain-names/example.com/nameservers",
+            "{}",
+            output.rendered
+        );
+    }
+
+    /// An unmatched literal path has no schema to route `--param` against, so
+    /// every value falls through to the body — same permissiveness as
+    /// `--field`, and the same thing that happens for an unrecognized
+    /// `--param` name on a matched endpoint.
+    #[tokio::test]
+    async fn call_dry_run_unmatched_literal_path_param_falls_through_to_body() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_module(super::super::module()),
+        );
+        let output = cli
+            .run([
+                "gddy",
+                "api",
+                "call",
+                "/v1/totally/unmatched/path",
+                "--method",
+                "POST",
+                "--param",
+                "note=hello",
+                "--dry-run",
+                "--output",
+                "json",
+            ])
+            .await;
+        assert_eq!(output.exit_code, 0, "{}", output.rendered);
+    }
+
+    fn endpoint_fixture(json: &str) -> Endpoint {
+        serde_json::from_str(json).expect("valid endpoint fixture")
+    }
+
+    #[test]
+    fn partition_call_params_routes_by_declared_location() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "POST",
+                "path": "/things/{thingId}",
+                "summary": "",
+                "parameters": [
+                    {"name": "thingId", "in": "path", "required": true},
+                    {"name": "filter", "in": "query", "required": false},
+                    {"name": "x-trace-id", "in": "header", "required": false}
+                ]
+            }"#,
+        );
+        let parts = partition_call_params(
+            Some(&ep),
+            &[
+                "thingId=abc".to_owned(),
+                "filter=active".to_owned(),
+                "x-trace-id=t1".to_owned(),
+                "note=hello".to_owned(),
+            ],
+        )
+        .expect("valid args");
+        assert_eq!(parts.path, vec![("thingId".to_owned(), "abc".to_owned())]);
+        assert_eq!(
+            parts.query,
+            vec![("filter".to_owned(), "active".to_owned())]
+        );
+        assert_eq!(
+            parts.header,
+            vec![("x-trace-id".to_owned(), "t1".to_owned())]
+        );
+        assert_eq!(parts.body, vec![("note".to_owned(), "hello".to_owned())]);
+    }
+
+    /// No matched endpoint (e.g. an unmatched literal path) means no
+    /// declared parameters to route against — every `--param` falls through
+    /// to the body, same permissiveness as `--field`.
+    #[test]
+    fn partition_call_params_with_no_endpoint_routes_everything_to_body() {
+        let parts =
+            partition_call_params(None, &["a=1".to_owned(), "b=2".to_owned()]).expect("valid args");
+        assert!(parts.path.is_empty());
+        assert!(parts.query.is_empty());
+        assert!(parts.header.is_empty());
+        assert_eq!(
+            parts.body,
+            vec![
+                ("a".to_owned(), "1".to_owned()),
+                ("b".to_owned(), "2".to_owned())
+            ]
+        );
+    }
+
+    #[test]
+    fn partition_call_params_rejects_a_malformed_pair() {
+        let ep = endpoint_fixture(
+            r#"{"operationId": "testOp", "method": "GET", "path": "/things", "summary": ""}"#,
+        );
+        let err = partition_call_params(Some(&ep), &["no-equals-sign".to_owned()])
+            .expect_err("must reject a value with no '='");
+        assert!(err.to_string().contains("expected name=value"), "{err}");
+    }
+
+    #[test]
+    fn validate_required_params_batches_every_missing_name() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "POST",
+                "path": "/things/{thingId}",
+                "summary": "",
+                "parameters": [
+                    {"name": "thingId", "in": "path", "required": true},
+                    {"name": "x-trace-id", "in": "header", "required": true}
+                ]
+            }"#,
+        );
+        let err =
+            validate_required_params(&ep, &ep.path.clone(), &PartitionedParams::default(), &[])
+                .expect_err("both required params are missing");
+        let msg = err.to_string();
+        assert!(msg.contains("thingId"), "{msg}");
+        assert!(msg.contains("x-trace-id"), "{msg}");
+    }
+
+    /// A literal path that already has a required path param's value
+    /// filled in (no `{name}` placeholder left) satisfies it without any
+    /// `--param` — the literal-path analog of substituting one in.
+    #[test]
+    fn validate_required_params_path_satisfied_by_an_already_filled_in_literal_path() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "PUT",
+                "path": "/things/{thingId}",
+                "summary": "",
+                "parameters": [
+                    {"name": "thingId", "in": "path", "required": true}
+                ]
+            }"#,
+        );
+        validate_required_params(&ep, "/things/abc123", &PartitionedParams::default(), &[])
+            .expect("thingId's placeholder is already filled in, no --param needed");
+    }
+
+    /// A required query param already present in a literal path's own
+    /// `?...` suffix satisfies it without `--param` — otherwise a caller who
+    /// already fully specifies their own query string would be newly
+    /// rejected by validation that didn't exist before `--param` did.
+    #[test]
+    fn validate_required_params_query_satisfied_by_an_existing_query_string() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "GET",
+                "path": "/things",
+                "summary": "",
+                "parameters": [
+                    {"name": "filter", "in": "query", "required": true}
+                ]
+            }"#,
+        );
+        validate_required_params(
+            &ep,
+            "/things?filter=active",
+            &PartitionedParams::default(),
+            &[],
+        )
+        .expect("filter is already present in the literal path's query string");
+    }
+
+    /// A required header satisfied by a plain `--header` flag (not routed
+    /// through `--param`) counts — `headers` is the merged `--header` +
+    /// `--param`-routed-header list, so either channel satisfies it.
+    #[test]
+    fn validate_required_params_header_satisfied_by_a_header_flag() {
+        let ep = endpoint_fixture(
+            r#"{
+                "operationId": "testOp",
+                "method": "PUT",
+                "path": "/things",
+                "summary": "",
+                "parameters": [
+                    {"name": "Idempotency-Key", "in": "header", "required": true}
+                ]
+            }"#,
+        );
+        let headers = vec![("Idempotency-Key".to_owned(), "abc".to_owned())];
+        validate_required_params(&ep, "/things", &PartitionedParams::default(), &headers)
+            .expect("Idempotency-Key was supplied via a plain --header flag");
+    }
+
+    #[test]
+    fn append_query_is_a_no_op_for_no_query_params() {
+        assert_eq!(
+            append_query("https://example.com/foo", &[]).expect("no-op"),
+            "https://example.com/foo"
+        );
+    }
+
+    #[test]
+    fn append_query_encodes_multiple_pairs() {
+        let url = append_query(
+            "https://example.com/foo",
+            &[
+                ("a".to_owned(), "1".to_owned()),
+                ("b".to_owned(), "hello world".to_owned()),
+            ],
+        )
+        .expect("valid url");
+        assert_eq!(url, "https://example.com/foo?a=1&b=hello+world");
     }
 }

--- a/rust/src/api_explorer/catalog.rs
+++ b/rust/src/api_explorer/catalog.rs
@@ -230,6 +230,7 @@ fn path_matches_template(template: &str, concrete: &str) -> bool {
             })
 }
 
+#[cfg(test)]
 pub(super) fn find_endpoint<'a>(
     catalog: &'a [Domain],
     query: &str,
@@ -342,6 +343,28 @@ pub(super) fn resolve_operation<'a>(
             }
         }
         _ => Err(ambiguous_operation_error(query, &exact_hits)),
+    }
+}
+
+/// Locates a literal request path against the catalog — the literal-path
+/// counterpart to `resolve_operation`'s operation-id resolution, built on
+/// the same exact/template `find_endpoint_exact` (never `find_endpoint`'s
+/// looser substring `contains` fallback, which can match the wrong
+/// endpoint). Unlike `resolve_operation`, zero hits is not an error: a
+/// literal path may legitimately target an endpoint the embedded catalog
+/// doesn't know about, and `api call` falls back to the generic gateway
+/// host for that case. More than one hit (the same path+method template
+/// declared in two domain specs) is ambiguous, same as `resolve_operation`.
+pub(super) fn locate_by_path<'a>(
+    catalog: &'a [Domain],
+    path: &str,
+    method: &str,
+) -> Result<Option<(&'a Domain, &'a Endpoint)>, CliCoreError> {
+    let hits = find_endpoint_exact(catalog, path, Some(method));
+    match hits.len() {
+        0 => Ok(None),
+        1 => Ok(Some(hits[0])),
+        _ => Err(ambiguous_operation_error(path, &hits)),
     }
 }
 
@@ -573,7 +596,7 @@ pub(super) fn graphql_valid_arg_names(g: &GraphqlOpRef<'_>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{catalog, find_endpoint};
+    use super::{Domain, catalog, find_endpoint, locate_by_path};
 
     /// `catalog()` sorts once so every listing (`api domain list`, `api
     /// search`, `api operation get`) sees the same stable, alphabetical order.
@@ -633,5 +656,71 @@ mod tests {
                 .any(|(_, ep)| ep.operation_id == "postCatalogGraphql"),
             "expected a GraphQL operation name to surface its parent endpoint in search results"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // locate_by_path — the literal-path counterpart to resolve_operation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn locate_by_path_matches_a_concrete_path_against_its_template() {
+        let (domain, ep) = locate_by_path(catalog(), "/stores/abc123/fulfillments", "GET")
+            .expect("no ambiguity")
+            .expect("concrete path matches the templated catalog path");
+        assert_eq!(domain.name, "fulfillments");
+        assert_eq!(ep.operation_id, "listFulfillments");
+    }
+
+    #[test]
+    fn locate_by_path_filters_by_method() {
+        assert!(
+            locate_by_path(catalog(), "/stores/abc123/fulfillments", "DELETE")
+                .expect("no ambiguity")
+                .is_none(),
+            "listFulfillments is GET-only, so a DELETE must not match it"
+        );
+    }
+
+    #[test]
+    fn locate_by_path_returns_none_for_no_catalog_match() {
+        assert!(
+            locate_by_path(catalog(), "/totally/not/a/real/path", "GET")
+                .expect("no ambiguity")
+                .is_none()
+        );
+    }
+
+    fn two_domains_sharing_one_path(path: &str, method: &str) -> Vec<Domain> {
+        let json = format!(
+            r#"[
+                {{
+                    "name": "domain-a",
+                    "title": "",
+                    "description": "",
+                    "baseUrl": "https://a.example.com",
+                    "endpoints": [
+                        {{"operationId": "opA", "method": "{method}", "path": "{path}", "summary": ""}}
+                    ]
+                }},
+                {{
+                    "name": "domain-b",
+                    "title": "",
+                    "description": "",
+                    "baseUrl": "https://b.example.com",
+                    "endpoints": [
+                        {{"operationId": "opB", "method": "{method}", "path": "{path}", "summary": ""}}
+                    ]
+                }}
+            ]"#
+        );
+        serde_json::from_str(&json).expect("valid domain fixture")
+    }
+
+    #[test]
+    fn locate_by_path_errors_on_an_ambiguous_match() {
+        let domains = two_domains_sharing_one_path("/things/{thingId}", "GET");
+        let err = locate_by_path(&domains, "/things/abc", "GET")
+            .expect_err("the same path+method template in two domains is ambiguous");
+        assert!(err.to_string().contains("matches 2 operations"), "{err}");
     }
 }

--- a/rust/src/api_explorer/graphql/call.rs
+++ b/rust/src/api_explorer/graphql/call.rs
@@ -7,7 +7,9 @@ use super::super::catalog::{
     GraphqlOpRef, catalog, graphql_base_type_name, graphql_operation_id,
     graphql_operation_not_found_error, graphql_valid_arg_names, resolve_graphql_operation,
 };
-use super::super::http::{merge_required_scopes, parsed_extra_headers, send_and_report};
+use super::super::http::{
+    encode_path_segment, merge_required_scopes, parsed_extra_headers, send_and_report,
+};
 
 #[derive(Debug, Clone, clap::Args)]
 struct GraphqlCallArgs {
@@ -208,7 +210,7 @@ fn build_graphql_call(
             .and_then(|p| p.get("in").and_then(Value::as_str))
             .unwrap_or("query");
         match location {
-            "path" => path = path.replace(&format!("{{{name}}}"), value),
+            "path" => path = path.replace(&format!("{{{name}}}"), &encode_path_segment(value)),
             "header" => extra_headers.push((name.clone(), value.clone())),
             _ => {}
         }
@@ -548,6 +550,44 @@ mod tests {
         assert!(
             !built.path.contains('{'),
             "path params substituted: {}",
+            built.path
+        );
+    }
+
+    /// A wrapper path-parameter value containing `/` must be
+    /// percent-encoded (via the shared `encode_path_segment`), not spliced
+    /// in raw — a raw splice would let the value inject an extra path
+    /// segment into the URL.
+    #[test]
+    fn build_graphql_call_percent_encodes_a_slash_in_a_path_param_value() {
+        let id = a_query_id();
+        let g = resolve_graphql_operation(catalog(), &id).expect("id resolves");
+        let path_param_name = g
+            .parent
+            .parameters
+            .iter()
+            .find(|p| p.get("in").and_then(serde_json::Value::as_str) == Some("path"))
+            .and_then(|p| p.get("name").and_then(serde_json::Value::as_str))
+            .expect("postTaxGraphql has a path parameter (storeId)")
+            .to_owned();
+        let mut args = graphql_call_args_with(&id, vec![], Some("__typename"));
+        for p in &g.parent.parameters {
+            if let Some(name) = p.get("name").and_then(serde_json::Value::as_str) {
+                let value = if name == path_param_name {
+                    "a/b"
+                } else {
+                    "placeholder"
+                };
+                args.arg.push(format!("{name}={value}"));
+            }
+        }
+        for a in &g.op.args {
+            args.arg.push(format!("{}=placeholder", a.name));
+        }
+        let built = build_graphql_call(&g, &args).expect("builds without error");
+        assert!(
+            built.path.contains("a%2Fb"),
+            "path param value must be percent-encoded: {}",
             built.path
         );
     }

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -19,6 +19,12 @@ pub(super) fn split_header(raw: &str) -> Option<(&str, &str)> {
     (!k.is_empty()).then(|| (k, v.trim()))
 }
 
+/// Split a `NAME=VALUE` value on the first `=`. Shared by `--field` and
+/// `--arg` parsing; callers attach their own flag-specific error message.
+pub(super) fn split_kv(raw: &str) -> Option<(&str, &str)> {
+    raw.split_once('=')
+}
+
 /// Whether an HTTP method mutates server state, for `--dry-run` gating.
 /// `call`'s tier is fixed at spec-build time, but the method is a runtime
 /// arg — this decides per-invocation whether `--dry-run` should actually

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -25,6 +25,24 @@ pub(super) fn split_kv(raw: &str) -> Option<(&str, &str)> {
     raw.split_once('=')
 }
 
+/// Percent-encodes `value` for safe use as a single, literal path segment —
+/// unlike a bare path percent-encode, `/` and `%` are escaped too (via
+/// `Url::path_segments_mut().push`, which treats its argument as one opaque
+/// segment, never a sub-path), so a substituted path-parameter value can't
+/// inject an extra path segment or otherwise corrupt the URL's structure.
+/// Shared by `call`'s `--param` path substitution and `graphql::call`'s
+/// wrapper path substitution — both splice a caller-supplied value into a
+/// `{name}` placeholder in a path template. Uses `url` (already a
+/// dependency) rather than adding `percent-encoding` directly, since `url`
+/// doesn't re-export it publicly.
+pub(super) fn encode_path_segment(value: &str) -> String {
+    let mut url = url::Url::parse("http://x").expect("valid base URL");
+    url.path_segments_mut()
+        .expect("http URL always has path segments")
+        .push(value);
+    url.path()[1..].to_owned()
+}
+
 /// Whether an HTTP method mutates server state, for `--dry-run` gating.
 /// `call`'s tier is fixed at spec-build time, but the method is a runtime
 /// arg — this decides per-invocation whether `--dry-run` should actually
@@ -232,8 +250,8 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        graphql_errors, is_mutating_method, merge_required_scopes, parse_response_body,
-        send_and_report, split_header,
+        encode_path_segment, graphql_errors, is_mutating_method, merge_required_scopes,
+        parse_response_body, send_and_report, split_header,
     };
     use crate::api_explorer::catalog::{catalog, find_endpoint};
 
@@ -302,6 +320,31 @@ mod tests {
     fn split_header_rejects_an_empty_key() {
         assert_eq!(split_header(":value"), None);
         assert_eq!(split_header("  :value"), None);
+    }
+
+    #[test]
+    fn encode_path_segment_passes_through_a_plain_value() {
+        assert_eq!(encode_path_segment("abc123"), "abc123");
+    }
+
+    /// `/` must be escaped (not treated as a segment separator) — otherwise
+    /// a substituted path-parameter value could inject an extra path
+    /// segment into the URL.
+    #[test]
+    fn encode_path_segment_escapes_a_slash() {
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+    }
+
+    /// A literal `%` must itself be escaped, or a crafted value like
+    /// `%2e%2e` could smuggle a pre-encoded traversal sequence through.
+    #[test]
+    fn encode_path_segment_escapes_a_percent() {
+        assert_eq!(encode_path_segment("100%"), "100%25");
+    }
+
+    #[test]
+    fn encode_path_segment_escapes_a_space() {
+        assert_eq!(encode_path_segment("a b"), "a%20b");
     }
 
     #[test]

--- a/rust/src/api_explorer/http.rs
+++ b/rust/src/api_explorer/http.rs
@@ -20,7 +20,7 @@ pub(super) fn split_header(raw: &str) -> Option<(&str, &str)> {
 }
 
 /// Split a `NAME=VALUE` value on the first `=`. Shared by `--field` and
-/// `--arg` parsing; callers attach their own flag-specific error message.
+/// `--param` parsing; callers attach their own flag-specific error message.
 pub(super) fn split_kv(raw: &str) -> Option<(&str, &str)> {
     raw.split_once('=')
 }


### PR DESCRIPTION
## Summary
- `api call <operationId>` now resolves via the same catalog lookup `api operation get` uses, instead of requiring a literal, concrete request path.
- `--param name=value` (repeatable) supplies path, query, header, and body values, routed automatically by the resolved endpoint's declared parameters — unrecognized names fall through to the body, same as `--field`.
- Locating an endpoint (literal path vs. operation id) and processing the request (routing `--param`, substituting the path, validating required values) are now separate steps, so both forms behave identically once located — including treating a value already present in a literal path (a filled-in placeholder, or an existing `?name=value`) as already supplied.
- `find_endpoint`'s loose substring-`contains` matching is no longer used by `api call`'s production path (replaced by the stricter `find_endpoint_exact`-based `locate_by_path`, mirroring `resolve_operation`'s ambiguity handling); it's kept `#[cfg(test)]`-only since several existing tests still use it as a fixture lookup.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (607 passed)
- [x] `cargo fmt --check`
- [x] `./scripts/check-module-size.sh`
- [x] Manual dry-run smoke tests confirming an operation-id call and the equivalent literal-path call resolve to the identical `path` and produce identical missing-required-parameter errors

Closes DEVEX-1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)