### PR TITLE
fix(ci): build full workspace for CodeQL Rust scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: rust-src
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           languages: rust
 
       - name: Build
-        run: cargo build
+        run: cargo build --workspace --all-targets
         working-directory: rust
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary
- CodeQL's Rust code-scanning quality warning flagged low call-target (35%, threshold 50%) and known-type (48%, threshold 20%) resolution.
- Two CI-hygiene fixes landed here, both legitimate improvements independent of the metric outcome:
  1. `rust/Cargo.toml` is a mixed package+workspace root with no `default-members`, so `cargo build` only ever built the root `godaddy-cli` package — `tools/generate-api-catalog` and all test targets/dev-dependencies were never compiled. Switched to `cargo build --workspace --all-targets`.
  2. `dtolnay/rust-toolchain@stable` installs the `minimal` rustup profile (no `rust-src`), which looked like a plausible cause for widespread macro-expansion failures. Added `components: rust-src`.
- **Neither change affected the quality metrics.** Three scans (baseline, post-build-fix, post-rust-src-fix) produced byte-for-byte identical results: 35%/48%, 135/17 files with/without extraction errors, and exactly 2,800 macro-expansion failures for ordinary macros (`format!`, `vec!`, `assert!`/`assert_eq!`, `json!`). Digging into the `Analyze` job log: CodeQL's Rust extractor runs its own indexing pass independent of the workflow's `Build` step, and its internal config shows `sysroot_src: None` / `proc_macro_server: None` even after confirming `rust-src` was actually installed — it isn't picking up the active toolchain's sysroot at all. This looks like a current limitation of the bundled Rust extractor (already on the latest `codeql-bundle-v2.26.3`) rather than something fixable from our side.

## Test plan
- [x] `cargo build --workspace --all-targets` succeeds locally and in CI, now compiling `generate-api-catalog`, test binaries, and dev-dependencies that previously weren't built.
- [x] Confirmed via three separate CodeQL runs that the database quality metrics are unaffected by either change — documented above rather than claimed as fixed.