### PR TITLE
feat(cli): right-align numeric table columns

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -500,9 +500,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713a9330b7c1a2529c5e7fb4aa8fda5eb5db6b4f39bec63085ec62e9f60d970d"
+checksum = "ef786368f0cb17f02cbd81b751c05db1a81b430c675b6ca732d3e09c9c47011c"
 dependencies = [
  "async-trait",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.8.4" }
+cli-engine = { features = ["pkce-auth"], version = "0.8.6" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"

--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -1,6 +1,6 @@
 //! `dns add` — append new DNS records to a domain without touching existing ones.
 
-use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
+use cli_engine::{Alignment, CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
 use serde_json::{Value, json};
 
 use crate::domain::make_client;
@@ -85,8 +85,8 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("domain", "Domain"),
         TableColumn::new("type", "Type"),
         TableColumn::new("name", "Name"),
-        TableColumn::new("created", "Created"),
-        TableColumn::new("failed", "Failed"),
+        TableColumn::new("created", "Created").align(Alignment::Right),
+        TableColumn::new("failed", "Failed").align(Alignment::Right),
         TableColumn::new("results", "Results").nested(vec![
             TableColumn::new("data", "Data"),
             TableColumn::new("status", "Status"),

--- a/rust/src/dns/delete.rs
+++ b/rust/src/dns/delete.rs
@@ -1,6 +1,6 @@
 //! `dns delete` — remove all records matching a type+name from a domain.
 
-use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
+use cli_engine::{Alignment, CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
 use serde_json::{Value, json};
 
 use crate::domain::{api_error, make_client};
@@ -135,8 +135,8 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("domain", "Domain"),
         TableColumn::new("type", "Type"),
         TableColumn::new("name", "Name"),
-        TableColumn::new("deleted", "Deleted"),
-        TableColumn::new("failed", "Failed"),
+        TableColumn::new("deleted", "Deleted").align(Alignment::Right),
+        TableColumn::new("failed", "Failed").align(Alignment::Right),
         TableColumn::new("action", "Action"),
         TableColumn::new("records", "Records").nested(vec![
             TableColumn::new("recordId", "Record ID"),

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -1,6 +1,6 @@
 //! `dns set` — replace every record for a type+name pair (destructive).
 
-use cli_engine::{CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
+use cli_engine::{Alignment, CommandResult, CommandSpec, RuntimeCommandSpec, TableColumn, Tier};
 
 use crate::domain::{api_error, make_client};
 use crate::output_schema::output_schema;
@@ -49,9 +49,9 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("domain", "Domain"),
         TableColumn::new("type", "Type"),
         TableColumn::new("name", "Name"),
-        TableColumn::new("replaced", "Replaced"),
-        TableColumn::new("created", "Created"),
-        TableColumn::new("deleted", "Deleted"),
+        TableColumn::new("replaced", "Replaced").align(Alignment::Right),
+        TableColumn::new("created", "Created").align(Alignment::Right),
+        TableColumn::new("deleted", "Deleted").align(Alignment::Right),
         TableColumn::new("action", "Action"),
         TableColumn::new("plan", "Plan").nested(vec![
             TableColumn::new("action", "Action"),

--- a/rust/src/domain/available.rs
+++ b/rust/src/domain/available.rs
@@ -1,7 +1,7 @@
 //! `gddy domain available` — check whether a domain can be registered (v3).
 
 use cli_engine::{
-    CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+    Alignment, CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
 };
 use serde_json::json;
 
@@ -33,9 +33,9 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("currency", "Currency"),
         TableColumn::new("terms", "Terms").nested(vec![
             TableColumn::new("periodLabel", "Period"),
-            TableColumn::new("price", "Price"),
-            TableColumn::new("firstTermPrice", "First-Term Price"),
-            TableColumn::new("renewalPrice", "Renewal Price"),
+            TableColumn::new("price", "Price").align(Alignment::Right),
+            TableColumn::new("firstTermPrice", "First-Term Price").align(Alignment::Right),
+            TableColumn::new("renewalPrice", "Renewal Price").align(Alignment::Right),
         ]),
     ]
 }

--- a/rust/src/domain/quote.rs
+++ b/rust/src/domain/quote.rs
@@ -1,8 +1,8 @@
 //! `gddy domain quote` — price a registration, lock a quote, cache it (v3).
 
 use cli_engine::{
-    CliCoreError, CommandResult, CommandSpec, NextActionParam, Result, RuntimeCommandSpec,
-    TableColumn, Tier,
+    Alignment, CliCoreError, CommandResult, CommandSpec, NextActionParam, Result,
+    RuntimeCommandSpec, TableColumn, Tier,
 };
 use serde_json::json;
 
@@ -250,8 +250,8 @@ fn view_columns() -> Vec<TableColumn> {
     vec![
         TableColumn::new("domain", "Domain"),
         TableColumn::new("available", "Available"),
-        TableColumn::new("price", "Price"),
-        TableColumn::new("renewalPrice", "Renewal Price"),
+        TableColumn::new("price", "Price").align(Alignment::Right),
+        TableColumn::new("renewalPrice", "Renewal Price").align(Alignment::Right),
         TableColumn::new("currency", "Currency"),
         TableColumn::new("periodLabel", "Period"),
         TableColumn::new("quoteToken", "Quote Token").no_truncate(true),
@@ -260,7 +260,7 @@ fn view_columns() -> Vec<TableColumn> {
         TableColumn::new("inventory", "Inventory"),
         TableColumn::new("fees", "Fees").nested(vec![
             TableColumn::new("type", "Type"),
-            TableColumn::new("amount", "Amount"),
+            TableColumn::new("amount", "Amount").align(Alignment::Right),
             TableColumn::new("currency", "Currency"),
         ]),
         TableColumn::new("agreements", "Agreements"),

--- a/rust/src/domain/suggest.rs
+++ b/rust/src/domain/suggest.rs
@@ -1,6 +1,8 @@
 //! `gddy domain suggest` — suggest available domains for a query (v3).
 
-use cli_engine::{CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, Tier};
+use cli_engine::{
+    Alignment, CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+};
 use serde_json::json;
 
 use domains_client::types;
@@ -30,6 +32,22 @@ output_schema!(DomainSuggestResult {
 /// anyway, since `0`/negative simply means "unset".
 fn nonzero(n: i64) -> Option<std::num::NonZeroU64> {
     u64::try_from(n).ok().and_then(std::num::NonZeroU64::new)
+}
+
+/// `price1Year`/`price2Year` and their renewal counterparts are formatted
+/// currency strings (see `format_money`), not JSON numbers, so cli-engine's
+/// auto-alignment for no-view columns doesn't apply to them — they're
+/// right-aligned explicitly here instead so decimal points line up across
+/// rows of differently-priced suggestions.
+fn view_columns() -> Vec<TableColumn> {
+    vec![
+        TableColumn::new("domain", "Domain"),
+        TableColumn::new("price1Year", "1yr Price").align(Alignment::Right),
+        TableColumn::new("renewalPrice1Year", "1yr Renewal").align(Alignment::Right),
+        TableColumn::new("price2Year", "2yr Price").align(Alignment::Right),
+        TableColumn::new("renewalPrice2Year", "2yr Renewal").align(Alignment::Right),
+        TableColumn::new("currency", "Currency"),
+    ]
 }
 
 /// Build the JSON view of a single suggestion, flattening its 1- and 2-year
@@ -126,6 +144,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
             .with_tier(Tier::Read)
             .with_default_fields("domain,price1Year,renewalPrice1Year,currency")
             .with_output_schema::<DomainSuggestResult>()
+            .with_view(view_columns())
             .with_scopes(&[DOMAINS_READ]),
         |ctx, args: SuggestArgs| async move {
             let query = args.query;


### PR DESCRIPTION
## Summary
- Bumps `cli-engine` to 0.8.6, which adds `TableColumn::align(Alignment::Right)` and auto-right-aligns numeric columns for commands with no explicit view (e.g. `api domain list`'s `endpoints` count, `api search`/`api operation list`'s `graphqlOperations` count now line up with no gddy code changes needed).
- Right-aligns price/count columns in gddy's own explicit views:
  - `domain available`/`domain quote`: price columns, including the nested `terms` (per-registration-term pricing) and `fees` (premium domain surcharge) tables
  - `domain suggest`: added a new explicit view (it had none before) so its per-term prices right-align — this is the command where ragged decimal points were actually visible to users today
  - `dns add`/`dns delete`/`dns set`: record counts (`created`/`failed`/`deleted`/`replaced`)

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (660 passing)
- [x] `cargo fmt --check`
- [x] `./scripts/check-module-size.sh`
- [x] Manually verified rendered output for `domain available`, `domain suggest`, `api domain list` — prices/counts line up on the decimal/least-significant digit

🤖 Generated with [Claude Code](https://claude.com/claude-code)