### PR TITLE
fix: omit null settings presentation fields

### DIFF
--- a/rust/src/application/commands/release.rs
+++ b/rust/src/application/commands/release.rs
@@ -390,6 +390,18 @@ mod tests {
             entry.get("iconName").is_none(),
             "absent icon should be omitted"
         );
+        assert!(
+            entry["presentation"]["sections"][0]
+                .get("visibleWhen")
+                .is_none(),
+            "absent section visibility should be omitted instead of serialized as null"
+        );
+        assert!(
+            entry["presentation"]["sections"][0]["fields"][0]
+                .get("description")
+                .is_none(),
+            "absent field properties should be omitted instead of serialized as null"
+        );
     }
 
     #[test]

--- a/rust/src/application/commands/release.rs
+++ b/rust/src/application/commands/release.rs
@@ -361,6 +361,44 @@ mod tests {
         }
     }
 
+    fn list_group_presentation() -> crate::config::settings_form::SettingsFormV1Presentation {
+        use crate::config::settings_form::{
+            ChoiceOption, ListGroupItem, SelectValue, SettingsFormV1Field, SettingsFormV1Section,
+        };
+        crate::config::settings_form::SettingsFormV1Presentation {
+            sections: vec![SettingsFormV1Section {
+                key: "rules".to_owned(),
+                label: "Rules".to_owned(),
+                description: None,
+                visible_when: None,
+                fields: vec![SettingsFormV1Field::ListGroup {
+                    key: "rules".to_owned(),
+                    label: "Rules".to_owned(),
+                    description: None,
+                    required: false,
+                    min_items: None,
+                    max_items: None,
+                    item: ListGroupItem {
+                        id_field: "id".to_owned(),
+                        title_field: None,
+                        fields: vec![SettingsFormV1Field::Select {
+                            key: "country".to_owned(),
+                            label: "Country".to_owned(),
+                            description: None,
+                            required: true,
+                            options: vec![ChoiceOption {
+                                value: SelectValue::Str("US".to_owned()),
+                                label: "United States".to_owned(),
+                                description: None,
+                            }],
+                            default_value: None,
+                        }],
+                    },
+                }],
+            }],
+        }
+    }
+
     #[test]
     fn setting_entry_rejects_missing_presentation() {
         let err = super::setting_entry(&placement_only_setting(), std::path::Path::new(""))
@@ -425,6 +463,30 @@ mod tests {
         assert_eq!(entry["iconName"], "percent");
         assert_eq!(entry["iconLibrary"], "lucide");
         assert_eq!(entry["metadata"]["provider"], "godaddy-tax");
+    }
+
+    #[test]
+    fn setting_entry_omits_absent_list_group_and_choice_option_fields() {
+        let mut setting = placement_only_setting();
+        setting.presentation = Some(list_group_presentation());
+
+        let entry = super::setting_entry(&setting, std::path::Path::new(""))
+            .expect("list-group entry builds");
+        let list_group = &entry["presentation"]["sections"][0]["fields"][0];
+        assert!(
+            list_group.get("minItems").is_none(),
+            "absent list-group bounds should be omitted instead of serialized as null"
+        );
+        assert!(
+            list_group["item"].get("titleField").is_none(),
+            "absent list-group item properties should be omitted instead of serialized as null"
+        );
+
+        let option = &list_group["item"]["fields"][0]["options"][0];
+        assert!(
+            option.get("description").is_none(),
+            "absent choice-option properties should be omitted instead of serialized as null"
+        );
     }
 
     #[test]

--- a/rust/src/config/settings_form.rs
+++ b/rust/src/config/settings_form.rs
@@ -16,9 +16,9 @@ pub struct SettingsFormV1Presentation {
 pub struct SettingsFormV1Section {
     pub key: String,
     pub label: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_when: Option<SettingsFormV1VisibilityCondition>,
     pub fields: Vec<SettingsFormV1Field>,
 }
@@ -36,105 +36,105 @@ pub enum SettingsFormV1Field {
     Text {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         min_length: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         max_length: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<String>,
     },
     #[serde(rename = "textarea", rename_all = "camelCase")]
     Textarea {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         min_length: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         max_length: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<String>,
     },
     #[serde(rename = "number", rename_all = "camelCase")]
     Number {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         min: Option<f64>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         max: Option<f64>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         step: Option<f64>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         suffix: Option<String>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<f64>,
     },
     #[serde(rename = "boolean", rename_all = "camelCase")]
     Boolean {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<bool>,
     },
     #[serde(rename = "select", rename_all = "camelCase")]
     Select {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
         options: Vec<ChoiceOption>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<SelectValue>,
     },
     #[serde(rename = "multi-select", rename_all = "camelCase")]
     MultiSelect {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
         options: Vec<ChoiceOption>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         min_items: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         max_items: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         default_value: Option<Vec<SelectValue>>,
     },
     #[serde(rename = "list-group", rename_all = "camelCase")]
     ListGroup {
         key: String,
         label: String,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
         #[serde(default)]
         required: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         min_items: Option<u32>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         max_items: Option<u32>,
         item: ListGroupItem,
     },
@@ -158,7 +158,7 @@ impl SettingsFormV1Field {
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupItem {
     pub id_field: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_field: Option<String>,
     pub fields: Vec<SettingsFormV1Field>,
 }
@@ -167,7 +167,7 @@ pub struct ListGroupItem {
 pub struct ChoiceOption {
     pub value: SelectValue,
     pub label: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 


### PR DESCRIPTION
## Problem

The release command serializes omitted optional settings-form-v1 properties as explicit JSON null values. App Registry rejects the createRelease payload with validation errors such as visibleWhen expecting an object and nested fields reporting invalid input.

## Fix

Omit absent optional presentation properties during serialization, including section, field, list-group, and choice-option values. Regression assertions verify these properties are absent from the release payload instead of null.