### PR TITLE
fix(dns): enforce TLSA/CAA required fields for lower-case --type

### DIFF
--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -72,7 +72,7 @@ mod tests {
                     .with_module(module()),
             )
         };
-        let cases: [(&[&str], &str); 4] = [
+        let cases: [(&[&str], &str); 6] = [
             (
                 &[
                     "gddy",
@@ -123,6 +123,39 @@ mod tests {
                     "1",
                 ],
                 "--data",
+            ),
+            // A lower-case --type must require the same fields as an upper-case
+            // one. clap compares `required_if_eq` against the raw argument, so
+            // these two only hold while `--type` sets `ignore_case`.
+            (
+                &[
+                    "gddy",
+                    "dns",
+                    "add",
+                    "example.com",
+                    "--type",
+                    "tlsa",
+                    "--name",
+                    "www",
+                    "--data",
+                    "d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971",
+                ],
+                "--usage",
+            ),
+            (
+                &[
+                    "gddy",
+                    "dns",
+                    "set",
+                    "example.com",
+                    "--type",
+                    "caa",
+                    "--name",
+                    "@",
+                    "--data",
+                    "letsencrypt.org",
+                ],
+                "--tag",
             ),
         ];
         for (args, needle) in cases {

--- a/rust/src/dns/records.rs
+++ b/rust/src/dns/records.rs
@@ -109,8 +109,13 @@ pub(super) struct RecordWriteArgs {
     #[arg(value_name = "DOMAIN")]
     pub(super) domain: String,
 
+    // `ignore_case` is load-bearing, not cosmetic. The `required_if_eq` predicates
+    // below compare against the *raw* `--type` value, not the `parse_write_type_arg`
+    // output — so without it `--type tlsa` (accepted, and canonicalized to `TLSA`)
+    // never trips the `--usage`/`--selector`/`--matching-type` requirement, and
+    // `--type caa` never trips `--tag`.
     /// Record type (A, AAAA, ALIAS, CAA, CNAME, HTTPS, MX, SRV, SVCB, TLSA, TXT).
-    #[arg(long = "type", value_name = "TYPE", value_parser = parse_write_type_arg)]
+    #[arg(long = "type", value_name = "TYPE", value_parser = parse_write_type_arg, ignore_case = true)]
     pub(super) record_type: String,
 
     /// Record name relative to the domain (e.g. www, @ for the apex).
@@ -152,9 +157,10 @@ pub(super) struct RecordWriteArgs {
     #[arg(long, value_name = "N", value_parser = clap::value_parser!(i64).range(0..=255))]
     pub(super) flag: Option<i64>,
 
-    // A CAA record needs a tag; enforce it at parse time (before auth). The
-    // reverse guard — flag/tag only valid for CAA — lives in the handler
-    // (`validate_caa_fields`), which clap can't express.
+    // A CAA record needs a tag; enforce it at parse time (before auth) — which
+    // holds for `--type caa` as well as `--type CAA` only because `record_type`
+    // sets `ignore_case`. The reverse guard — flag/tag only valid for CAA —
+    // lives in the handler (`validate_caa_fields`), which clap can't express.
     /// CAA property tag, e.g. issue/issuewild/iodef (CAA only; required for CAA).
     #[arg(long, value_name = "TAG", required_if_eq("record_type", "CAA"))]
     pub(super) tag: Option<String>,
@@ -203,9 +209,10 @@ pub(super) fn validate_caa_fields(record_type: &str, opts: &RecordOptions) -> Re
 
 /// Validate the TLSA-specific fields against the record type. `--usage`/
 /// `--selector`/`--matching-type` being present when `record_type` is TLSA is
-/// already enforced by clap (`required_if_eq`); this only guards the reverse —
-/// they're meaningless for other types. Pure so it's unit-testable and runs
-/// before any network call.
+/// enforced by clap (`required_if_eq`, which covers a lower-case `--type` only
+/// because the arg sets `ignore_case`); this only guards the reverse — they're
+/// meaningless for other types. Pure so it's unit-testable and runs before any
+/// network call.
 pub(super) fn validate_tlsa_fields(record_type: &str, opts: &RecordOptions) -> Result<(), String> {
     if record_type != "TLSA"
         && (opts.usage.is_some() || opts.selector.is_some() || opts.matching_type.is_some())


### PR DESCRIPTION
## Summary
- `--type` is parsed with a `value_parser` that upper-cases the value, but clap matches `required_if_eq` against the **raw** argument (`MatchedArg::check_explicit` reads `raw_vals_flatten()`). So `gddy dns add example.com --type tlsa …` never triggered the `--usage`/`--selector`/`--matching-type` requirement that `--type TLSA` enforces — the record was built with `certificateData` but no `usage`/`selector`/`matchingType` and sent to the API, which the v3 schema requires all four for.
- `--type caa` slipped past the `--tag` requirement the same way. That one is caught by `validate_caa_fields`, but only in the handler — so for anyone not already authenticated it surfaces as an auth error rather than a validation error.
- Set `ignore_case` on the `--type` arg, which is what clap documents for exactly this case ("the equality check done by `required_if_eq` … is case-insensitive"). All four `required_if_eq` predicates in the crate key off this one argument, so a single flag covers both record types and keeps the rejection at parse time, before auth.
- Updated the two comments that claimed clap was already enforcing this, so the flag doesn't read as cosmetic and get dropped later.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace` — 776 passed
- [x] `./rust/scripts/check-module-size.sh`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean for this change. (Heads-up unrelated to this PR: on a Windows host it errors on a pre-existing unused `use super::*` in `extension/security/file_discovery.rs`, whose only two tests are `#[cfg(unix)]`, so the test module compiles empty there. CI on ubuntu is unaffected.)
- [x] Added two rows to the existing `invalid_dns_input_is_rejected_before_auth_or_dry_run` table for lower-case `tlsa` and `caa`. Confirmed they fail without the fix — the `tlsa` row gets as far as auth resolution instead of being rejected at parse:
      `expected "--usage", got: {"error": {"code": "ERROR", "message": "auth: no provider registered ...`
- [x] `gddy dns add example.com --type tlsa --name www --data d2ab…e971` now fails at parse with the identical error `--type TLSA` gives (`--usage <N>`, `--selector <N>`, `--matching-type <N>`); mixed case `TlSa` too
- [x] `gddy dns set example.com --type caa --name @ --data letsencrypt.org` now fails at parse asking for `--tag`
- [x] No regressions: `--type TLSA` unchanged; lower-case `tlsa` with all three fields supplied parses and proceeds; `--type a` still works; `--type bogus` and `--type ns` still rejected with their existing messages
