### PR TITLE
feat(platform): add store app enablements command

### DIFF
--- a/docs/application-settings.md
+++ b/docs/application-settings.md
@@ -30,7 +30,7 @@ An application-settings capability lets a GoDaddy Platform Application (GPA) con
    { "error": { "code": "VALIDATION_ERROR", "message": "settings 'godaddy-tax' has no presentation — add a [settings.presentation] block or a presentationFile before releasing" } }
    ```
 
-4. **Enable/backfill** — `gddy platform app enable <name> --store-id <storeId>` makes the placement discoverable for a store. Settings (like actions/subscriptions/uiExtensions) are keyed per-release with no inheritance — a store already enabled against an older release doesn't pick up settings added in a newer one until `enable` is re-run for that store.
+4. **Enable/backfill** — `gddy platform app enable <name> --store-id <storeId>` makes the placement discoverable for a store. Confirm with `gddy platform app enablements --store-id <storeId>` (lists apps currently enabled on that store). Settings (like actions/subscriptions/uiExtensions) are keyed per-release with no inheritance — a store already enabled against an older release doesn't pick up settings added in a newer one until `enable` is re-run for that store.
 
 ## Presentation shape
 
@@ -181,5 +181,5 @@ Deeper semantics stay server-validated — bounds consistency (`maxLength ≥ mi
 ## Gotchas
 
 - **No release inheritance.** `release` resends every current setting from `godaddy.toml`; leaving one out doesn't archive it globally, but any store enabled against the *new* release loses it.
-- **Existing stores don't auto-upgrade.** Adding settings to a release only affects stores enabled *after* that release goes active — re-run `gddy platform app enable <name> --store-id <storeId>` per store to backfill.
+- **Existing stores don't auto-upgrade.** Adding settings to a release only affects stores enabled *after* that release goes active — re-run `gddy platform app enable <name> --store-id <storeId>` per store to backfill, then `gddy platform app enablements --store-id <storeId>` to confirm.
 - **`presentation`/`presentationFile` is mandatory before release, not before `add settings`.** A placement-only entry parses and works fine for every other command (`add action`, `info`, `validate`, `deploy`) — it only fails at `release`, with the message shown above.

--- a/rust/src/application/client.rs
+++ b/rust/src/application/client.rs
@@ -222,6 +222,27 @@ impl ApplicationClient {
         .await
     }
 
+    /// Lists applications enabled on a commerce store.
+    ///
+    /// Returns an empty JSON array when nothing is enabled (not an error).
+    /// `storeId` is sent as a GraphQL variable only — same pattern as
+    /// [`Self::enable_application`] / [`Self::disable_application`].
+    pub async fn list_enabled_store_applications(
+        &self,
+        store_id: &str,
+    ) -> Result<Value, ClientError> {
+        let data = self
+            .query(json!({
+                "query": "query EnabledStoreApplications($storeId: String!) { enabledStoreApplications(storeId: $storeId) { id name label status release { id version } } }",
+                "variables": { "storeId": store_id }
+            }))
+            .await?;
+        Ok(data
+            .get("enabledStoreApplications")
+            .cloned()
+            .unwrap_or_else(|| json!([])))
+    }
+
     pub async fn archive_application(&self, id: &str) -> Result<Value, ClientError> {
         self.query(json!({
             "query": "mutation ArchiveApplication($id: String!) { archiveApplication(id: $id) { id label name status createdAt archivedAt } }",
@@ -487,6 +508,71 @@ mod tests {
 
         mock.assert_async().await;
         assert_eq!(data["activateRelease"]["status"], "ACTIVE");
+    }
+
+    #[tokio::test]
+    async fn list_enabled_store_applications_sends_store_id_variable() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .header("authorization", "Bearer test-token")
+                    .is_true(|req| {
+                        let body = req.body_string();
+                        body.contains("EnabledStoreApplications")
+                            && body.contains("enabledStoreApplications")
+                            && body.contains(r#""storeId":"store-abc""#)
+                            && body.contains("label")
+                    });
+                then.status(200).json_body(json!({
+                    "data": {
+                        "enabledStoreApplications": [{
+                            "id": "app-1",
+                            "name": "my-app",
+                            "label": "My App",
+                            "status": "ACTIVE",
+                            "release": { "id": "rel-1", "version": "1.0.0" }
+                        }]
+                    }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .list_enabled_store_applications("store-abc")
+            .await
+            .expect("list enabled store applications");
+
+        mock.assert_async().await;
+        assert_eq!(data.as_array().expect("array").len(), 1);
+        assert_eq!(data[0]["name"], "my-app");
+        assert_eq!(data[0]["label"], "My App");
+        assert_eq!(data[0]["release"]["version"], "1.0.0");
+    }
+
+    #[tokio::test]
+    async fn list_enabled_store_applications_empty_list_is_success() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/apps/app-registry-subgraph")
+                    .header("authorization", "Bearer test-token")
+                    .is_true(|req| req.body_string().contains("EnabledStoreApplications"));
+                then.status(200).json_body(json!({
+                    "data": { "enabledStoreApplications": [] }
+                }));
+            })
+            .await;
+
+        let data = ApplicationClient::new(server.base_url(), "test-token")
+            .list_enabled_store_applications("store-empty")
+            .await
+            .expect("empty enablements");
+
+        mock.assert_async().await;
+        assert_eq!(data, json!([]));
     }
 
     #[tokio::test]

--- a/rust/src/application/commands/enablements.rs
+++ b/rust/src/application/commands/enablements.rs
@@ -165,10 +165,7 @@ mod tests {
     #[test]
     fn flatten_enablements_null_release_version_when_missing() {
         let input = json!([{ "id": "app-1", "name": "my-app", "status": "ACTIVE" }]);
-        assert_eq!(
-            flatten_enablements(input)[0]["releaseVersion"],
-            json!(null)
-        );
+        assert_eq!(flatten_enablements(input)[0]["releaseVersion"], json!(null));
     }
 
     #[test]

--- a/rust/src/application/commands/enablements.rs
+++ b/rust/src/application/commands/enablements.rs
@@ -1,0 +1,217 @@
+//! `gddy platform app enablements` — list apps enabled on a commerce store.
+
+use cli_engine::{
+    CommandResult, CommandSpec, NextActionParam, RuntimeCommandSpec, TableColumn, Tier,
+};
+use serde_json::{Value, json};
+
+use super::schemas::StoreEnablement;
+use crate::next_action::{next_action, required_value};
+use crate::scopes::APP_REGISTRY_READ;
+
+#[derive(Debug, Clone, clap::Args)]
+struct EnablementsArgs {
+    /// Commerce store ID whose enablements to list.
+    #[arg(long = "store-id", value_name = "STORE_ID")]
+    store_id: String,
+}
+
+fn view_columns() -> Vec<TableColumn> {
+    vec![
+        TableColumn::new("name", "Name"),
+        TableColumn::new("status", "Status"),
+        TableColumn::new("releaseVersion", "Release"),
+        TableColumn::new("label", "Label"),
+        TableColumn::new("id", "ID"),
+    ]
+}
+
+/// Flatten App Registry enablement rows for CLI output.
+///
+/// Lifts `release.version` to top-level `releaseVersion` so defaults can show
+/// the version string without embedding the whole `release` object (dotted
+/// `--fields` paths like `release.version` are not supported).
+fn flatten_enablements(data: Value) -> Value {
+    let Some(rows) = data.as_array() else {
+        return json!([]);
+    };
+    let flattened: Vec<Value> = rows
+        .iter()
+        .map(|row| {
+            let release_version = row
+                .pointer("/release/version")
+                .cloned()
+                .unwrap_or(Value::Null);
+            json!({
+                "id": row.get("id").cloned().unwrap_or(Value::Null),
+                "name": row.get("name").cloned().unwrap_or(Value::Null),
+                "label": row.get("label").cloned().unwrap_or(Value::Null),
+                "status": row.get("status").cloned().unwrap_or(Value::Null),
+                "releaseVersion": release_version,
+            })
+        })
+        .collect();
+    json!(flattened)
+}
+
+pub(super) fn command() -> RuntimeCommandSpec {
+    RuntimeCommandSpec::new_typed_with_context::<EnablementsArgs, _, _, _>(
+        CommandSpec::from_args::<EnablementsArgs>(
+            "enablements",
+            "List applications enabled on a store",
+        )
+        .with_long(
+            "List GoDaddy developer-platform applications currently enabled on \
+            a specific commerce store. This is the read counterpart to \
+            `gddy platform app enable` / `disable`. Requires a store ID; returns \
+            an empty list when nothing is enabled. Application status is the \
+            registry lifecycle (usually ACTIVE), not the enablement itself — \
+            presence in this list means the app is enabled on the store. Defaults \
+            show name, status, and releaseVersion; pass `--fields id,label,...` \
+            (or `--fields all`) to include the application id and/or label.",
+        )
+        .with_system("applications")
+        .with_tier(Tier::Read)
+        .with_scopes(&[APP_REGISTRY_READ])
+        .with_default_fields("name,status,releaseVersion")
+        .with_output_schema::<StoreEnablement>()
+        .with_view(view_columns()),
+        |ctx, args: EnablementsArgs| async move {
+            let store_id = args.store_id;
+            let client = super::make_client(&ctx).await?;
+            let data = client
+                .list_enabled_store_applications(&store_id)
+                .await
+                .map_err(super::client_err)?;
+            Ok(
+                CommandResult::new(flatten_enablements(data)).with_next_actions(vec![
+                    next_action(
+                        "platform app enable <name> --store-id <store-id>",
+                        "Enable an application on this store",
+                    )
+                    .with_param("name", NextActionParam::required())
+                    .with_param("store-id", required_value(&store_id)),
+                    next_action(
+                        "platform app disable <name> --store-id <store-id>",
+                        "Disable an application on this store",
+                    )
+                    .with_param("name", NextActionParam::required())
+                    .with_param("store-id", required_value(&store_id)),
+                    next_action(
+                        "platform app info --name <name>",
+                        "Inspect a listed application",
+                    )
+                    .with_param("name", NextActionParam::required()),
+                ]),
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use cli_engine::{Cli, CliConfig, Stage};
+    use serde_json::json;
+
+    use super::{command, flatten_enablements};
+
+    #[test]
+    fn command_requires_store_id_flag() {
+        command()
+            .spec
+            .clap_command()
+            .try_get_matches_from(["enablements"])
+            .expect_err("--store-id is required");
+    }
+
+    #[test]
+    fn command_accepts_store_id_flag() {
+        command()
+            .spec
+            .clap_command()
+            .try_get_matches_from(["enablements", "--store-id", "store-123"])
+            .expect("--store-id should be accepted");
+    }
+
+    #[test]
+    fn default_fields_are_name_status_release_version() {
+        assert_eq!(
+            command().spec.default_fields.as_deref(),
+            Some("name,status,releaseVersion")
+        );
+    }
+
+    #[test]
+    fn flatten_enablements_lifts_release_version_only() {
+        let input = json!([{
+            "id": "app-1",
+            "name": "my-app",
+            "label": "My App",
+            "status": "ACTIVE",
+            "release": { "id": "rel-1", "version": "1.2.3" }
+        }]);
+        assert_eq!(
+            flatten_enablements(input),
+            json!([{
+                "id": "app-1",
+                "name": "my-app",
+                "label": "My App",
+                "status": "ACTIVE",
+                "releaseVersion": "1.2.3"
+            }])
+        );
+    }
+
+    #[test]
+    fn flatten_enablements_null_release_version_when_missing() {
+        let input = json!([{ "id": "app-1", "name": "my-app", "status": "ACTIVE" }]);
+        assert_eq!(
+            flatten_enablements(input)[0]["releaseVersion"],
+            json!(null)
+        );
+    }
+
+    #[test]
+    fn flatten_enablements_null_label_when_missing() {
+        let input = json!([{ "id": "app-1", "name": "my-app", "status": "ACTIVE" }]);
+        assert_eq!(flatten_enablements(input)[0]["label"], json!(null));
+    }
+
+    #[tokio::test]
+    async fn platform_app_enablements_requires_auth() {
+        let cli = Cli::new(
+            CliConfig::new("gddy", "GoDaddy developer CLI", "gddy")
+                .with_min_stage(Stage::Experimental)
+                .with_default_auth_provider("godaddy")
+                .with_module(crate::platform::module()),
+        );
+
+        let output = cli
+            .run([
+                "gddy",
+                "platform",
+                "app",
+                "enablements",
+                "--store-id",
+                "store-123",
+                "--output",
+                "json",
+            ])
+            .await;
+
+        const AUTH_FAILURE_EXIT: i32 = 2;
+        assert_eq!(
+            output.exit_code, AUTH_FAILURE_EXIT,
+            "platform app enablements must fail closed at auth resolution, got: {}",
+            output.rendered
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&output.rendered).expect("valid json output");
+        let message = json["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("provider"),
+            "expected an auth-provider resolution error, got: {}",
+            output.rendered
+        );
+    }
+}

--- a/rust/src/application/commands/lifecycle.rs
+++ b/rust/src/application/commands/lifecycle.rs
@@ -24,8 +24,10 @@ pub(super) fn enable_command() -> RuntimeCommandSpec {
         CommandSpec::from_args::<EnableDisableArgs>("enable", "Enable an application on a store")
             .with_long(
                 "Make a GoDaddy developer-platform application available on a \
-                specific store. Use `gddy platform app disable` to reverse this. \
-                Both the application name and a store ID are required.",
+                specific store. Use `gddy platform app enablements --store-id \
+                <store-id>` to verify what is enabled on that store, and \
+                `gddy platform app disable` to reverse this. Both the \
+                application name and a store ID are required.",
             )
             .with_system("applications")
             .with_tier(Tier::Mutate)
@@ -41,6 +43,11 @@ pub(super) fn enable_command() -> RuntimeCommandSpec {
                 .map_err(super::client_err)?;
             Ok(
                 CommandResult::new(data["enableStoreApplication"].clone()).with_next_actions(vec![
+                    next_action(
+                        "platform app enablements --store-id <store-id>",
+                        "List applications enabled on this store",
+                    )
+                    .with_param("store-id", required_value(&store_id)),
                     next_action(
                         "platform app disable <name> --store-id <store-id>",
                         "Disable the application on the same store",
@@ -82,6 +89,11 @@ pub(super) fn disable_command() -> RuntimeCommandSpec {
             Ok(
                 CommandResult::new(data["disableStoreApplication"].clone()).with_next_actions(
                     vec![
+                        next_action(
+                            "platform app enablements --store-id <store-id>",
+                            "List applications enabled on this store",
+                        )
+                        .with_param("store-id", required_value(&store_id)),
                         next_action(
                             "platform app enable <name> --store-id <store-id>",
                             "Re-enable the application on the same store",

--- a/rust/src/application/commands/mod.rs
+++ b/rust/src/application/commands/mod.rs
@@ -10,6 +10,7 @@ mod add;
 mod add_extension;
 mod config;
 mod deploy;
+mod enablements;
 mod info;
 mod init;
 mod lifecycle;
@@ -81,6 +82,7 @@ pub fn application_group() -> RuntimeGroupSpec {
     .with_command(update::command())
     .with_command(lifecycle::enable_command())
     .with_command(lifecycle::disable_command())
+    .with_command(enablements::command())
     .with_command(lifecycle::archive_command())
     .with_command(release::command())
     .with_command(deploy::command())

--- a/rust/src/application/commands/schemas.rs
+++ b/rust/src/application/commands/schemas.rs
@@ -41,6 +41,14 @@ output_schema!(ApplicationRef {
     "id": "string";
 });
 
+output_schema!(StoreEnablement {
+    "name": "string";
+    "status": "string";
+    "releaseVersion": "string", optional;
+    "id": "string", optional;
+    "label": "string", optional;
+});
+
 output_schema!(ApplicationArchive {
     "id": "string";
     "name": "string";

--- a/rust/src/platform/guides/platform-overview.md
+++ b/rust/src/platform/guides/platform-overview.md
@@ -46,14 +46,18 @@ Bundles, security-scans, and uploads the extensions declared in `godaddy.toml`, 
 ```sh
 gddy platform app enable <name> --store-id <storeId>
 gddy platform app disable <name> --store-id <storeId>
+gddy platform app enablements --store-id <storeId>
 ```
 
-Makes the application (and everything in its latest release — actions, subscriptions, extensions, settings) available on, or removes it from, one store. Settings have no inheritance across releases: a store already enabled against an older release does not pick up settings added by a newer one until `enable` is re-run for that store.
+`enable` / `disable` make the application (and everything in its latest release — actions, subscriptions, extensions, settings) available on, or remove it from, one store. Settings have no inheritance across releases: a store already enabled against an older release does not pick up settings added by a newer one until `enable` is re-run for that store.
+
+`enablements` is the read counterpart: it lists which applications are currently enabled on that store (empty list if none). Use it to verify an `enable` or audit what is bound to a store. Default output fields are `name`, `status`, and `releaseVersion` (the enabled release’s version string — not the full release object). Pass `--fields id,label` or `--fields all` to include the application id and/or label. App listing (`list` / `info`) is separate — those show developer apps in App Registry, not per-store enablements.
 
 ## Other useful commands
 
 - `gddy platform app validate <name>` — check *remote* application state (URL/proxy-url set, not INACTIVE), as opposed to `config validate`'s local manifest check.
-- `gddy platform app info --name <name>` / `list` — inspect a single app or list all of them.
+- `gddy platform app info --name <name>` / `list` — inspect a single app or list all of them (developer catalog, not store enablements).
+- `gddy platform app enablements --store-id <storeId>` — list apps enabled on a store (defaults: name, status, releaseVersion).
 - `gddy platform app archive <name>` — irreversible; confirm the name with `list` first.
 - `gddy platform actions` / `gddy platform webhook` — browse the platform's action and webhook-event catalogs (used when choosing values for `add action`/`add subscription`).
 

--- a/rust/src/platform/guides/platform-settings.md
+++ b/rust/src/platform/guides/platform-settings.md
@@ -28,7 +28,7 @@ An application-settings capability lets a GoDaddy Platform Application (GPA) con
 
 3. **Release** — `gddy platform app release --application-id <id> --version <version>` resends every setting in `godaddy.toml`, same as it does for actions/subscriptions/extensions. It rejects any settings entry with neither `presentation` nor `presentationFile` (`{"error":{"code":"VALIDATION_ERROR","message":"settings 'godaddy-tax' has no presentation — add a [settings.presentation] block or a presentationFile before releasing"}}`).
 
-4. **Enable/backfill** — `gddy platform app enable <name> --store-id <storeId>` makes the placement discoverable for a store. Settings (like actions/subscriptions/uiExtensions) are keyed per-release with no inheritance — a store already enabled against an older release doesn't pick up settings added in a newer one until `enable` is re-run for that store.
+4. **Enable/backfill** — `gddy platform app enable <name> --store-id <storeId>` makes the placement discoverable for a store. Confirm with `gddy platform app enablements --store-id <storeId>` (lists apps currently enabled on that store). Settings (like actions/subscriptions/uiExtensions) are keyed per-release with no inheritance — a store already enabled against an older release doesn't pick up settings added in a newer one until `enable` is re-run for that store.
 
 ## Presentation shape
 
@@ -153,5 +153,5 @@ Deeper semantics stay server-validated — bounds consistency (`maxLength ≥ mi
 ## Gotchas
 
 - **No release inheritance.** `release` resends every current setting from `godaddy.toml`; leaving one out doesn't archive it globally, but any store enabled against the *new* release loses it.
-- **Existing stores don't auto-upgrade.** Adding settings to a release only affects stores enabled *after* that release goes active — re-run `gddy platform app enable <name> --store-id <storeId>` per store to backfill.
+- **Existing stores don't auto-upgrade.** Adding settings to a release only affects stores enabled *after* that release goes active — re-run `gddy platform app enable <name> --store-id <storeId>` per store to backfill, then `gddy platform app enablements --store-id <storeId>` to confirm.
 - **`presentation`/`presentationFile` is mandatory before release, not before `add settings`.** A placement-only entry parses and works fine for every other command (`add action`, `info`, `validate`, `deploy`) — it only fails at `release`, with the message shown above.

--- a/rust/src/scopes.rs
+++ b/rust/src/scopes.rs
@@ -86,7 +86,8 @@ declare_scopes! {
     /// at login by default (it's a rare operation for most customers); the
     /// app-registry mutation commands (`platform app init/update/enable/disable/
     /// archive/release/deploy`) declare it via `with_scopes` so cli-engine
-    /// requests it on demand (OAuth step-up).
+    /// requests it on demand (OAuth step-up). Read commands such as
+    /// `platform app enablements` use [`APP_REGISTRY_READ`] only.
     APP_REGISTRY_WRITE => "apps.app-registry:write",
 
     /// Read domains, availability, suggestions, quotes, and DNS records.


### PR DESCRIPTION
## Summary

JIRA - https://godaddy-corp.atlassian.net/browse/DEVX-1075

Adds `gddy platform app enablements --store-id <storeId>` — the read counterpart to `enable` / `disable` — so you can verify which developer-platform apps are bound to a commerce store.

- Calls `enabledStoreApplications(storeId)` with GraphQL variables only (`APP_REGISTRY_READ`)
- Empty list is success (`[]`), not an error - means if given storeId has no apps enabled, the command still exits successfully and prints []
- Defaults: `name,status,releaseVersion` (flattens API `release.version`)
- Opt-in via `--fields`: `id`, `label` (or `--fields all`)
- Wires `enable` / `disable` next_actions + help/docs to point at enablements


## Behavior
| Situation | Result |
|---|---|
| Store has enabled apps | Success + list of apps |
| Store has zero enabled apps | Success + `[]` (not an error) |
| Store you can’t access / bad store id | Error (`UNAUTHORIZED`) |


## Usage

```sh
# List apps enabled on a store (defaults: name, status, releaseVersion)
gddy platform app enablements --store-id <storeId>

# Include id and/or label
gddy platform app enablements --store-id <storeId> --fields id,label,name,status,releaseVersion
gddy platform app enablements --store-id <storeId> --fields all

# JSON output
gddy platform app enablements --store-id <storeId> --output json

# Typical verify flow
gddy platform app enable <name> --store-id <storeId>
gddy platform app enablements --store-id <storeId>
gddy platform app disable <name> --store-id <storeId>
gddy platform app enablements --store-id <storeId>
```

**Notes**
- `list` / `info` = developer App Registry catalog; `enablements` = per-store bindings
- Store you cannot access → GraphQL `UNAUTHORIZED` (not `[]`)
- Presence in the list means enabled; `status` is registry lifecycle (usually `ACTIVE`)

## Example output shape

```json
[
  {
    "id": "app-1",
    "name": "my-app",
    "label": "My App",
    "status": "ACTIVE",
    "releaseVersion": "1.0.0"
  }
]
```

## Test plan

- [x] `cargo test --workspace enablements` (7 passed)
- [x] `cargo test --workspace list_enabled_store` (2 passed)
- [x] Manual smoke on test env: enable → enablements → disable → enablements