### PR TITLE
fix(platform): remove direct application status updates (DEVX-927)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_application_promotes_to_active() {
+    async fn update_application_sends_non_lifecycle_fields() {
         let server = MockServer::start_async().await;
         let mock = server
             .mock_async(|when, then| {
@@ -523,21 +523,22 @@ mod tests {
                     .path("/v1/apps/app-registry-subgraph")
                     .is_true(|req| {
                         let body = req.body_string();
-                        body.contains("updateApplication") && body.contains(r#""status":"ACTIVE""#)
+                        body.contains("updateApplication")
+                            && body.contains(r#""label":"Updated app""#)
                     });
                 then.status(200).json_body(json!({
-                    "data": { "updateApplication": { "id": "app-1", "status": "ACTIVE" } }
+                    "data": { "updateApplication": { "id": "app-1", "label": "Updated app" } }
                 }));
             })
             .await;
 
         let data = ApplicationClient::new(server.base_url(), "test-token")
-            .update_application("app-1", json!({ "status": "ACTIVE" }))
+            .update_application("app-1", json!({ "label": "Updated app" }))
             .await
             .expect("update application");
 
         mock.assert_async().await;
-        assert_eq!(data["updateApplication"]["status"], "ACTIVE");
+        assert_eq!(data["updateApplication"]["label"], "Updated app");
     }
 
     // httpmock can't sequence responses, so retries are verified by hit count

--- a/rust/src/application/commands/deploy/mod.rs
+++ b/rust/src/application/commands/deploy/mod.rs
@@ -83,7 +83,7 @@ fn deploy_result_event(
             "applicationId": application_id,
             "releaseId": release_id,
             "extensions": extensions,
-            "status": "ACTIVE",
+            "releaseStatus": "ACTIVE",
         },
         "next_actions": deploy_next_actions(name),
     })
@@ -254,8 +254,8 @@ pub(super) fn command() -> RuntimeCommandSpec {
     )
 }
 
-/// Finalize a deploy: activate the release, then promote the application to
-/// `ACTIVE`. Deploy must activate the release before promoting the application.
+/// Finalize a deploy by activating the release. Do not follow activation with
+/// an `updateApplication` status mutation.
 async fn finalize_deploy_activation(
     client: &ApplicationClient,
     sender: &StreamSender,
@@ -272,17 +272,6 @@ async fn finalize_deploy_activation(
     sender
         .send(json!({ "type": "step", "name": "release.activate", "status": "completed" }))
         .await;
-    sender
-        .send(json!({ "type": "step", "name": "application.activate", "status": "started" }))
-        .await;
-    client
-        .update_application(application_id, json!({ "status": "ACTIVE" }))
-        .await
-        .map_err(super::client_err)?;
-    sender
-        .send(json!({ "type": "step", "name": "application.activate", "status": "completed" }))
-        .await;
-
     Ok(())
 }
 
@@ -375,7 +364,7 @@ mod tests {
         assert_eq!(event["result"]["applicationId"], "app-123");
         assert_eq!(event["result"]["releaseId"], "rel-456");
         assert_eq!(event["result"]["extensions"], 2);
-        assert_eq!(event["result"]["status"], "ACTIVE");
+        assert_eq!(event["result"]["releaseStatus"], "ACTIVE");
         assert_eq!(
             event["next_actions"].as_array().map(|a| a.len()),
             Some(3),

--- a/rust/src/application/commands/info.rs
+++ b/rust/src/application/commands/info.rs
@@ -45,17 +45,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 )
                 .with_param("name", required_value(&name)),
                 next_action(
-                    "platform app update --id <id> [--label <label>] [--description <description>] [--status <status>]",
+                    "platform app update --id <id> [--label <label>] [--description <description>]",
                     "Update application configuration",
                 )
-                .with_param("id", required_value(&app_id))
-                .with_param(
-                    "status",
-                    NextActionParam {
-                        r#enum: vec!["ACTIVE".to_owned(), "INACTIVE".to_owned()],
-                        ..Default::default()
-                    },
-                ),
+                .with_param("id", required_value(&app_id)),
                 next_action(
                     "platform app release --application-id <application-id> --version <version>",
                     "Create a release",

--- a/rust/src/application/commands/update.rs
+++ b/rust/src/application/commands/update.rs
@@ -1,4 +1,4 @@
-//! `gddy platform app update` — update label, description, or status.
+//! `gddy platform app update` — update label or description.
 
 use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, Tier};
 use serde_json::json;
@@ -10,7 +10,7 @@ use crate::scopes::{APP_REGISTRY_READ, APP_REGISTRY_WRITE};
 /// "At least one of" fields for `update`, flattened into [`UpdateArgs`].
 ///
 /// Kept as its own derive struct (rather than inline fields on `UpdateArgs`)
-/// so the struct-level `#[group(...)]` only covers these three — `id` stays
+/// so the struct-level `#[group(...)]` only covers these two — `id` stays
 /// outside the group and independently required. See the flatten caveat on
 /// `CommandSpec::from_args`: a struct can't both flatten a field and declare
 /// its own enforced group.
@@ -24,10 +24,6 @@ struct UpdateFields {
     /// New description.
     #[arg(long, value_name = "TEXT")]
     description: Option<String>,
-
-    /// Application status (ACTIVE or INACTIVE).
-    #[arg(long, value_name = "STATUS", value_parser = ["ACTIVE", "INACTIVE"])]
-    status: Option<String>,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -44,9 +40,9 @@ pub(super) fn command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_typed_with_context::<UpdateArgs, _, _, _>(
         CommandSpec::from_args::<UpdateArgs>("update", "Update an application")
             .with_long(
-                "Update the label, description, or status of a GoDaddy \
+                "Update the label or description of a GoDaddy \
                 developer-platform application by its ID. At least one of \
-                --label, --description, or --status must be provided. Use \
+                --label or --description must be provided. Use \
                 `gddy platform app info --name <name>` to retrieve the \
                 application ID.",
             )
@@ -61,9 +57,6 @@ pub(super) fn command() -> RuntimeCommandSpec {
             }
             if let Some(description) = args.fields.description {
                 input.insert("description".to_owned(), json!(description));
-            }
-            if let Some(status) = args.fields.status {
-                input.insert("status".to_owned(), json!(status));
             }
             let client = super::make_client(&context).await?;
             let data = client
@@ -99,26 +92,11 @@ mod tests {
     }
 
     #[test]
-    fn status_rejects_values_outside_active_inactive() {
-        for bad in ["active", "DISABLED", "PENDING"] {
-            let err = update_clap_command()
-                .try_get_matches_from(["update", "--id", "app-1", "--status", bad])
-                .expect_err("invalid --status should be rejected");
-            assert_eq!(
-                err.kind(),
-                clap::error::ErrorKind::InvalidValue,
-                "--status {bad:?} should fail possible-value validation, got: {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn status_accepts_active_and_inactive() {
-        for good in ["ACTIVE", "INACTIVE"] {
-            update_clap_command()
-                .try_get_matches_from(["update", "--id", "app-1", "--status", good])
-                .expect("ACTIVE|INACTIVE --status should be accepted");
-        }
+    fn status_is_an_unsupported_argument() {
+        let err = update_clap_command()
+            .try_get_matches_from(["update", "--id", "app-1", "--status", "ACTIVE"])
+            .expect_err("--status must not be accepted by app update");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
@@ -141,9 +119,6 @@ mod tests {
         update_clap_command()
             .try_get_matches_from(["update", "--id", "app-1", "--description", "Desc"])
             .expect("--description alone should be accepted");
-        update_clap_command()
-            .try_get_matches_from(["update", "--id", "app-1", "--status", "ACTIVE"])
-            .expect("--status alone should be accepted");
     }
 
     #[test]
@@ -157,8 +132,6 @@ mod tests {
                 "New",
                 "--description",
                 "Desc",
-                "--status",
-                "INACTIVE",
             ])
             .expect("multiple update fields should be allowed together");
     }


### PR DESCRIPTION
## Summary
- remove `--status` from `gddy platform app update` and its suggested next action
- reject the removed flag as an unsupported argument
- stop deploy from sending a direct `updateApplication` status mutation after release activation
- report the activated release status rather than claiming an application-status update

## Verification
- `cargo fmt --check`
- `cargo test application::commands::update` (4 passed)

Refs: DEVX-927