### PR TITLE
feat(deps): bump cli-engine to 0.9.3

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -544,9 +544,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-engine"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdd934fca13a77d706d45bae8289d7d35f90ff077c99dd7404bda279a3bd3af"
+checksum = "2293555112db3ed0d4205f3068396ab86039cf39c73f3a76331cf2dd1ddd52ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -566,6 +566,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strsim",
  "termimad",
  "thiserror",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["std", "string"] }
-cli-engine = { features = ["pkce-auth"], version = "0.9.0" }
+cli-engine = { features = ["pkce-auth"], version = "0.9.3" }
 dirs = "6"
 domains-client = { path = "domains-client" }
 fancy-regex = "0.14"


### PR DESCRIPTION
## Summary
Bumps `cli-engine` from 0.9.0 to 0.9.3, picking up three releases worth of engine fixes/features:

- **0.9.1** — `feat(cli)`: suggest the nearest command when an engine-intercepted invocation doesn't match a known command (adds `strsim` as a transitive dependency for the fuzzy match).
- **0.9.2** — `fix(interactivity)`: corrected prompt formatting for interactive argument prompts.
- **0.9.3** — `fix(output)`: reject unknown `--fields` names instead of silently rendering empty rows.

No source changes were required on our side — the API surface we use is unaffected.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (752 passed)
- [x] `cargo fmt --check`
- [x] `./rust/scripts/check-module-size.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)