### PR TITLE
fix(api-search): make operationId the leading default column

### DIFF
--- a/rust/src/api_explorer/search.rs
+++ b/rust/src/api_explorer/search.rs
@@ -35,7 +35,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
         CommandSpec::from_args::<SearchArgs>("search", "Search API endpoints by keyword")
             .with_long(
                 "Full-text searches across all API domains, matching against \
-                operation IDs, paths, and descriptions. Use \
+                operation IDs, paths, summaries, and descriptions. Use \
                 `api operation get <operationId>` to inspect a result in full \
                 detail.",
             )

--- a/rust/src/api_explorer/search.rs
+++ b/rust/src/api_explorer/search.rs
@@ -34,15 +34,15 @@ pub(super) fn command() -> RuntimeCommandSpec {
     RuntimeCommandSpec::new_typed::<SearchArgs, _, _, _>(
         CommandSpec::from_args::<SearchArgs>("search", "Search API endpoints by keyword")
             .with_long(
-                "Full-text searches across all API domains, matching against operation IDs, \
-                 paths, summaries, and descriptions. Returns matching endpoints with domain, \
-                 method, path, and summary. Use `api operation get <operationId>` \
-                 to inspect a result in full detail.",
+                "Full-text searches across all API domains, matching against \
+                operation IDs, paths, and descriptions. Use \
+                `api operation get <operationId>` to inspect a result in full \
+                detail.",
             )
             .with_system("api")
             .with_tier(Tier::Read)
             .no_auth(true)
-            .with_default_fields("domain,method,path,summary")
+            .with_default_fields("operationId,domain,method,path,summary")
             .with_output_schema::<ApiEndpoint>()
             .with_pagination(PaginationConfig {
                 max_limit: 100,


### PR DESCRIPTION
## Summary
- `gddy api search` rows for shared domain/method/path (notably GraphQL sub-operations under one wrapper endpoint) rendered as visually identical rows since `operationId` — the one field that's actually unique per row — wasn't part of the default column set.
- Add `operationId` as the first default column so it's the highest-priority column and the last one dropped when a row doesn't fit the terminal width, and tighten the command's `--help` long description.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `./rust/scripts/check-module-size.sh`
- [x] Manually ran `gddy api search catalog` and confirmed `operationId` now distinguishes previously-identical-looking rows