### PR TITLE
feat(dns): add HTTPS, SVCB, and TLSA record support

### DIFF
--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -9,7 +9,8 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 
 use super::conflicts::{WriteErrorContext, describe_write_error};
 use super::records::{
-    RecordOptions, RecordWriteArgs, v3_records, validate_caa_fields, verify_with_list_action,
+    RecordOptions, RecordWriteArgs, v3_records, validate_caa_fields, validate_svcb_fields,
+    validate_tlsa_fields, verify_with_list_action,
 };
 
 // `dns add` creates one v3 record per `--data` value; it reports each outcome
@@ -125,6 +126,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let name = args.name;
             let data = args.data;
             validate_caa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
+            validate_tlsa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
+            validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
             let records = v3_records(&name, &record_type, &data, &opts);
 

--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -10,7 +10,7 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 use super::conflicts::{WriteErrorContext, describe_write_error};
 use super::records::{
     RecordOptions, RecordWriteArgs, v3_records, validate_caa_fields, validate_svcb_fields,
-    validate_tlsa_fields, validate_tlsa_values, verify_with_list_action,
+    validate_tlsa_fields, verify_with_list_action,
 };
 
 // `dns add` creates one v3 record per `--data` value; it reports each outcome
@@ -130,13 +130,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 .map_err(crate::error::GddyError::validation)?;
             validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
-            validate_tlsa_values(&record_type, &args.data, &args.cert_data)
-                .map_err(crate::error::GddyError::validation)?;
-            let data = if record_type == "TLSA" {
-                args.cert_data
-            } else {
-                args.data
-            };
+            let data = args.data;
             let records = v3_records(&name, &record_type, &data, &opts);
 
             let debug = !ctx.middleware.debug.is_empty();

--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -163,6 +163,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                             name: name.as_str(),
                             desired_type: record_type.as_str(),
                             desired_data: value.as_str(),
+                            opts: &opts,
                             action: "adding DNS record",
                             debug,
                         },

--- a/rust/src/dns/add.rs
+++ b/rust/src/dns/add.rs
@@ -10,7 +10,7 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 use super::conflicts::{WriteErrorContext, describe_write_error};
 use super::records::{
     RecordOptions, RecordWriteArgs, v3_records, validate_caa_fields, validate_svcb_fields,
-    validate_tlsa_fields, verify_with_list_action,
+    validate_tlsa_fields, validate_tlsa_values, verify_with_list_action,
 };
 
 // `dns add` creates one v3 record per `--data` value; it reports each outcome
@@ -124,13 +124,19 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let domain = args.domain;
             let record_type = args.record_type;
             let name = args.name;
-            let data = args.data;
             validate_caa_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
             validate_tlsa_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
             validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
+            validate_tlsa_values(&record_type, &args.data, &args.cert_data)
+                .map_err(crate::error::GddyError::validation)?;
+            let data = if record_type == "TLSA" {
+                args.cert_data
+            } else {
+                args.data
+            };
             let records = v3_records(&name, &record_type, &data, &opts);
 
             let debug = !ctx.middleware.debug.is_empty();

--- a/rust/src/dns/conflicts.rs
+++ b/rust/src/dns/conflicts.rs
@@ -7,7 +7,7 @@ use crate::domain::{api_error, format_api_error};
 
 use domains_client::types;
 
-use super::records::fetch_records;
+use super::records::{fetch_records, record_value};
 
 /// A v3 validation-error body's `details[].issue` codes. Deliberately not
 /// `domain::common`'s `ApiErrorBody` — that type is about rendering a friendly
@@ -106,14 +106,14 @@ pub(super) fn describe_duplicate_record(
                 "`{name}` already has a CNAME record (→ `{}`), which can't coexist with \
                  {desired_type} records — DNS only allows one or the other at a given \
                  name.{remediation}",
-                conflicts[0].data.as_deref().unwrap_or("(no data)"),
+                record_value(conflicts[0]).unwrap_or("(no data)"),
             )
         };
     }
 
     if at_name
         .iter()
-        .any(|r| r.type_.as_str() == desired_type && r.data.as_deref() == Some(desired_data))
+        .any(|r| r.type_.as_str() == desired_type && record_value(r) == Some(desired_data))
     {
         return format!("a {desired_type} record with this exact value already exists at {name}.");
     }
@@ -228,6 +228,16 @@ mod tests {
         }
     }
 
+    /// A TLSA record as `v3_record` actually builds one: its value lives in
+    /// `certificate_data`, not `data`.
+    fn tlsa_record(cert: &str) -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: Some(cert.to_string()),
+            data: None,
+            ..dns_record("TLSA", "")
+        }
+    }
+
     #[test]
     fn duplicate_record_issue_detects_the_v3_issue_code() {
         // The exact body the reporting user got back from a `dns set` CNAME conflict.
@@ -328,5 +338,19 @@ mod tests {
             msg.contains("dns list example.com --type A --name www"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn describe_duplicate_record_recognizes_tlsa_exact_duplicates_via_certificate_data() {
+        // TLSA's value lives in `certificate_data`, not `data` — the exact-
+        // duplicate check must read through `record_value` to see it.
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let exact = vec![tlsa_record(cert)];
+        let msg = describe_duplicate_record("TLSA", cert, "example.com", "www", &exact, true);
+        assert!(msg.contains("exact value already exists"), "{msg}");
+
+        let different = vec![tlsa_record("00")];
+        let msg = describe_duplicate_record("TLSA", cert, "example.com", "www", &different, true);
+        assert!(msg.contains("already has conflicting TLSA data"), "{msg}");
     }
 }

--- a/rust/src/dns/conflicts.rs
+++ b/rust/src/dns/conflicts.rs
@@ -7,7 +7,7 @@ use crate::domain::{api_error, format_api_error};
 
 use domains_client::types;
 
-use super::records::{fetch_records, record_value};
+use super::records::{RecordOptions, fetch_records, record_value, same_content, v3_record};
 
 /// A v3 validation-error body's `details[].issue` codes. Deliberately not
 /// `domain::common`'s `ApiErrorBody` — that type is about rendering a friendly
@@ -68,6 +68,7 @@ pub(super) fn describe_duplicate_record(
     desired_data: &str,
     domain: &str,
     name: &str,
+    opts: &RecordOptions,
     at_name: &[types::DnsRecord],
     can_auto_replace: bool,
 ) -> String {
@@ -111,9 +112,16 @@ pub(super) fn describe_duplicate_record(
         };
     }
 
+    // Full-content comparison, not just the primary value: CAA's flag/tag,
+    // SRV's priority/weight/port, TLSA's usage/selector/matchingType, and
+    // HTTPS/SVCB's priority/parameters are all part of what makes a record
+    // an "exact duplicate" — matching only `desired_data` would call two
+    // TLSA records with the same cert data but different usage an exact
+    // duplicate even though they're not.
+    let desired = v3_record(name, desired_type, desired_data, opts);
     if at_name
         .iter()
-        .any(|r| r.type_.as_str() == desired_type && record_value(r) == Some(desired_data))
+        .any(|r| r.type_.as_str() == desired_type && same_content(r, &desired))
     {
         return format!("a {desired_type} record with this exact value already exists at {name}.");
     }
@@ -145,6 +153,7 @@ pub(super) struct WriteErrorContext<'a> {
     pub(super) name: &'a str,
     pub(super) desired_type: &'a str,
     pub(super) desired_data: &'a str,
+    pub(super) opts: &'a RecordOptions,
     pub(super) action: &'a str,
     pub(super) debug: bool,
 }
@@ -186,6 +195,7 @@ pub(super) async fn describe_write_error(
             ctx.desired_data,
             ctx.domain,
             ctx.name,
+            ctx.opts,
             &at_name,
             false,
         ),
@@ -230,11 +240,31 @@ mod tests {
 
     /// A TLSA record as `v3_record` actually builds one: its value lives in
     /// `certificate_data`, not `data`.
-    fn tlsa_record(cert: &str) -> types::DnsRecord {
+    fn tlsa_record(cert: &str, usage: u8, selector: u8, matching_type: u8) -> types::DnsRecord {
         types::DnsRecord {
             certificate_data: Some(cert.to_string()),
+            usage: Some(types::TlsaUsage(usage)),
+            selector: Some(types::TlsaSelector(selector)),
+            matching_type: Some(types::TlsaMatchingType(matching_type)),
             data: None,
             ..dns_record("TLSA", "")
+        }
+    }
+
+    fn opts() -> RecordOptions {
+        RecordOptions {
+            ttl: None,
+            priority: None,
+            port: None,
+            weight: None,
+            protocol: None,
+            service: None,
+            flag: None,
+            tag: None,
+            usage: None,
+            selector: None,
+            matching_type: None,
+            parameters: None,
         }
     }
 
@@ -273,13 +303,28 @@ mod tests {
     fn describe_duplicate_record_explains_cname_exclusivity() {
         let at_name = vec![dns_record("CNAME", "parkpage.godaddy.com")];
 
-        let msg = describe_duplicate_record("A", "1.2.3.4", "example.com", "www", &at_name, true);
+        let msg = describe_duplicate_record(
+            "A",
+            "1.2.3.4",
+            "example.com",
+            "www",
+            &opts(),
+            &at_name,
+            true,
+        );
         assert!(msg.contains("already has a CNAME record"), "{msg}");
         assert!(msg.contains("parkpage.godaddy.com"), "{msg}");
         assert!(msg.contains("--replace-conflicting-types"), "{msg}");
 
-        let msg_no_flag =
-            describe_duplicate_record("A", "1.2.3.4", "example.com", "www", &at_name, false);
+        let msg_no_flag = describe_duplicate_record(
+            "A",
+            "1.2.3.4",
+            "example.com",
+            "www",
+            &opts(),
+            &at_name,
+            false,
+        );
         assert!(
             msg_no_flag.contains("dns delete example.com --type CNAME --name www"),
             "{msg_no_flag}"
@@ -295,6 +340,7 @@ mod tests {
             "target.example.net",
             "example.com",
             "www",
+            &opts(),
             &others,
             true,
         );
@@ -308,6 +354,7 @@ mod tests {
             "target.example.net",
             "example.com",
             "www",
+            &opts(),
             &others,
             false,
         );
@@ -325,14 +372,22 @@ mod tests {
     fn describe_duplicate_record_names_exact_and_generic_cases() {
         // Exact same-type-same-data match.
         let exact = vec![dns_record("A", "1.2.3.4")];
-        let msg = describe_duplicate_record("A", "1.2.3.4", "example.com", "www", &exact, true);
+        let msg =
+            describe_duplicate_record("A", "1.2.3.4", "example.com", "www", &opts(), &exact, true);
         assert!(msg.contains("exact value already exists"), "{msg}");
 
         // Same type, different data — DUPLICATE_RECORD but not a cross-type
         // conflict → generic fallback pointing at `dns list`.
         let different_data = vec![dns_record("A", "9.9.9.9")];
-        let msg =
-            describe_duplicate_record("A", "1.2.3.4", "example.com", "www", &different_data, true);
+        let msg = describe_duplicate_record(
+            "A",
+            "1.2.3.4",
+            "example.com",
+            "www",
+            &opts(),
+            &different_data,
+            true,
+        );
         assert!(msg.contains("already has conflicting A data"), "{msg}");
         assert!(
             msg.contains("dns list example.com --type A --name www"),
@@ -343,14 +398,44 @@ mod tests {
     #[test]
     fn describe_duplicate_record_recognizes_tlsa_exact_duplicates_via_certificate_data() {
         // TLSA's value lives in `certificate_data`, not `data` — the exact-
-        // duplicate check must read through `record_value` to see it.
+        // duplicate check must read through `same_content` to see it.
         let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
-        let exact = vec![tlsa_record(cert)];
-        let msg = describe_duplicate_record("TLSA", cert, "example.com", "www", &exact, true);
+        let mut tlsa_opts = opts();
+        tlsa_opts.usage = Some(3);
+        tlsa_opts.selector = Some(1);
+        tlsa_opts.matching_type = Some(1);
+
+        let exact = vec![tlsa_record(cert, 3, 1, 1)];
+        let msg =
+            describe_duplicate_record("TLSA", cert, "example.com", "www", &tlsa_opts, &exact, true);
         assert!(msg.contains("exact value already exists"), "{msg}");
 
-        let different = vec![tlsa_record("00")];
-        let msg = describe_duplicate_record("TLSA", cert, "example.com", "www", &different, true);
+        // Different cert data → not a duplicate, generic fallback.
+        let different = vec![tlsa_record("00", 3, 1, 1)];
+        let msg = describe_duplicate_record(
+            "TLSA",
+            cert,
+            "example.com",
+            "www",
+            &tlsa_opts,
+            &different,
+            true,
+        );
+        assert!(msg.contains("already has conflicting TLSA data"), "{msg}");
+
+        // Same cert data but a different usage → a genuinely different TLSA
+        // record, not an exact duplicate (this is the bug: comparing only
+        // the cert data would wrongly call this a duplicate).
+        let same_cert_different_usage = vec![tlsa_record(cert, 1, 0, 0)];
+        let msg = describe_duplicate_record(
+            "TLSA",
+            cert,
+            "example.com",
+            "www",
+            &tlsa_opts,
+            &same_cert_different_usage,
+            true,
+        );
         assert!(msg.contains("already has conflicting TLSA data"), "{msg}");
     }
 }

--- a/rust/src/dns/delete.rs
+++ b/rust/src/dns/delete.rs
@@ -9,7 +9,7 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 
 use domains_client::types;
 
-use super::records::{fetch_records, parse_write_type_arg, verify_with_list_action};
+use super::records::{fetch_records, parse_write_type_arg, record_value, verify_with_list_action};
 
 output_schema!(DnsDeleteResult {
     "domain": "string";
@@ -85,7 +85,7 @@ fn dry_run_delete_preview(
             } else {
                 "would fail (missing recordId)"
             };
-            json!({"recordId": rec.record_id, "data": rec.data, "status": status})
+            json!({"recordId": rec.record_id, "data": record_value(rec), "status": status})
         })
         .collect();
 
@@ -217,7 +217,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                         }
                     },
                 };
-                outcomes.push((rec.data.as_deref().unwrap_or("(no data)").to_string(), err));
+                outcomes.push((record_value(rec).unwrap_or("(no data)").to_string(), err));
             }
 
             summarize_delete_outcomes(&domain, &record_type, &name, &outcomes)
@@ -296,6 +296,17 @@ mod tests {
         }
     }
 
+    /// A TLSA record as `v3_record` actually builds one: its value lives in
+    /// `certificate_data`, not `data`.
+    fn test_tlsa_record(record_id: &str, cert: &str) -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: Some(cert.to_owned()),
+            data: None,
+            type_: types::DnsRecordType("TLSA".to_owned()),
+            ..test_record(record_id, "")
+        }
+    }
+
     #[test]
     fn dry_run_delete_preview_lists_every_matched_record_without_deleting() {
         let existing = vec![test_record("r1", "1.2.3.4"), test_record("r2", "5.6.7.8")];
@@ -307,6 +318,18 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0]["data"], "1.2.3.4");
         assert_eq!(records[0]["status"], "would delete");
+    }
+
+    /// TLSA's value lives in `certificate_data`, not `data` — the preview
+    /// must read through `record_value` to show it rather than reporting
+    /// null.
+    #[test]
+    fn dry_run_delete_preview_shows_tlsa_certificate_data_as_the_value() {
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let existing = vec![test_tlsa_record("r1", cert)];
+        let preview = dry_run_delete_preview("example.com", "TLSA", "www", &existing);
+        let records = preview["records"].as_array().expect("records array");
+        assert_eq!(records[0]["data"], cert);
     }
 
     /// A record without a recordId can't actually be deleted (the real

--- a/rust/src/dns/delete.rs
+++ b/rust/src/dns/delete.rs
@@ -117,7 +117,7 @@ struct DeleteArgs {
     #[arg(value_name = "DOMAIN")]
     domain: String,
 
-    /// Record type (A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT).
+    /// Record type (A, AAAA, ALIAS, CAA, CNAME, HTTPS, MX, SRV, SVCB, TLSA, TXT).
     #[arg(long = "type", value_name = "TYPE", value_parser = parse_write_type_arg)]
     record_type: String,
 

--- a/rust/src/dns/list.rs
+++ b/rust/src/dns/list.rs
@@ -18,8 +18,8 @@ struct ListArgs {
     #[arg(value_name = "DOMAIN")]
     domain: String,
 
-    /// Only records of this type (A, AAAA, ALIAS, CAA, CNAME, MX, NS, SOA,
-    /// SRV, TXT).
+    /// Only records of this type (A, AAAA, ALIAS, CAA, CNAME, HTTPS, MX, NS,
+    /// SOA, SRV, SVCB, TLSA, TXT).
     #[arg(long = "type", value_name = "TYPE", value_parser = parse_list_type_arg)]
     record_type: Option<String>,
 

--- a/rust/src/dns/list.rs
+++ b/rust/src/dns/list.rs
@@ -10,7 +10,7 @@ use crate::scopes::DOMAINS_READ;
 
 use domains_client::types;
 
-use super::records::{fetch_records, parse_list_type_arg};
+use super::records::{fetch_records, merged_tlsa_data, parse_list_type_arg};
 
 #[derive(Debug, Clone, clap::Args)]
 struct ListArgs {
@@ -38,10 +38,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
             )
             .with_system("domain")
             .with_tier(Tier::Read)
-            // TLSA records carry their value in `certificateData`, not
-            // `data` (which is absent for them) — include it so `dns list
-            // --type TLSA` doesn't show a blank value column by default.
-            .with_default_fields("type,name,data,certificateData,ttl")
+            .with_default_fields("type,name,data,ttl")
             .with_json_schema::<types::DnsRecord>()
             .with_scopes(&[DOMAINS_READ])
             .with_pagination(PaginationConfig {
@@ -64,21 +61,38 @@ pub(super) fn command() -> RuntimeCommandSpec {
             )
             .await?;
 
-            let out: Vec<Value> = records
-                .iter()
-                .map(serde_json::to_value)
-                .collect::<Result<_, _>>()
-                .map_err(|e| {
-                    CliCoreError::message(format!("failed to serialize DNS records: {e}"))
-                })?;
+            let out = build_list_output(&records).map_err(|e| {
+                CliCoreError::message(format!("failed to serialize DNS records: {e}"))
+            })?;
             Ok(CommandResult::new(json!(out)))
         },
     )
 }
 
+/// Serialize fetched records for `dns list`'s output, re-merging TLSA's
+/// split fields back into a single `data` string (see
+/// [`merged_tlsa_data`]) — every other type already has a meaningful `data`.
+/// The original `certificateData`/`usage`/`selector`/`matchingType` fields
+/// are left in place alongside it. Pure so the merge is unit-testable
+/// without a mock server.
+fn build_list_output(records: &[types::DnsRecord]) -> Result<Vec<Value>, serde_json::Error> {
+    records
+        .iter()
+        .map(|rec| {
+            let mut v = serde_json::to_value(rec)?;
+            if rec.type_.as_str() == "TLSA"
+                && let Some(obj) = v.as_object_mut()
+            {
+                obj.insert("data".to_string(), json!(merged_tlsa_data(rec)));
+            }
+            Ok(v)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::command;
+    use super::*;
     use cli_engine::PaginationConfig;
 
     #[test]
@@ -92,14 +106,57 @@ mod tests {
         );
     }
 
-    /// TLSA's value lives in `certificateData`, not `data` — the default
-    /// projection must include it or a TLSA row's value column is blank.
+    fn a_record() -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: None,
+            matching_type: None,
+            selector: None,
+            usage: None,
+            data: Some("1.2.3.4".to_string()),
+            flag: None,
+            name: "www".to_string(),
+            parameters: None,
+            port: None,
+            priority: None,
+            protocol: None,
+            record_id: Some("r1".to_string()),
+            service: None,
+            tag: None,
+            ttl: 3600,
+            type_: types::DnsRecordType("A".to_string()),
+            weight: None,
+        }
+    }
+
+    fn tlsa_record(cert: &str) -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: Some(cert.to_string()),
+            matching_type: Some(types::TlsaMatchingType(1)),
+            selector: Some(types::TlsaSelector(1)),
+            usage: Some(types::TlsaUsage(3)),
+            data: None,
+            type_: types::DnsRecordType("TLSA".to_string()),
+            ..a_record()
+        }
+    }
+
+    /// DNS treats a TLSA record's RDATA as one blob (RFC 6698) — `dns list`
+    /// re-merges the split fields into `data` for display, without dropping
+    /// the originals.
     #[test]
-    fn default_fields_includes_certificate_data_for_tlsa() {
-        let default_fields = command().spec.default_fields.unwrap_or_default();
-        assert!(
-            default_fields.contains("certificateData"),
-            "{default_fields:?}"
-        );
+    fn build_list_output_merges_tlsa_fields_into_data() {
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let out = build_list_output(&[tlsa_record(cert)]).expect("serializes");
+        assert_eq!(out[0]["data"], format!("3 1 1 {cert}"));
+        assert_eq!(out[0]["certificateData"], cert);
+        assert_eq!(out[0]["usage"], 3);
+        assert_eq!(out[0]["selector"], 1);
+        assert_eq!(out[0]["matchingType"], 1);
+    }
+
+    #[test]
+    fn build_list_output_leaves_other_types_data_untouched() {
+        let out = build_list_output(&[a_record()]).expect("serializes");
+        assert_eq!(out[0]["data"], "1.2.3.4");
     }
 }

--- a/rust/src/dns/list.rs
+++ b/rust/src/dns/list.rs
@@ -38,7 +38,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
             )
             .with_system("domain")
             .with_tier(Tier::Read)
-            .with_default_fields("type,name,data,ttl")
+            // TLSA records carry their value in `certificateData`, not
+            // `data` (which is absent for them) — include it so `dns list
+            // --type TLSA` doesn't show a blank value column by default.
+            .with_default_fields("type,name,data,certificateData,ttl")
             .with_json_schema::<types::DnsRecord>()
             .with_scopes(&[DOMAINS_READ])
             .with_pagination(PaginationConfig {
@@ -86,6 +89,17 @@ mod tests {
                 max_limit: 500,
                 ..Default::default()
             })
+        );
+    }
+
+    /// TLSA's value lives in `certificateData`, not `data` — the default
+    /// projection must include it or a TLSA row's value column is blank.
+    #[test]
+    fn default_fields_includes_certificate_data_for_tlsa() {
+        let default_fields = command().spec.default_fields.unwrap_or_default();
+        assert!(
+            default_fields.contains("certificateData"),
+            "{default_fields:?}"
         );
     }
 }

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -72,7 +72,7 @@ mod tests {
                     .with_module(module()),
             )
         };
-        let cases: [(&[&str], &str); 3] = [
+        let cases: [(&[&str], &str); 4] = [
             (
                 &[
                     "gddy",
@@ -104,6 +104,25 @@ mod tests {
             (
                 &["gddy", "dns", "list", "example.com", "--name", "www"],
                 "--type",
+            ),
+            (
+                &[
+                    "gddy",
+                    "dns",
+                    "add",
+                    "example.com",
+                    "--type",
+                    "TLSA",
+                    "--name",
+                    "www",
+                    "--usage",
+                    "3",
+                    "--selector",
+                    "1",
+                    "--matching-type",
+                    "1",
+                ],
+                "--cert-data",
             ),
         ];
         for (args, needle) in cases {

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -122,7 +122,7 @@ mod tests {
                     "--matching-type",
                     "1",
                 ],
-                "--cert-data",
+                "--data",
             ),
         ];
         for (args, needle) in cases {

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -161,17 +161,17 @@ pub(super) struct RecordWriteArgs {
 
     /// TLSA certificate usage, 0-3 (RFC 6698 §2.1.1; TLSA only; required for
     /// TLSA). 0 PKIX-TA, 1 PKIX-EE, 2 DANE-TA, 3 DANE-EE.
-    #[arg(long = "usage", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    #[arg(long = "usage", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=3), required_if_eq("record_type", "TLSA"))]
     pub(super) usage: Option<i64>,
 
     /// TLSA selector, 0-1 (RFC 6698 §2.1.2; TLSA only; required for TLSA). 0
     /// full certificate, 1 SubjectPublicKeyInfo.
-    #[arg(long = "selector", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    #[arg(long = "selector", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=1), required_if_eq("record_type", "TLSA"))]
     pub(super) selector: Option<i64>,
 
     /// TLSA matching type, 0-2 (RFC 6698 §2.1.3; TLSA only; required for
     /// TLSA). 0 exact match, 1 SHA-256, 2 SHA-512.
-    #[arg(long = "matching-type", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    #[arg(long = "matching-type", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=2), required_if_eq("record_type", "TLSA"))]
     pub(super) matching_type: Option<i64>,
 
     /// SvcParams for HTTPS/SVCB records (RFC 9460), e.g. "alpn=h2,h3

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -283,6 +283,15 @@ pub(super) fn v3_records(
     data.iter().map(|d| v3_record(name, ty, d, opts)).collect()
 }
 
+/// The user-facing "value" of a fetched v3 `DnsRecord`: `data` for every type
+/// except TLSA, which carries its value in `certificateData` instead (see
+/// [`v3_record`]'s TLSA branch). Conflict diagnosis, delete/set reporting, and
+/// exact-duplicate detection all need "the value" regardless of which wire
+/// field holds it, so they read through this rather than `data` directly.
+pub(super) fn record_value(rec: &types::DnsRecord) -> Option<&str> {
+    rec.data.as_deref().or(rec.certificate_data.as_deref())
+}
+
 /// List every v3 DNS record for a zone matching the optional `type`/`name`
 /// filters, paging through the collection (v3 list is paginated). Shared by
 /// `list`, `set`, and `delete` — the latter two need the matching records' ids.

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -13,12 +13,13 @@ use domains_client::types;
 /// NS and SOA are registry-managed / read-only, so they're excluded. v3's
 /// `DNSRecordType` is otherwise an open string; this list is the CLI's guardrail
 /// against typos and includes `CAA` and GoDaddy's `ALIAS` extension.
-pub(super) const WRITABLE_TYPES: &[&str] =
-    &["A", "AAAA", "ALIAS", "CAA", "CNAME", "MX", "SRV", "TXT"];
+pub(super) const WRITABLE_TYPES: &[&str] = &[
+    "A", "AAAA", "ALIAS", "CAA", "CNAME", "HTTPS", "MX", "SRV", "SVCB", "TLSA", "TXT",
+];
 /// Record types accepted by the `list` filter — the writable set plus the
 /// read-only NS/SOA, which are listable even though they can't be modified.
 pub(super) const LISTABLE_TYPES: &[&str] = &[
-    "A", "AAAA", "ALIAS", "CAA", "CNAME", "MX", "NS", "SOA", "SRV", "TXT",
+    "A", "AAAA", "ALIAS", "CAA", "CNAME", "HTTPS", "MX", "NS", "SOA", "SRV", "SVCB", "TLSA", "TXT",
 ];
 /// Default TTL (seconds) for `dns add`/`set` when `--ttl` is omitted (v3 requires a ttl).
 pub(super) const DEFAULT_TTL: i64 = 3600;
@@ -64,7 +65,8 @@ pub(super) fn parse_list_type_arg(raw: &str) -> Result<String, String> {
 }
 
 /// Optional record fields shared by `add` and `set`, including the CAA-only
-/// `flag`/`tag`.
+/// `flag`/`tag`, the TLSA-only `usage`/`selector`/`matching_type`, and the
+/// HTTPS/SVCB-only `parameters` (SvcParams).
 pub(super) struct RecordOptions {
     pub(super) ttl: Option<i64>,
     pub(super) priority: Option<i64>,
@@ -74,6 +76,10 @@ pub(super) struct RecordOptions {
     pub(super) service: Option<String>,
     pub(super) flag: Option<i64>,
     pub(super) tag: Option<String>,
+    pub(super) usage: Option<i64>,
+    pub(super) selector: Option<i64>,
+    pub(super) matching_type: Option<i64>,
+    pub(super) parameters: Option<String>,
 }
 
 impl RecordOptions {
@@ -87,6 +93,10 @@ impl RecordOptions {
             service: args.service.clone(),
             flag: args.flag,
             tag: args.tag.clone(),
+            usage: args.usage,
+            selector: args.selector,
+            matching_type: args.matching_type,
+            parameters: args.parameters.clone(),
         }
     }
 }
@@ -99,7 +109,7 @@ pub(super) struct RecordWriteArgs {
     #[arg(value_name = "DOMAIN")]
     pub(super) domain: String,
 
-    /// Record type (A, AAAA, ALIAS, CAA, CNAME, MX, SRV, TXT).
+    /// Record type (A, AAAA, ALIAS, CAA, CNAME, HTTPS, MX, SRV, SVCB, TLSA, TXT).
     #[arg(long = "type", value_name = "TYPE", value_parser = parse_write_type_arg)]
     pub(super) record_type: String,
 
@@ -107,7 +117,9 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "NAME")]
     pub(super) name: String,
 
-    /// Record value (repeatable for multiple records on the same name).
+    /// Record value (repeatable for multiple records on the same name). For
+    /// TLSA, this is the hex-encoded certificate association data; use
+    /// `--usage`/`--selector`/`--matching-type` for the rest.
     #[arg(long, value_name = "VALUE", required = true)]
     pub(super) data: Vec<String>,
 
@@ -115,11 +127,12 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "SECONDS", value_parser = clap::value_parser!(i64).range(1..))]
     pub(super) ttl: Option<i64>,
 
-    /// Record priority (MX and SRV only).
+    /// Record priority (MX, SRV, HTTPS, and SVCB only). For HTTPS/SVCB, 0
+    /// means AliasMode.
     #[arg(long, value_name = "N", value_parser = clap::value_parser!(i64).range(0..=65535))]
     pub(super) priority: Option<i64>,
 
-    /// Service port (SRV only).
+    /// Service port (SRV and TLSA only).
     #[arg(long, value_name = "PORT", value_parser = clap::value_parser!(i64).range(1..=65535))]
     pub(super) port: Option<i64>,
 
@@ -127,7 +140,7 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "N", value_parser = clap::value_parser!(i64).range(0..=65535))]
     pub(super) weight: Option<i64>,
 
-    /// Service protocol (SRV only).
+    /// Service protocol, e.g. _tcp (SRV and TLSA only).
     #[arg(long, value_name = "PROTO")]
     pub(super) protocol: Option<String>,
 
@@ -145,6 +158,26 @@ pub(super) struct RecordWriteArgs {
     /// CAA property tag, e.g. issue/issuewild/iodef (CAA only; required for CAA).
     #[arg(long, value_name = "TAG", required_if_eq("record_type", "CAA"))]
     pub(super) tag: Option<String>,
+
+    /// TLSA certificate usage, 0-3 (RFC 6698 §2.1.1; TLSA only; required for
+    /// TLSA). 0 PKIX-TA, 1 PKIX-EE, 2 DANE-TA, 3 DANE-EE.
+    #[arg(long = "usage", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    pub(super) usage: Option<i64>,
+
+    /// TLSA selector, 0-1 (RFC 6698 §2.1.2; TLSA only; required for TLSA). 0
+    /// full certificate, 1 SubjectPublicKeyInfo.
+    #[arg(long = "selector", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    pub(super) selector: Option<i64>,
+
+    /// TLSA matching type, 0-2 (RFC 6698 §2.1.3; TLSA only; required for
+    /// TLSA). 0 exact match, 1 SHA-256, 2 SHA-512.
+    #[arg(long = "matching-type", value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255), required_if_eq("record_type", "TLSA"))]
+    pub(super) matching_type: Option<i64>,
+
+    /// SvcParams for HTTPS/SVCB records (RFC 9460), e.g. "alpn=h2,h3
+    /// port=8443" (HTTPS/SVCB only).
+    #[arg(long, value_name = "PARAMS")]
+    pub(super) parameters: Option<String>,
 }
 
 /// Validate the CAA-specific fields against the record type. A CAA record needs a
@@ -168,9 +201,39 @@ pub(super) fn validate_caa_fields(record_type: &str, opts: &RecordOptions) -> Re
     Ok(())
 }
 
+/// Validate the TLSA-specific fields against the record type. `--usage`/
+/// `--selector`/`--matching-type` being present when `record_type` is TLSA is
+/// already enforced by clap (`required_if_eq`); this only guards the reverse —
+/// they're meaningless for other types. Pure so it's unit-testable and runs
+/// before any network call.
+pub(super) fn validate_tlsa_fields(record_type: &str, opts: &RecordOptions) -> Result<(), String> {
+    if record_type != "TLSA"
+        && (opts.usage.is_some() || opts.selector.is_some() || opts.matching_type.is_some())
+    {
+        return Err(format!(
+            "--usage/--selector/--matching-type are only valid for TLSA records, not {record_type}"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the HTTPS/SVCB-specific `--parameters` (SvcParams) field against
+/// the record type — meaningless for anything else. Pure so it's
+/// unit-testable and runs before any network call.
+pub(super) fn validate_svcb_fields(record_type: &str, opts: &RecordOptions) -> Result<(), String> {
+    if opts.parameters.is_some() && !matches!(record_type, "HTTPS" | "SVCB") {
+        return Err(format!(
+            "--parameters is only valid for HTTPS/SVCB records, not {record_type}"
+        ));
+    }
+    Ok(())
+}
+
 /// Build one v3 `DnsRecord` from a `--data` value + shared options. `ttl` defaults
 /// to [`DEFAULT_TTL`] (v3 requires it). SRV/MX numerics convert into v3's `u16`
-/// and the CAA `flag` into `u8` (clap already bounds both ranges).
+/// and the CAA `flag`/TLSA `usage`/`selector`/`matchingType` into `u8` (clap
+/// already bounds all four ranges). TLSA doesn't use `data` — v3 wants its
+/// value under `certificateData` instead — so `data`'s value moves there.
 pub(super) fn v3_record(
     name: &str,
     ty: &str,
@@ -178,20 +241,26 @@ pub(super) fn v3_record(
     opts: &RecordOptions,
 ) -> types::DnsRecord {
     let to_u16 = |v: Option<i64>| v.and_then(|n| u16::try_from(n).ok());
+    let to_u8 = |v: Option<i64>| v.and_then(|n| u8::try_from(n).ok());
+    let is_tlsa = ty == "TLSA";
     types::DnsRecord {
-        // TLSA-only fields — the CLI's writable types (WRITABLE_TYPES) never
-        // include TLSA, so these are always absent for records this builds.
-        certificate_data: None,
-        matching_type: None,
-        selector: None,
-        usage: None,
-        data: Some(data.to_owned()),
+        certificate_data: is_tlsa.then(|| data.to_owned()),
+        matching_type: is_tlsa
+            .then(|| to_u8(opts.matching_type))
+            .flatten()
+            .map(types::TlsaMatchingType),
+        selector: is_tlsa
+            .then(|| to_u8(opts.selector))
+            .flatten()
+            .map(types::TlsaSelector),
+        usage: is_tlsa
+            .then(|| to_u8(opts.usage))
+            .flatten()
+            .map(types::TlsaUsage),
+        data: (!is_tlsa).then(|| data.to_owned()),
         flag: opts.flag.and_then(|n| u8::try_from(n).ok()),
         name: name.to_owned(),
-        // SvcParams for HTTPS/SVCB records (RFC 9460) — no CLI flag sets
-        // these yet, so every record is built without them, same as before
-        // this field existed.
-        parameters: None,
+        parameters: opts.parameters.clone(),
         port: to_u16(opts.port),
         priority: to_u16(opts.priority),
         protocol: opts.protocol.clone(),
@@ -289,6 +358,10 @@ mod tests {
             service: None,
             flag: None,
             tag: None,
+            usage: None,
+            selector: None,
+            matching_type: None,
+            parameters: None,
         }
     }
 
@@ -297,6 +370,9 @@ mod tests {
         assert_eq!(parse_write_type_arg("aaaa").expect("valid"), "AAAA");
         assert_eq!(parse_write_type_arg("caa").expect("valid"), "CAA");
         assert_eq!(parse_write_type_arg("Alias").expect("valid"), "ALIAS");
+        assert_eq!(parse_write_type_arg("https").expect("valid"), "HTTPS");
+        assert_eq!(parse_write_type_arg("svcb").expect("valid"), "SVCB");
+        assert_eq!(parse_write_type_arg("tlsa").expect("valid"), "TLSA");
         // NS/SOA are registry-managed / read-only → rejected with a clear reason.
         for ty in ["NS", "soa"] {
             let err = parse_write_type_arg(ty).expect_err("read-only");
@@ -370,5 +446,62 @@ mod tests {
         assert!(err.contains("only valid for CAA"), "got: {err}");
         // A non-CAA type with no CAA fields → ok.
         assert!(validate_caa_fields("A", &opts()).is_ok());
+    }
+
+    #[test]
+    fn v3_record_carries_https_svcb_and_tlsa_fields() {
+        let mut https_opts = opts();
+        https_opts.priority = Some(1);
+        https_opts.parameters = Some("alpn=h2,h3".to_string());
+        let https = v3_record("@", "HTTPS", ".", &https_opts);
+        assert_eq!(https.priority, Some(1));
+        assert_eq!(https.parameters.as_deref(), Some("alpn=h2,h3"));
+        assert_eq!(https.data.as_deref(), Some("."));
+        assert_eq!(https.certificate_data, None);
+
+        let mut tlsa_opts = opts();
+        tlsa_opts.usage = Some(3);
+        tlsa_opts.selector = Some(1);
+        tlsa_opts.matching_type = Some(1);
+        tlsa_opts.protocol = Some("_tcp".to_string());
+        tlsa_opts.port = Some(443);
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let tlsa = v3_record("www", "TLSA", cert, &tlsa_opts);
+        // TLSA doesn't use `data` — the value moves to `certificateData`.
+        assert_eq!(tlsa.data, None);
+        assert_eq!(tlsa.certificate_data.as_deref(), Some(cert));
+        assert_eq!(tlsa.usage.map(|u| u.0), Some(3));
+        assert_eq!(tlsa.selector.map(|s| s.0), Some(1));
+        assert_eq!(tlsa.matching_type.map(|m| m.0), Some(1));
+        assert_eq!(tlsa.protocol.as_deref(), Some("_tcp"));
+        assert_eq!(tlsa.port, Some(443));
+    }
+
+    #[test]
+    fn tlsa_fields_are_required_for_tlsa_and_rejected_otherwise() {
+        // --usage/--selector/--matching-type on a non-TLSA type → rejected.
+        let mut a = opts();
+        a.usage = Some(3);
+        let err = validate_tlsa_fields("A", &a).expect_err("TLSA fields are TLSA-only");
+        assert!(err.contains("only valid for TLSA"), "got: {err}");
+        // TLSA with the fields set → ok.
+        let mut tlsa = opts();
+        tlsa.usage = Some(3);
+        tlsa.selector = Some(1);
+        tlsa.matching_type = Some(1);
+        assert!(validate_tlsa_fields("TLSA", &tlsa).is_ok());
+        // A non-TLSA type with no TLSA fields → ok.
+        assert!(validate_tlsa_fields("A", &opts()).is_ok());
+    }
+
+    #[test]
+    fn svcb_parameters_are_rejected_for_other_types() {
+        let mut a = opts();
+        a.parameters = Some("alpn=h2".to_string());
+        let err = validate_svcb_fields("A", &a).expect_err("parameters are HTTPS/SVCB-only");
+        assert!(err.contains("only valid for HTTPS/SVCB"), "got: {err}");
+        assert!(validate_svcb_fields("HTTPS", &a).is_ok());
+        assert!(validate_svcb_fields("SVCB", &a).is_ok());
+        assert!(validate_svcb_fields("A", &opts()).is_ok());
     }
 }

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -117,10 +117,17 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "NAME")]
     pub(super) name: String,
 
-    /// Record value (repeatable for multiple records on the same name). For
-    /// TLSA, this is the hex-encoded certificate association data; use
-    /// `--usage`/`--selector`/`--matching-type` for the rest.
-    #[arg(long, value_name = "VALUE", required = true)]
+    /// Record value (repeatable for multiple records on the same name). Not
+    /// used for TLSA — use `--cert-data` instead.
+    // Required for every writable type except TLSA — clap has no "required
+    // unless" value match, so this lists WRITABLE_TYPES minus TLSA; keep the
+    // two in sync.
+    #[arg(long, value_name = "VALUE", required_if_eq_any([
+        ("record_type", "A"), ("record_type", "AAAA"), ("record_type", "ALIAS"),
+        ("record_type", "CAA"), ("record_type", "CNAME"), ("record_type", "HTTPS"),
+        ("record_type", "MX"), ("record_type", "SRV"), ("record_type", "SVCB"),
+        ("record_type", "TXT"),
+    ]))]
     pub(super) data: Vec<String>,
 
     /// Time-to-live in seconds (defaults to 3600 when omitted).
@@ -158,6 +165,16 @@ pub(super) struct RecordWriteArgs {
     /// CAA property tag, e.g. issue/issuewild/iodef (CAA only; required for CAA).
     #[arg(long, value_name = "TAG", required_if_eq("record_type", "CAA"))]
     pub(super) tag: Option<String>,
+
+    /// Certificate association data, hex-encoded (repeatable for multiple
+    /// records on the same name; TLSA only; required for TLSA, in place of
+    /// `--data`).
+    #[arg(
+        long = "cert-data",
+        value_name = "HEX",
+        required_if_eq("record_type", "TLSA")
+    )]
+    pub(super) cert_data: Vec<String>,
 
     /// TLSA certificate usage, 0-3 (RFC 6698 §2.1.1; TLSA only; required for
     /// TLSA). 0 PKIX-TA, 1 PKIX-EE, 2 DANE-TA, 3 DANE-EE.
@@ -212,6 +229,27 @@ pub(super) fn validate_tlsa_fields(record_type: &str, opts: &RecordOptions) -> R
     {
         return Err(format!(
             "--usage/--selector/--matching-type are only valid for TLSA records, not {record_type}"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate `--data`/`--cert-data` against the record type: TLSA carries its
+/// value via `--cert-data` (clap's `required_if_eq` on `cert_data` already
+/// enforces that it's present for TLSA), never `--data`; every other type is
+/// the reverse. Pure so it's unit-testable and runs before any network call.
+pub(super) fn validate_tlsa_values(
+    record_type: &str,
+    data: &[String],
+    cert_data: &[String],
+) -> Result<(), String> {
+    if record_type == "TLSA" {
+        if !data.is_empty() {
+            return Err("TLSA records carry their value via --cert-data, not --data".to_string());
+        }
+    } else if !cert_data.is_empty() {
+        return Err(format!(
+            "--cert-data is only valid for TLSA records, not {record_type}"
         ));
     }
     Ok(())
@@ -512,5 +550,22 @@ mod tests {
         assert!(validate_svcb_fields("HTTPS", &a).is_ok());
         assert!(validate_svcb_fields("SVCB", &a).is_ok());
         assert!(validate_svcb_fields("A", &opts()).is_ok());
+    }
+
+    #[test]
+    fn tlsa_uses_cert_data_not_data_and_vice_versa_for_other_types() {
+        let cert = ["d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971".to_string()];
+        let value = ["1.2.3.4".to_string()];
+
+        // TLSA with --data instead of --cert-data → rejected.
+        let err = validate_tlsa_values("TLSA", &value, &[]).expect_err("TLSA needs --cert-data");
+        assert!(err.contains("--cert-data"), "got: {err}");
+        // TLSA with --cert-data → ok.
+        assert!(validate_tlsa_values("TLSA", &[], &cert).is_ok());
+        // A non-TLSA type with --cert-data → rejected.
+        let err = validate_tlsa_values("A", &value, &cert).expect_err("--cert-data is TLSA-only");
+        assert!(err.contains("only valid for TLSA"), "got: {err}");
+        // A non-TLSA type with --data → ok.
+        assert!(validate_tlsa_values("A", &value, &[]).is_ok());
     }
 }

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -345,15 +345,23 @@ pub(super) fn record_value(rec: &types::DnsRecord) -> Option<&str> {
 /// four JSON fields is that API's own modeling, not something DNS does (same
 /// story as CAA's `flag`/`tag`/`data` split). The write path (`v3_record`)
 /// never populates `data` for TLSA, so `dns list` reconstructs it here for
-/// display; the original four fields are left untouched alongside it.
+/// display; the original four fields are left untouched alongside it. Only
+/// builds the full presentation string when all three numeric fields are
+/// present — the API's schema guarantees that together for a real TLSA
+/// record, but substituting 0 (a real, meaningful usage/selector/matching-type
+/// value, not a sentinel) for a genuinely absent field would fabricate RDATA
+/// that was never actually returned; fall back to the certificate data alone.
 pub(super) fn merged_tlsa_data(rec: &types::DnsRecord) -> String {
-    format!(
-        "{} {} {} {}",
-        rec.usage.as_ref().map_or(0, |u| u.0),
-        rec.selector.as_ref().map_or(0, |s| s.0),
-        rec.matching_type.as_ref().map_or(0, |m| m.0),
-        rec.certificate_data.as_deref().unwrap_or(""),
-    )
+    match (&rec.usage, &rec.selector, &rec.matching_type) {
+        (Some(usage), Some(selector), Some(matching_type)) => format!(
+            "{} {} {} {}",
+            usage.0,
+            selector.0,
+            matching_type.0,
+            rec.certificate_data.as_deref().unwrap_or(""),
+        ),
+        _ => rec.certificate_data.clone().unwrap_or_default(),
+    }
 }
 
 /// Whether two v3 records have the same content — every field except `ttl`
@@ -649,6 +657,21 @@ mod tests {
         let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
         let tlsa = v3_record("www", "TLSA", cert, &tlsa_opts);
         assert_eq!(merged_tlsa_data(&tlsa), format!("3 1 1 {cert}"));
+    }
+
+    /// The API's schema guarantees usage/selector/matchingType/certificateData
+    /// together for a real TLSA record, but if one is ever absent, this must
+    /// not fabricate RDATA by substituting 0 (a real, meaningful value).
+    #[test]
+    fn merged_tlsa_data_falls_back_to_certificate_data_when_a_numeric_field_is_missing() {
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let mut tlsa = v3_record("www", "TLSA", cert, &opts());
+        // opts() has no usage/selector/matching_type set, so v3_record leaves
+        // them None — exactly the "missing field" case.
+        assert_eq!(merged_tlsa_data(&tlsa), cert);
+
+        tlsa.certificate_data = None;
+        assert_eq!(merged_tlsa_data(&tlsa), "");
     }
 
     #[test]

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -326,8 +326,15 @@ pub(super) fn v3_records(
 /// [`v3_record`]'s TLSA branch). Conflict diagnosis, delete/set reporting, and
 /// exact-duplicate detection all need "the value" regardless of which wire
 /// field holds it, so they read through this rather than `data` directly.
+/// Checks `type_` rather than just falling back on an absent `data`, so a
+/// TLSA record correctly prefers `certificateData` even if the API ever
+/// returns both fields populated.
 pub(super) fn record_value(rec: &types::DnsRecord) -> Option<&str> {
-    rec.data.as_deref().or(rec.certificate_data.as_deref())
+    if rec.type_.as_str() == "TLSA" {
+        rec.certificate_data.as_deref().or(rec.data.as_deref())
+    } else {
+        rec.data.as_deref().or(rec.certificate_data.as_deref())
+    }
 }
 
 /// List every v3 DNS record for a zone matching the optional `type`/`name`
@@ -567,5 +574,28 @@ mod tests {
         assert!(err.contains("only valid for TLSA"), "got: {err}");
         // A non-TLSA type with --data → ok.
         assert!(validate_tlsa_values("A", &value, &[]).is_ok());
+    }
+
+    #[test]
+    fn record_value_prefers_certificate_data_for_tlsa_even_if_data_is_also_set() {
+        // A record we'd never build ourselves (v3_record always nulls one of
+        // the two), but defends against the API ever returning both fields
+        // populated for a TLSA record — the certificate data must win, not
+        // whichever field happens to be checked first.
+        let mut tlsa = v3_record(
+            "www",
+            "TLSA",
+            "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971",
+            &opts(),
+        );
+        tlsa.data = Some("stale-or-unrelated".to_string());
+        assert_eq!(
+            record_value(&tlsa),
+            Some("d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971")
+        );
+
+        // Non-TLSA types are unaffected — `data` still wins.
+        let a = v3_record("www", "A", "1.2.3.4", &opts());
+        assert_eq!(record_value(&a), Some("1.2.3.4"));
     }
 }

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -356,6 +356,28 @@ pub(super) fn merged_tlsa_data(rec: &types::DnsRecord) -> String {
     )
 }
 
+/// Whether two v3 records have the same content — every field except `ttl`
+/// and `recordId`, neither of which makes two records a different *value*
+/// (a TTL-only change was never treated as a new value, and `recordId` only
+/// ever exists on a fetched record, never a desired one). Used by
+/// duplicate/no-op detection so a record type whose identity spans several
+/// fields (CAA's `flag`/`tag`, SRV's `priority`/`weight`/`port`, TLSA's
+/// `usage`/`selector`/`matchingType`, HTTPS/SVCB's `priority`/`parameters`)
+/// isn't misjudged by comparing only [`record_value`]. Compares via JSON
+/// rather than a hand-maintained field list, so a future `DnsRecord` field
+/// is covered without another update here.
+pub(super) fn same_content(a: &types::DnsRecord, b: &types::DnsRecord) -> bool {
+    let strip = |r: &types::DnsRecord| {
+        let mut v = serde_json::to_value(r).unwrap_or(serde_json::Value::Null);
+        if let Some(obj) = v.as_object_mut() {
+            obj.remove("ttl");
+            obj.remove("recordId");
+        }
+        v
+    };
+    strip(a) == strip(b)
+}
+
 /// List every v3 DNS record for a zone matching the optional `type`/`name`
 /// filters, paging through the collection (v3 list is paginated). Shared by
 /// `list`, `set`, and `delete` — the latter two need the matching records' ids.
@@ -627,5 +649,36 @@ mod tests {
         let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
         let tlsa = v3_record("www", "TLSA", cert, &tlsa_opts);
         assert_eq!(merged_tlsa_data(&tlsa), format!("3 1 1 {cert}"));
+    }
+
+    #[test]
+    fn same_content_compares_every_field_except_ttl_and_record_id() {
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let mut tlsa_opts = opts();
+        tlsa_opts.usage = Some(3);
+        tlsa_opts.selector = Some(1);
+        tlsa_opts.matching_type = Some(1);
+        tlsa_opts.ttl = Some(600);
+        let mut existing = v3_record("www", "TLSA", cert, &tlsa_opts);
+        existing.record_id = Some("r1".to_string());
+
+        // Identical content, different ttl/recordId → still the same record.
+        let desired = v3_record("www", "TLSA", cert, &tlsa_opts);
+        assert!(same_content(&existing, &desired));
+
+        // Same cert data, different usage → not the same record.
+        let mut different_usage = tlsa_opts;
+        different_usage.usage = Some(1);
+        let desired = v3_record("www", "TLSA", cert, &different_usage);
+        assert!(!same_content(&existing, &desired));
+
+        // CAA: same domain value, different tag → not the same record.
+        let mut caa_opts = opts();
+        caa_opts.tag = Some("issue".to_string());
+        let existing_caa = v3_record("@", "CAA", "letsencrypt.org", &caa_opts);
+        let mut caa_opts_wild = opts();
+        caa_opts_wild.tag = Some("issuewild".to_string());
+        let desired_caa = v3_record("@", "CAA", "letsencrypt.org", &caa_opts_wild);
+        assert!(!same_content(&existing_caa, &desired_caa));
     }
 }

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -117,17 +117,10 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "NAME")]
     pub(super) name: String,
 
-    /// Record value (repeatable for multiple records on the same name). Not
-    /// used for TLSA — use `--cert-data` instead.
-    // Required for every writable type except TLSA — clap has no "required
-    // unless" value match, so this lists WRITABLE_TYPES minus TLSA; keep the
-    // two in sync.
-    #[arg(long, value_name = "VALUE", required_if_eq_any([
-        ("record_type", "A"), ("record_type", "AAAA"), ("record_type", "ALIAS"),
-        ("record_type", "CAA"), ("record_type", "CNAME"), ("record_type", "HTTPS"),
-        ("record_type", "MX"), ("record_type", "SRV"), ("record_type", "SVCB"),
-        ("record_type", "TXT"),
-    ]))]
+    /// Record value (repeatable for multiple records on the same name). For
+    /// TLSA, this is the hex-encoded certificate association data; use
+    /// `--usage`/`--selector`/`--matching-type` for the rest.
+    #[arg(long, value_name = "VALUE", required = true)]
     pub(super) data: Vec<String>,
 
     /// Time-to-live in seconds (defaults to 3600 when omitted).
@@ -165,16 +158,6 @@ pub(super) struct RecordWriteArgs {
     /// CAA property tag, e.g. issue/issuewild/iodef (CAA only; required for CAA).
     #[arg(long, value_name = "TAG", required_if_eq("record_type", "CAA"))]
     pub(super) tag: Option<String>,
-
-    /// Certificate association data, hex-encoded (repeatable for multiple
-    /// records on the same name; TLSA only; required for TLSA, in place of
-    /// `--data`).
-    #[arg(
-        long = "cert-data",
-        value_name = "HEX",
-        required_if_eq("record_type", "TLSA")
-    )]
-    pub(super) cert_data: Vec<String>,
 
     /// TLSA certificate usage, 0-3 (RFC 6698 §2.1.1; TLSA only; required for
     /// TLSA). 0 PKIX-TA, 1 PKIX-EE, 2 DANE-TA, 3 DANE-EE.
@@ -229,27 +212,6 @@ pub(super) fn validate_tlsa_fields(record_type: &str, opts: &RecordOptions) -> R
     {
         return Err(format!(
             "--usage/--selector/--matching-type are only valid for TLSA records, not {record_type}"
-        ));
-    }
-    Ok(())
-}
-
-/// Validate `--data`/`--cert-data` against the record type: TLSA carries its
-/// value via `--cert-data` (clap's `required_if_eq` on `cert_data` already
-/// enforces that it's present for TLSA), never `--data`; every other type is
-/// the reverse. Pure so it's unit-testable and runs before any network call.
-pub(super) fn validate_tlsa_values(
-    record_type: &str,
-    data: &[String],
-    cert_data: &[String],
-) -> Result<(), String> {
-    if record_type == "TLSA" {
-        if !data.is_empty() {
-            return Err("TLSA records carry their value via --cert-data, not --data".to_string());
-        }
-    } else if !cert_data.is_empty() {
-        return Err(format!(
-            "--cert-data is only valid for TLSA records, not {record_type}"
         ));
     }
     Ok(())
@@ -606,23 +568,6 @@ mod tests {
         assert!(validate_svcb_fields("HTTPS", &a).is_ok());
         assert!(validate_svcb_fields("SVCB", &a).is_ok());
         assert!(validate_svcb_fields("A", &opts()).is_ok());
-    }
-
-    #[test]
-    fn tlsa_uses_cert_data_not_data_and_vice_versa_for_other_types() {
-        let cert = ["d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971".to_string()];
-        let value = ["1.2.3.4".to_string()];
-
-        // TLSA with --data instead of --cert-data → rejected.
-        let err = validate_tlsa_values("TLSA", &value, &[]).expect_err("TLSA needs --cert-data");
-        assert!(err.contains("--cert-data"), "got: {err}");
-        // TLSA with --cert-data → ok.
-        assert!(validate_tlsa_values("TLSA", &[], &cert).is_ok());
-        // A non-TLSA type with --cert-data → rejected.
-        let err = validate_tlsa_values("A", &value, &cert).expect_err("--cert-data is TLSA-only");
-        assert!(err.contains("only valid for TLSA"), "got: {err}");
-        // A non-TLSA type with --data → ok.
-        assert!(validate_tlsa_values("A", &value, &[]).is_ok());
     }
 
     #[test]

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -337,6 +337,25 @@ pub(super) fn record_value(rec: &types::DnsRecord) -> Option<&str> {
     }
 }
 
+/// Re-merge a TLSA record's split fields (`usage`/`selector`/`matchingType`/
+/// `certificateData`) back into a single presentation-format string, for
+/// `dns list` output. DNS itself treats a TLSA record's RDATA as one blob
+/// (RFC 6698 §2.1) — `dig`/zone-file output shows
+/// `"<usage> <selector> <matching-type> <hex>"` — the v3 API's split into
+/// four JSON fields is that API's own modeling, not something DNS does (same
+/// story as CAA's `flag`/`tag`/`data` split). The write path (`v3_record`)
+/// never populates `data` for TLSA, so `dns list` reconstructs it here for
+/// display; the original four fields are left untouched alongside it.
+pub(super) fn merged_tlsa_data(rec: &types::DnsRecord) -> String {
+    format!(
+        "{} {} {} {}",
+        rec.usage.as_ref().map_or(0, |u| u.0),
+        rec.selector.as_ref().map_or(0, |s| s.0),
+        rec.matching_type.as_ref().map_or(0, |m| m.0),
+        rec.certificate_data.as_deref().unwrap_or(""),
+    )
+}
+
 /// List every v3 DNS record for a zone matching the optional `type`/`name`
 /// filters, paging through the collection (v3 list is paginated). Shared by
 /// `list`, `set`, and `delete` — the latter two need the matching records' ids.
@@ -597,5 +616,16 @@ mod tests {
         // Non-TLSA types are unaffected — `data` still wins.
         let a = v3_record("www", "A", "1.2.3.4", &opts());
         assert_eq!(record_value(&a), Some("1.2.3.4"));
+    }
+
+    #[test]
+    fn merged_tlsa_data_reconstructs_the_rfc6698_presentation_format() {
+        let mut tlsa_opts = opts();
+        tlsa_opts.usage = Some(3);
+        tlsa_opts.selector = Some(1);
+        tlsa_opts.matching_type = Some(1);
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let tlsa = v3_record("www", "TLSA", cert, &tlsa_opts);
+        assert_eq!(merged_tlsa_data(&tlsa), format!("3 1 1 {cert}"));
     }
 }

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -285,9 +285,11 @@ pub(super) fn v3_records(
 
 /// The user-facing "value" of a fetched v3 `DnsRecord`: `data` for every type
 /// except TLSA, which carries its value in `certificateData` instead (see
-/// [`v3_record`]'s TLSA branch). Conflict diagnosis, delete/set reporting, and
-/// exact-duplicate detection all need "the value" regardless of which wire
-/// field holds it, so they read through this rather than `data` directly.
+/// [`v3_record`]'s TLSA branch). Delete/set per-record reporting and the
+/// CNAME-conflict message need "the value" regardless of which wire field
+/// holds it, so they read through this rather than `data` directly (exact-
+/// duplicate/no-op detection compares full records via [`same_content`]
+/// instead, since a shared value alone doesn't make two records identical).
 /// Checks `type_` rather than just falling back on an absent `data`, so a
 /// TLSA record correctly prefers `certificateData` even if the API ever
 /// returns both fields populated.
@@ -337,8 +339,12 @@ pub(super) fn merged_tlsa_data(rec: &types::DnsRecord) -> String {
 /// rather than a hand-maintained field list, so a future `DnsRecord` field
 /// is covered without another update here.
 pub(super) fn same_content(a: &types::DnsRecord, b: &types::DnsRecord) -> bool {
+    // `DnsRecord` is all plain String/Option/newtype fields, so this should
+    // never actually fail — falling back to a placeholder value on error
+    // would let two unrelated records that both failed to serialize compare
+    // as "equal" and silently skip a real change.
     let strip = |r: &types::DnsRecord| {
-        let mut v = serde_json::to_value(r).unwrap_or(serde_json::Value::Null);
+        let mut v = serde_json::to_value(r).expect("DnsRecord always serializes to JSON");
         if let Some(obj) = v.as_object_mut() {
             obj.remove("ttl");
             obj.remove("recordId");

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -7,7 +7,10 @@ use crate::output_schema::output_schema;
 use crate::scopes::DOMAINS_DNS_UPDATE;
 
 use super::records::verify_with_list_action;
-use super::records::{RecordOptions, RecordWriteArgs, fetch_records, validate_caa_fields};
+use super::records::{
+    RecordOptions, RecordWriteArgs, fetch_records, validate_caa_fields, validate_svcb_fields,
+    validate_tlsa_fields,
+};
 
 mod outcome;
 mod plan;
@@ -99,6 +102,10 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let data = args.write.data;
             let replace_conflicting = args.replace_conflicting_types;
             validate_caa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
+            validate_tlsa_fields(&record_type, &opts)
+                .map_err(crate::error::GddyError::validation)?;
+            validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
 
             let debug = !ctx.middleware.debug.is_empty();

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -8,8 +8,8 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 
 use super::records::verify_with_list_action;
 use super::records::{
-    RecordOptions, RecordWriteArgs, fetch_records, validate_caa_fields, validate_svcb_fields,
-    validate_tlsa_fields,
+    RecordOptions, RecordWriteArgs, fetch_records, record_value, validate_caa_fields,
+    validate_svcb_fields, validate_tlsa_fields,
 };
 
 mod outcome;
@@ -182,7 +182,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                                 &req,
                                 &record_id,
                                 &old_detail,
-                                old_record.and_then(|r| r.data.as_deref()),
+                                old_record.and_then(record_value),
                             )
                             .await,
                         );

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -9,7 +9,7 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 use super::records::verify_with_list_action;
 use super::records::{
     RecordOptions, RecordWriteArgs, fetch_records, validate_caa_fields, validate_svcb_fields,
-    validate_tlsa_fields, validate_tlsa_values,
+    validate_tlsa_fields,
 };
 
 mod outcome;
@@ -106,13 +106,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 .map_err(crate::error::GddyError::validation)?;
             validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
-            validate_tlsa_values(&record_type, &args.write.data, &args.write.cert_data)
-                .map_err(crate::error::GddyError::validation)?;
-            let data = if record_type == "TLSA" {
-                args.write.cert_data
-            } else {
-                args.write.data
-            };
+            let data = args.write.data;
 
             let debug = !ctx.middleware.debug.is_empty();
             let client = make_client(&ctx).await?;

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -9,7 +9,7 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 use super::records::verify_with_list_action;
 use super::records::{
     RecordOptions, RecordWriteArgs, fetch_records, record_value, validate_caa_fields,
-    validate_svcb_fields, validate_tlsa_fields,
+    validate_svcb_fields, validate_tlsa_fields, validate_tlsa_values,
 };
 
 mod outcome;
@@ -99,7 +99,6 @@ pub(super) fn command() -> RuntimeCommandSpec {
             let domain = args.write.domain;
             let record_type = args.write.record_type;
             let name = args.write.name;
-            let data = args.write.data;
             let replace_conflicting = args.replace_conflicting_types;
             validate_caa_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
@@ -107,6 +106,13 @@ pub(super) fn command() -> RuntimeCommandSpec {
                 .map_err(crate::error::GddyError::validation)?;
             validate_svcb_fields(&record_type, &opts)
                 .map_err(crate::error::GddyError::validation)?;
+            validate_tlsa_values(&record_type, &args.write.data, &args.write.cert_data)
+                .map_err(crate::error::GddyError::validation)?;
+            let data = if record_type == "TLSA" {
+                args.write.cert_data
+            } else {
+                args.write.data
+            };
 
             let debug = !ctx.middleware.debug.is_empty();
             let client = make_client(&ctx).await?;

--- a/rust/src/dns/set/mod.rs
+++ b/rust/src/dns/set/mod.rs
@@ -8,8 +8,8 @@ use crate::scopes::DOMAINS_DNS_UPDATE;
 
 use super::records::verify_with_list_action;
 use super::records::{
-    RecordOptions, RecordWriteArgs, fetch_records, record_value, validate_caa_fields,
-    validate_svcb_fields, validate_tlsa_fields, validate_tlsa_values,
+    RecordOptions, RecordWriteArgs, fetch_records, validate_caa_fields, validate_svcb_fields,
+    validate_tlsa_fields, validate_tlsa_values,
 };
 
 mod outcome;
@@ -183,14 +183,7 @@ pub(super) fn command() -> RuntimeCommandSpec {
                             .find(|r| r.record_id.as_deref() == Some(record_id.as_str()));
                         let old_detail = record_label(&existing, &record_type, &record_id);
                         outcomes.extend(
-                            apply_replace(
-                                &client,
-                                &req,
-                                &record_id,
-                                &old_detail,
-                                old_record.and_then(record_value),
-                            )
-                            .await,
+                            apply_replace(&client, &req, &record_id, &old_detail, old_record).await,
                         );
                     }
                     SetAction::Create { data: value } => {

--- a/rust/src/dns/set/outcome.rs
+++ b/rust/src/dns/set/outcome.rs
@@ -5,6 +5,7 @@
 use domains_client::types;
 use serde_json::{Value, json};
 
+use super::super::records::record_value;
 use super::plan::SetAction;
 
 /// Outcome of one applied `set` reconcile action, for reporting.
@@ -125,7 +126,7 @@ pub(super) fn record_label(
     existing
         .iter()
         .find(|r| r.record_id.as_deref() == Some(record_id))
-        .map(|r| format!("{record_type} {}", r.data.as_deref().unwrap_or("(no data)")))
+        .map(|r| format!("{record_type} {}", record_value(r).unwrap_or("(no data)")))
         .unwrap_or_else(|| record_id.to_string())
 }
 
@@ -133,6 +134,40 @@ pub(super) fn record_label(
 mod tests {
     use super::*;
     use crate::dns::set::plan::plan_set;
+
+    fn tlsa_record(record_id: &str, cert: &str) -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: Some(cert.to_owned()),
+            matching_type: None,
+            selector: None,
+            usage: None,
+            data: None,
+            flag: None,
+            name: "www".to_owned(),
+            parameters: None,
+            port: None,
+            priority: None,
+            protocol: None,
+            record_id: Some(record_id.to_owned()),
+            service: None,
+            tag: None,
+            ttl: 3600,
+            type_: types::DnsRecordType("TLSA".to_owned()),
+            weight: None,
+        }
+    }
+
+    /// TLSA's value lives in `certificate_data`, not `data` — the label must
+    /// read through `record_value` to show it rather than "(no data)".
+    #[test]
+    fn record_label_shows_tlsa_certificate_data_as_the_value() {
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let existing = vec![tlsa_record("r1", cert)];
+        assert_eq!(
+            record_label(&existing, "TLSA", "r1"),
+            format!("TLSA {cert}")
+        );
+    }
 
     #[test]
     fn summarize_set_reports_counts_and_flags_partial_failure() {

--- a/rust/src/dns/set/write.rs
+++ b/rust/src/dns/set/write.rs
@@ -266,6 +266,10 @@ mod tests {
             service: None,
             flag: None,
             tag: None,
+            usage: None,
+            selector: None,
+            matching_type: None,
+            parameters: None,
         }
     }
 
@@ -290,6 +294,93 @@ mod tests {
             name: "www",
             record_type: "A",
             value: "1.2.3.4",
+            opts: &opts,
+            replace_conflicting: false,
+            debug: false,
+        };
+        let outcomes = write_with_conflict_handling(&client_for(&server), &req).await;
+
+        create.assert_async().await;
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].kind, "created");
+        assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+    }
+
+    #[tokio::test]
+    async fn write_with_conflict_handling_sends_https_parameters_in_request_body() {
+        let server = MockServer::start_async().await;
+        let create = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v3/domains/zones/example.com/dns-records")
+                    .json_body(json!({
+                        "data": ".",
+                        "name": "@",
+                        "parameters": "alpn=h2,h3",
+                        "priority": 1,
+                        "ttl": 3600,
+                        "type": "HTTPS"
+                    }));
+                then.status(201)
+                    .json_body(json!({ "type": "HTTPS", "name": "@", "data": ".", "ttl": 3600 }));
+            })
+            .await;
+
+        let mut opts = write_opts();
+        opts.priority = Some(1);
+        opts.parameters = Some("alpn=h2,h3".to_string());
+        let req = WriteRequest {
+            domain: "example.com",
+            name: "@",
+            record_type: "HTTPS",
+            value: ".",
+            opts: &opts,
+            replace_conflicting: false,
+            debug: false,
+        };
+        let outcomes = write_with_conflict_handling(&client_for(&server), &req).await;
+
+        create.assert_async().await;
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].kind, "created");
+        assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+    }
+
+    #[tokio::test]
+    async fn write_with_conflict_handling_sends_tlsa_fields_in_request_body() {
+        let server = MockServer::start_async().await;
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let create = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v3/domains/zones/example.com/dns-records")
+                    .json_body(json!({
+                        "certificateData": cert,
+                        "matchingType": 1,
+                        "name": "www",
+                        "port": 443,
+                        "protocol": "_tcp",
+                        "selector": 1,
+                        "ttl": 3600,
+                        "type": "TLSA",
+                        "usage": 3
+                    }));
+                then.status(201)
+                    .json_body(json!({ "type": "TLSA", "name": "www", "ttl": 3600 }));
+            })
+            .await;
+
+        let mut opts = write_opts();
+        opts.usage = Some(3);
+        opts.selector = Some(1);
+        opts.matching_type = Some(1);
+        opts.protocol = Some("_tcp".to_string());
+        opts.port = Some(443);
+        let req = WriteRequest {
+            domain: "example.com",
+            name: "www",
+            record_type: "TLSA",
+            value: cert,
             opts: &opts,
             replace_conflicting: false,
             debug: false,

--- a/rust/src/dns/set/write.rs
+++ b/rust/src/dns/set/write.rs
@@ -7,7 +7,7 @@ use domains_client::types;
 use crate::dns::conflicts::{
     conflicting_records, conflicting_records_at, describe_duplicate_record, duplicate_record_issue,
 };
-use crate::dns::records::{RecordOptions, v3_record};
+use crate::dns::records::{RecordOptions, record_value, v3_record};
 use crate::domain::{api_error, format_api_error};
 
 use super::outcome::SetOutcome;
@@ -41,7 +41,7 @@ async fn delete_conflicts(
         let detail = format!(
             "{} {}",
             rec.type_.as_str(),
-            rec.data.as_deref().unwrap_or("(no data)")
+            record_value(rec).unwrap_or("(no data)")
         );
         let Some(record_id) = rec.record_id.as_deref() else {
             outcomes.push(SetOutcome::new(

--- a/rust/src/dns/set/write.rs
+++ b/rust/src/dns/set/write.rs
@@ -7,7 +7,7 @@ use domains_client::types;
 use crate::dns::conflicts::{
     conflicting_records, conflicting_records_at, describe_duplicate_record, duplicate_record_issue,
 };
-use crate::dns::records::{RecordOptions, record_value, v3_record};
+use crate::dns::records::{RecordOptions, record_value, same_content, v3_record};
 use crate::domain::{api_error, format_api_error};
 
 use super::outcome::SetOutcome;
@@ -144,6 +144,7 @@ pub(super) async fn write_with_conflict_handling(
             req.value,
             req.domain,
             req.name,
+            req.opts,
             &at_name,
             true,
         );
@@ -173,13 +174,17 @@ pub(super) async fn write_with_conflict_handling(
 /// is the least-destructive way to emulate one: if the create fails, the old
 /// record is left untouched rather than risking data loss.
 ///
-/// `old_data` is the record's *current* value, if known — when it already
-/// equals `req.value` (a no-op `set`, e.g. re-running the same command, or
-/// only some of several values actually changed) this is a no-op: creating
-/// the "new" value while the identical old record still exists would fail
-/// with v3's exact-duplicate `DUPLICATE_RECORD` (see
+/// `old_record` is the record being replaced, if known — when its content
+/// already matches the desired record (a no-op `set`, e.g. re-running the
+/// same command, or only some of several values actually changed) this is a
+/// no-op: creating the "new" value while the identical old record still
+/// exists would fail with v3's exact-duplicate `DUPLICATE_RECORD` (see
 /// [`crate::dns::conflicts::describe_duplicate_record`]), which isn't a real
-/// failure, just this pairing having nothing to do.
+/// failure, just this pairing having nothing to do. Compares full record
+/// content ([`same_content`]), not just the value — a record type whose
+/// identity spans several fields (CAA's `flag`/`tag`, TLSA's `usage`/
+/// `selector`/`matchingType`, …) could otherwise have a field-only change
+/// wrongly skipped as a no-op.
 ///
 /// Relabels the create outcome's `kind` from `"created"` to `"replaced"` so
 /// `summarize_set_outcomes`'s tallies mean what the user asked for. If the
@@ -192,9 +197,10 @@ pub(super) async fn apply_replace(
     req: &WriteRequest<'_>,
     old_record_id: &str,
     old_detail: &str,
-    old_data: Option<&str>,
+    old_record: Option<&types::DnsRecord>,
 ) -> Vec<SetOutcome> {
-    if old_data == Some(req.value) {
+    let desired = v3_record(req.name, req.record_type, req.value, req.opts);
+    if old_record.is_some_and(|r| same_content(r, &desired)) {
         return vec![SetOutcome::new("replaced", req.value.to_string(), None)];
     }
 
@@ -523,6 +529,28 @@ mod tests {
         }
     }
 
+    fn old_a_record(data: &str) -> types::DnsRecord {
+        types::DnsRecord {
+            certificate_data: None,
+            matching_type: None,
+            selector: None,
+            usage: None,
+            data: Some(data.to_owned()),
+            flag: None,
+            name: "www".to_owned(),
+            parameters: None,
+            port: None,
+            priority: None,
+            protocol: None,
+            record_id: Some("old-1".to_owned()),
+            service: None,
+            tag: None,
+            ttl: 3600,
+            type_: types::DnsRecordType("A".to_owned()),
+            weight: None,
+        }
+    }
+
     #[tokio::test]
     async fn apply_replace_creates_then_deletes_the_old_record() {
         let server = MockServer::start_async().await;
@@ -545,12 +573,13 @@ mod tests {
 
         let opts = write_opts();
         let req = replace_req(&opts, "9.9.9.9");
+        let old_record = old_a_record("1.2.3.4");
         let outcomes = apply_replace(
             &client_for(&server),
             &req,
             "old-1",
             "A 1.2.3.4",
-            Some("1.2.3.4"),
+            Some(&old_record),
         )
         .await;
 
@@ -586,12 +615,13 @@ mod tests {
 
         let opts = write_opts();
         let req = replace_req(&opts, "1.2.3.4");
+        let old_record = old_a_record("1.2.3.4");
         let outcomes = apply_replace(
             &client_for(&server),
             &req,
             "old-1",
             "A 1.2.3.4",
-            Some("1.2.3.4"),
+            Some(&old_record),
         )
         .await;
 
@@ -608,6 +638,85 @@ mod tests {
         assert_eq!(outcomes.len(), 1);
         assert_eq!(outcomes[0].kind, "replaced");
         assert_eq!(outcomes[0].detail, "1.2.3.4");
+        assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+    }
+
+    /// A TLSA record's identity spans `usage`/`selector`/`matchingType`, not
+    /// just its certificate data — keeping the same `--cert-data` while
+    /// changing `--usage` is a real change, not a no-op, even though
+    /// comparing only the value string would say otherwise.
+    #[tokio::test]
+    async fn apply_replace_is_not_a_no_op_when_only_a_sibling_tlsa_field_changes() {
+        let server = MockServer::start_async().await;
+        let cert = "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971";
+        let create = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v3/domains/zones/example.com/dns-records");
+                then.status(201).json_body(json!({
+                    "type": "TLSA",
+                    "name": "www",
+                    "ttl": 3600,
+                    "usage": 1,
+                    "selector": 0,
+                    "matchingType": 0,
+                    "certificateData": cert
+                }));
+            })
+            .await;
+        let delete = server
+            .mock_async(|when, then| {
+                when.method(DELETE)
+                    .path("/v3/domains/zones/example.com/dns-records/old-1");
+                then.status(204);
+            })
+            .await;
+
+        let mut opts = write_opts();
+        opts.usage = Some(1);
+        opts.selector = Some(0);
+        opts.matching_type = Some(0);
+        let req = WriteRequest {
+            domain: "example.com",
+            name: "www",
+            record_type: "TLSA",
+            value: cert,
+            opts: &opts,
+            replace_conflicting: false,
+            debug: false,
+        };
+        let old_record = types::DnsRecord {
+            certificate_data: Some(cert.to_owned()),
+            matching_type: Some(types::TlsaMatchingType(1)),
+            selector: Some(types::TlsaSelector(1)),
+            usage: Some(types::TlsaUsage(3)),
+            data: None,
+            flag: None,
+            name: "www".to_owned(),
+            parameters: None,
+            port: None,
+            priority: None,
+            protocol: None,
+            record_id: Some("old-1".to_owned()),
+            service: None,
+            tag: None,
+            ttl: 3600,
+            type_: types::DnsRecordType("TLSA".to_owned()),
+            weight: None,
+        };
+        let outcomes = apply_replace(
+            &client_for(&server),
+            &req,
+            "old-1",
+            "TLSA 3 1 1 ...",
+            Some(&old_record),
+        )
+        .await;
+
+        create.assert_async().await;
+        delete.assert_async().await;
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].kind, "replaced");
         assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
     }
 
@@ -631,12 +740,13 @@ mod tests {
 
         let opts = write_opts();
         let req = replace_req(&opts, "9.9.9.9");
+        let old_record = old_a_record("1.2.3.4");
         let outcomes = apply_replace(
             &client_for(&server),
             &req,
             "old-1",
             "A 1.2.3.4",
-            Some("1.2.3.4"),
+            Some(&old_record),
         )
         .await;
 
@@ -676,12 +786,13 @@ mod tests {
 
         let opts = write_opts();
         let req = replace_req(&opts, "9.9.9.9");
+        let old_record = old_a_record("1.2.3.4");
         let outcomes = apply_replace(
             &client_for(&server),
             &req,
             "old-1",
             "A 1.2.3.4",
-            Some("1.2.3.4"),
+            Some(&old_record),
         )
         .await;
 

--- a/rust/src/dns/set/write.rs
+++ b/rust/src/dns/set/write.rs
@@ -184,7 +184,12 @@ pub(super) async fn write_with_conflict_handling(
 /// content ([`same_content`]), not just the value — a record type whose
 /// identity spans several fields (CAA's `flag`/`tag`, TLSA's `usage`/
 /// `selector`/`matchingType`, …) could otherwise have a field-only change
-/// wrongly skipped as a no-op.
+/// wrongly skipped as a no-op. `same_content` deliberately ignores `ttl`, so
+/// an explicit `--ttl` change (checked separately here, against the *raw*
+/// `req.opts.ttl` rather than `desired.ttl`'s defaulted value, so an omitted
+/// `--ttl` never forces a replace just because the default differs from the
+/// existing record's) still counts as a real change even when the value and
+/// every other field are unchanged.
 ///
 /// Relabels the create outcome's `kind` from `"created"` to `"replaced"` so
 /// `summarize_set_outcomes`'s tallies mean what the user asked for. If the
@@ -200,7 +205,11 @@ pub(super) async fn apply_replace(
     old_record: Option<&types::DnsRecord>,
 ) -> Vec<SetOutcome> {
     let desired = v3_record(req.name, req.record_type, req.value, req.opts);
-    if old_record.is_some_and(|r| same_content(r, &desired)) {
+    let ttl_changed = req
+        .opts
+        .ttl
+        .is_some_and(|t| old_record.map(|r| r.ttl) != Some(t));
+    if !ttl_changed && old_record.is_some_and(|r| same_content(r, &desired)) {
         return vec![SetOutcome::new("replaced", req.value.to_string(), None)];
     }
 
@@ -638,6 +647,100 @@ mod tests {
         assert_eq!(outcomes.len(), 1);
         assert_eq!(outcomes[0].kind, "replaced");
         assert_eq!(outcomes[0].detail, "1.2.3.4");
+        assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+    }
+
+    /// `same_content` deliberately ignores `ttl`, so an explicit `--ttl`
+    /// change has to be checked separately — otherwise a `dns set` that only
+    /// changes the TTL would be silently skipped as a no-op.
+    #[tokio::test]
+    async fn apply_replace_is_not_a_no_op_when_ttl_explicitly_changes() {
+        let server = MockServer::start_async().await;
+        let create = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v3/domains/zones/example.com/dns-records");
+                then.status(201).json_body(
+                    json!({ "type": "A", "name": "www", "data": "1.2.3.4", "ttl": 7200 }),
+                );
+            })
+            .await;
+        let delete = server
+            .mock_async(|when, then| {
+                when.method(DELETE)
+                    .path("/v3/domains/zones/example.com/dns-records/old-1");
+                then.status(204);
+            })
+            .await;
+
+        let mut opts = write_opts();
+        opts.ttl = Some(7200);
+        let req = replace_req(&opts, "1.2.3.4");
+        let old_record = old_a_record("1.2.3.4"); // ttl: 3600
+        let outcomes = apply_replace(
+            &client_for(&server),
+            &req,
+            "old-1",
+            "A 1.2.3.4",
+            Some(&old_record),
+        )
+        .await;
+
+        create.assert_async().await;
+        delete.assert_async().await;
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].kind, "replaced");
+        assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+    }
+
+    /// Omitting `--ttl` must not force a replace just because the CLI's
+    /// default (3600) differs from the existing record's actual TTL — only
+    /// an *explicit* `--ttl` counts as a real change.
+    #[tokio::test]
+    async fn apply_replace_is_still_a_no_op_when_ttl_is_omitted_even_if_existing_ttl_differs() {
+        let server = MockServer::start_async().await;
+        let create = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v3/domains/zones/example.com/dns-records");
+                then.status(201);
+            })
+            .await;
+        let delete = server
+            .mock_async(|when, then| {
+                when.method(DELETE)
+                    .path("/v3/domains/zones/example.com/dns-records/old-1");
+                then.status(204);
+            })
+            .await;
+
+        let opts = write_opts(); // ttl: None — no explicit --ttl
+        let req = replace_req(&opts, "1.2.3.4");
+        let old_record = types::DnsRecord {
+            ttl: 7200, // differs from v3_record's DEFAULT_TTL fallback (3600)
+            ..old_a_record("1.2.3.4")
+        };
+        let outcomes = apply_replace(
+            &client_for(&server),
+            &req,
+            "old-1",
+            "A 1.2.3.4",
+            Some(&old_record),
+        )
+        .await;
+
+        assert_eq!(
+            create.calls_async().await,
+            0,
+            "no create for a no-op replace"
+        );
+        assert_eq!(
+            delete.calls_async().await,
+            0,
+            "no delete for a no-op replace"
+        );
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].kind, "replaced");
         assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
     }
 

--- a/rust/src/dns/set/write.rs
+++ b/rust/src/dns/set/write.rs
@@ -745,9 +745,9 @@ mod tests {
     }
 
     /// A TLSA record's identity spans `usage`/`selector`/`matchingType`, not
-    /// just its certificate data — keeping the same `--cert-data` while
-    /// changing `--usage` is a real change, not a no-op, even though
-    /// comparing only the value string would say otherwise.
+    /// just its certificate data — keeping the same `--data` while changing
+    /// `--usage` is a real change, not a no-op, even though comparing only
+    /// the value string would say otherwise.
     #[tokio::test]
     async fn apply_replace_is_not_a_no_op_when_only_a_sibling_tlsa_field_changes() {
         let server = MockServer::start_async().await;


### PR DESCRIPTION
## Summary
- `gddy dns add`/`set`/`delete`/`list` now recognize `HTTPS`, `SVCB`, and `TLSA` record types (DEVEX-1105).
- TLSA reuses the existing `--data` flag for its certificate association data (hex-encoded) — same pattern as CAA/SRV/MX/HTTPS/SVCB, which all also split their RDATA across `--data` (the primary value) plus sibling flags. Adds dedicated `--usage`/`--selector`/`--matching-type` flags for the rest, clap-validated to their actual RFC 6698 ranges (0-3/0-1/0-2).
- HTTPS/SVCB get a new `--parameters` flag for SvcParams; `--priority` (already existing) doubles as SvcPriority.
- `dns list` re-merges TLSA's split fields (`usage`/`selector`/`matchingType`/`certificateData`) back into a single `data` string matching DNS's actual RDATA presentation format (RFC 6698 — same as `dig`/zone-file output), since the v3 API's `data` field is the one exception that goes unused for TLSA on the wire. The original four fields stay available alongside it.
- Duplicate/no-op detection (`dns add`'s "exact value already exists" message, `dns set`'s replace-vs-no-op decision) now compares full record content, not just the primary value — fixes a pre-existing gap (not new to this PR) that affected every multi-field type: CAA (`flag`/`tag`), SRV (`priority`/`weight`/`port`), and now TLSA (`usage`/`selector`/`matchingType`)/HTTPS/SVCB (`priority`/`parameters`) too. Also fixes `dns set --ttl <new>` being silently skipped as a no-op when only the TTL changed.

Rebased onto `main` now that #244 (spec drift resync, which this depends on for the real TLSA/HTTPS/SVCB API fields) has merged.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (773 passed)
- [x] `cargo fmt --check`
- [x] `./rust/scripts/check-module-size.sh`
- [x] Multiple rounds of Copilot review feedback addressed
- [x] GitHub Advanced Security CodeQL alert reviewed and dismissed (false positive: cleartext-logging heuristic on test-only DNS/TLSA values, which aren't secrets)