### PR TITLE
feat(platform): promote namespace to GA

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -132,9 +132,9 @@ mod tests {
 
     /// Regression test for a real bug found while wiring feature-flagging up
     /// properly: with no `min_stage` override anywhere, cli-engine's own
-    /// default (`Stage::Ga`) hides `hosting` and the Developer Platform
-    /// namespace entirely. Guards that the *global* default stays `Ga` per
-    /// product decision — i.e. these stay hidden absent an environment override.
+    /// default (`Stage::Ga`) hides `hosting`. Guards that the *global* default
+    /// stays `Ga` per product decision — i.e. beta and experimental modules
+    /// stay hidden absent an environment override.
     #[tokio::test]
     async fn beta_and_experimental_modules_stay_hidden_at_the_default_min_stage() {
         let cli = Cli::new(
@@ -151,16 +151,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn platform_namespace_is_hidden_at_the_default_min_stage() {
+    async fn platform_namespace_is_visible_at_the_default_min_stage() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
                 .with_min_stage(Stage::Ga)
                 .with_modules(super::all_modules()),
         );
         let output = cli.run(["gddy", "platform", "--help"]).await;
-        assert_ne!(
+        assert_eq!(
             output.exit_code, 0,
-            "platform should stay hidden at the Ga default: {}",
+            "platform should be visible at the Ga default: {}",
             output.rendered
         );
     }
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn platform_guides_are_discoverable_even_when_the_namespace_is_hidden() {
+    async fn platform_guides_are_discoverable() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
                 .with_min_stage(Stage::Ga)
@@ -223,7 +223,7 @@ mod tests {
     async fn platform_namespace_exposes_the_gpa_command_tree() {
         let cli = Cli::new(
             CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
-                .with_min_stage(Stage::Experimental)
+                .with_min_stage(Stage::Ga)
                 .with_modules(super::all_modules()),
         );
 

--- a/rust/src/platform/mod.rs
+++ b/rust/src/platform/mod.rs
@@ -4,18 +4,16 @@
 //! catalog, and webhook implementations retain their existing handlers and
 //! clients, while `platform` provides their unambiguous common CLI path.
 
-use cli_engine::{GroupSpec, Module, RuntimeGroupSpec, Stage};
+use cli_engine::{GroupSpec, Module, RuntimeGroupSpec};
 
 pub fn module() -> Module {
     Module::new("Platform", |_ctx| {
         RuntimeGroupSpec::new(
-            GroupSpec::new("platform", "Build and manage GoDaddy Platform integrations")
-                .with_long(
-                    "Build integrations for the GoDaddy Developer Platform. Manage your app, \
+            GroupSpec::new("platform", "Build and manage GoDaddy Platform integrations").with_long(
+                "Build integrations for the GoDaddy Developer Platform. Manage your app, \
                      browse action contracts, and inspect webhook event types from one \
                      namespace. Use `gddy platform app init` to create an app.",
-                )
-                .with_feature_flag("platform", Stage::Experimental),
+            ),
         )
         .with_group(crate::application::group())
         .with_group(crate::actions_catalog::group())


### PR DESCRIPTION
## Summary
- remove the Experimental feature flag from the `platform` command group
- expose platform app, actions, and webhook commands at the default GA stage
- update platform visibility and command-tree tests

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test` (693 passed)
- `./scripts/check-module-size.sh`
- `cargo run --quiet -- platform --help`

> Note: `cargo clippy -- -D warnings` currently fails on main at `rust/src/config/settings_form.rs:275` (`clippy::collapsible-match`), which is outside this PR.