### PR TITLE
feat(platform): add app enablements command (DEVX-1075)

### DIFF
--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -170,6 +170,20 @@ impl ApplicationClient {
         Ok(json!(nodes))
     }
 
+    /// Lists applications currently enabled for a store.
+    pub async fn list_enabled_applications(&self, store_id: &str) -> Result<Value, ClientError> {
+        let data = self
+            .query(json!({
+                "query": "query EnabledStoreApplications($storeId: String!) { enabledStoreApplications(storeId: $storeId) { id label name description status url proxyUrl release { id version description status createdAt updatedAt activatedAt } } }",
+                "variables": { "storeId": store_id }
+            }))
+            .await?;
+        Ok(data
+            .get("enabledStoreApplications")
+            .cloned()
+            .unwrap_or_else(|| json!([])))
+    }
+
     pub async fn get_application(&self, name: &str) -> Result<Value, ClientError> {
         self.query(json!({
             "query": "query Application($name: String!) { application(name: $name) { id label name description status url proxyUrl } }",
@@ -458,6 +472,43 @@ mod tests {
         mock.assert_async().await;
         assert_eq!(data.as_array().expect("array").len(), 2);
         assert_eq!(data[1]["status"], "INACTIVE");
+    }
+
+    #[tokio::test]
+    async fn list_enabled_applications_sends_store_id_and_returns_nodes() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .header("authorization", "Bearer test-token")
+                    .is_true(|req| {
+                        let body = req.body_string();
+                        body.contains("EnabledStoreApplications")
+                            && body.contains(r#""storeId":"store-123""#)
+                            && body.contains("release")
+                    });
+                then.status(200).json_body(json!({
+                    "data": {
+                        "enabledStoreApplications": [{
+                            "id": "app-1",
+                            "name": "test-app",
+                            "status": "ACTIVE",
+                            "release": { "id": "release-1", "version": "1.0.0" }
+                        }]
+                    }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .list_enabled_applications("store-123")
+            .await
+            .expect("list enabled applications");
+
+        mock.assert_async().await;
+        assert_eq!(data[0]["id"], "app-1");
+        assert_eq!(data[0]["release"]["version"], "1.0.0");
     }
 
     #[tokio::test]

--- a/rust/src/application/commands/enablements.rs
+++ b/rust/src/application/commands/enablements.rs
@@ -1,0 +1,54 @@
+//! `gddy platform app enablements` — list applications enabled for a store.
+
+use cli_engine::{CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, Tier};
+
+use super::schemas::EnabledApplication;
+use crate::next_action::{next_action, required_value};
+use crate::scopes::APP_REGISTRY_READ;
+
+#[derive(Debug, Clone, clap::Args)]
+struct EnablementsArgs {
+    /// Store ID whose enabled applications should be listed.
+    #[arg(long = "store-id", value_name = "STORE_ID")]
+    store_id: String,
+}
+
+pub(super) fn command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed_with_context::<EnablementsArgs, _, _, _>(
+        CommandSpec::from_args::<EnablementsArgs>(
+            "enablements",
+            "List applications enabled on a store",
+        )
+        .with_long(
+            "List all GoDaddy developer-platform applications enabled for a \
+            store by its store ID.",
+        )
+        .with_system("applications")
+        .with_tier(Tier::Read)
+        .with_scopes(&[APP_REGISTRY_READ])
+        .with_default_fields("name,label,status")
+        .with_output_schema::<EnabledApplication>(),
+        |ctx, args: EnablementsArgs| async move {
+            let store_id = args.store_id;
+            let client = super::make_client(&ctx).await?;
+            let applications = client
+                .list_enabled_applications(&store_id)
+                .await
+                .map_err(super::client_err)?;
+
+            Ok(CommandResult::new(applications).with_next_actions(vec![
+                next_action(
+                    "platform app info --name <name>",
+                    "Inspect one of the enabled applications",
+                )
+                .with_param("name", NextActionParam::required()),
+                next_action(
+                    "platform app disable <name> --store-id <store-id>",
+                    "Disable an application on this store",
+                )
+                .with_param("name", NextActionParam::required())
+                .with_param("store-id", required_value(&store_id)),
+            ]))
+        },
+    )
+}

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -10,6 +10,7 @@ mod add;
 mod add_extension;
 mod config;
 mod deploy;
+mod enablements;
 mod info;
 mod init;
 mod lifecycle;
@@ -75,6 +76,7 @@ pub fn application_group() -> RuntimeGroupSpec {
             .with_alias("application"),
     )
     .with_command(list::command())
+    .with_command(enablements::command())
     .with_command(info::command())
     .with_command(init::command())
     .with_command(validate::command())

--- a/rust/src/application/commands/schemas.rs
+++ b/rust/src/application/commands/schemas.rs
@@ -12,6 +12,17 @@ output_schema!(ApplicationSummary {
     "proxyUrl": "string", optional;
 });
 
+output_schema!(EnabledApplication {
+    "id": "string";
+    "name": "string";
+    "label": "string", optional;
+    "description": "string", optional;
+    "status": "string";
+    "url": "string", optional;
+    "proxyUrl": "string", optional;
+    "release": "object", optional;
+});
+
 output_schema!(ApplicationInit {
     "id": "string";
     "name": "string";

--- a/rust/src/platform/guides/platform-overview.md
+++ b/rust/src/platform/guides/platform-overview.md
@@ -54,6 +54,7 @@ Makes the application (and everything in its latest release — actions, subscri
 
 - `gddy platform app validate <name>` — check *remote* application state (URL/proxy-url set, not INACTIVE), as opposed to `config validate`'s local manifest check.
 - `gddy platform app info --name <name>` / `list` — inspect a single app or list all of them.
+- `gddy platform app enablements --store-id <storeId>` — list the applications enabled for a store.
 - `gddy platform app archive <name>` — irreversible; confirm the name with `list` first.
 - `gddy platform actions` / `gddy platform webhook` — browse the platform's action and webhook-event catalogs (used when choosing values for `add action`/`add subscription`).
 


### PR DESCRIPTION
## Summary

Adds `gddy platform app enablements --store-id <store-id>` to list applications enabled for a store.

- Calls the App Registry `enabledStoreApplications` GraphQL query.
- Returns application and enabled release details.
- Uses the existing `apps.app-registry:read` scope.
- Adds client HTTP coverage and platform guide documentation.

## Validation

- `git diff --check`
- Rust checks were not run because Cargo is unavailable in the local environment.
